### PR TITLE
feat: add initial database schema and prisma setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+DATABASE_URL ?= $$DATABASE_URL
+
+.PHONY: db-create db-drop migrate-dev seed reset
+
+db-create:
+	psql $(DATABASE_URL) -f db/schema.sql
+
+db-drop:
+	psql $(DATABASE_URL) -f db/rollback.sql
+
+migrate-dev:
+	npx prisma migrate dev --name init
+
+seed:
+	npm run seed
+
+reset: db-drop db-create migrate-dev seed

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # PropTechTest
+
+## Database Setup
+
+Ensure `DATABASE_URL` is set to your PostgreSQL connection string. To create the schema run:
+
+```bash
+psql $DATABASE_URL -f db/schema.sql
+```
+
+To rollback:
+
+```bash
+psql $DATABASE_URL -f db/rollback.sql
+```
+
+Alternatively, use the provided Makefile:
+
+```bash
+make db-create
+make db-drop
+```
+

--- a/db/rollback.sql
+++ b/db/rollback.sql
@@ -1,0 +1,37 @@
+-- Rollback script to drop all objects
+DROP TABLE IF EXISTS user_notification_settings CASCADE;
+DROP TABLE IF EXISTS notifications CASCADE;
+DROP TABLE IF EXISTS compliance_items CASCADE;
+DROP TABLE IF EXISTS documents CASCADE;
+DROP TABLE IF EXISTS messages CASCADE;
+DROP TABLE IF EXISTS maintenance_quotes CASCADE;
+DROP TABLE IF EXISTS vendors CASCADE;
+DROP TABLE IF EXISTS maintenance_jobs CASCADE;
+DROP TABLE IF EXISTS ledger_entries CASCADE;
+DROP TABLE IF EXISTS payments CASCADE;
+DROP TABLE IF EXISTS leases CASCADE;
+DROP TABLE IF EXISTS tenancies CASCADE;
+DROP TABLE IF EXISTS tenants CASCADE;
+DROP TABLE IF EXISTS properties CASCADE;
+DROP TABLE IF EXISTS user_roles CASCADE;
+DROP TABLE IF EXISTS roles CASCADE;
+DROP TABLE IF EXISTS users CASCADE;
+
+-- Drop types
+DROP TYPE IF EXISTS notification_status;
+DROP TYPE IF EXISTS notification_channel;
+DROP TYPE IF EXISTS compliance_status;
+DROP TYPE IF EXISTS compliance_type;
+DROP TYPE IF EXISTS document_owner_type;
+DROP TYPE IF EXISTS message_channel;
+DROP TYPE IF EXISTS message_thread_type;
+DROP TYPE IF EXISTS quote_status;
+DROP TYPE IF EXISTS job_status;
+DROP TYPE IF EXISTS job_priority;
+DROP TYPE IF EXISTS ledger_entry_type;
+DROP TYPE IF EXISTS payment_method;
+DROP TYPE IF EXISTS rent_frequency;
+DROP TYPE IF EXISTS tenancy_status;
+DROP TYPE IF EXISTS scope_type;
+DROP TYPE IF EXISTS role_code;
+

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,213 @@
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- Enums
+CREATE TYPE role_code AS ENUM ('OWNER', 'CO_OWNER', 'ACCOUNTANT', 'TENANT', 'TRADIE');
+CREATE TYPE scope_type AS ENUM ('GLOBAL', 'PROPERTY', 'TENANCY', 'JOB');
+CREATE TYPE tenancy_status AS ENUM ('ACTIVE', 'ENDED');
+CREATE TYPE rent_frequency AS ENUM ('WEEKLY', 'FORTNIGHTLY', 'MONTHLY');
+CREATE TYPE payment_method AS ENUM ('BANK_TRANSFER', 'CARD', 'CASH');
+CREATE TYPE ledger_entry_type AS ENUM ('RENT', 'ARREARS', 'ADJUSTMENT', 'FEE');
+CREATE TYPE job_priority AS ENUM ('LOW', 'NORMAL', 'URGENT');
+CREATE TYPE job_status AS ENUM ('SUBMITTED', 'APPROVED', 'IN_PROGRESS', 'DONE');
+CREATE TYPE quote_status AS ENUM ('REQUESTED', 'RECEIVED', 'APPROVED', 'REJECTED');
+CREATE TYPE message_thread_type AS ENUM ('TENANCY', 'JOB');
+CREATE TYPE message_channel AS ENUM ('IN_APP', 'EMAIL', 'SMS');
+CREATE TYPE document_owner_type AS ENUM ('PROPERTY', 'TENANCY', 'LEASE', 'JOB');
+CREATE TYPE compliance_type AS ENUM ('SMOKE_ALARM', 'ROUTINE_INSPECTION', 'INSURANCE_RENEWAL', 'POOL_CERT');
+CREATE TYPE compliance_status AS ENUM ('DUE', 'OK', 'OVERDUE');
+CREATE TYPE notification_channel AS ENUM ('IN_APP', 'EMAIL', 'PUSH');
+CREATE TYPE notification_status AS ENUM ('PENDING', 'SENT', 'READ');
+
+-- Users
+CREATE TABLE users (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL,
+    email TEXT NOT NULL UNIQUE,
+    phone TEXT,
+    auth_provider TEXT,
+    status TEXT
+);
+
+CREATE TABLE roles (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    code role_code NOT NULL UNIQUE,
+    description TEXT
+);
+
+CREATE TABLE user_roles (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    role_id UUID NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+    scope_type scope_type NOT NULL,
+    scope_id UUID,
+    UNIQUE(user_id, role_id, scope_type, scope_id)
+);
+
+-- Core Property Objects
+CREATE TABLE properties (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    owner_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    address_line1 TEXT,
+    suburb TEXT,
+    state TEXT,
+    postcode TEXT,
+    bedrooms INTEGER,
+    bathrooms INTEGER,
+    parking INTEGER,
+    notes TEXT
+);
+
+CREATE TABLE tenants (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    first_name TEXT NOT NULL,
+    last_name TEXT NOT NULL,
+    email TEXT,
+    phone TEXT,
+    emergency_contact TEXT,
+    bank_ref TEXT
+);
+
+CREATE TABLE tenancies (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    property_id UUID NOT NULL REFERENCES properties(id) ON DELETE CASCADE,
+    primary_tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    start_date DATE NOT NULL,
+    end_date DATE,
+    rent_amount NUMERIC(12,2) NOT NULL,
+    rent_frequency rent_frequency NOT NULL,
+    bond_amount NUMERIC(12,2),
+    payment_day_of_week INTEGER,
+    status tenancy_status NOT NULL DEFAULT 'ACTIVE'
+);
+
+CREATE TABLE leases (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenancy_id UUID NOT NULL REFERENCES tenancies(id) ON DELETE CASCADE,
+    start_date DATE NOT NULL,
+    end_date DATE,
+    terms_url TEXT,
+    bond_lodged BOOLEAN DEFAULT FALSE,
+    bond_number TEXT,
+    rent_review_date DATE
+);
+
+-- Money & Ledger
+CREATE TABLE payments (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenancy_id UUID NOT NULL REFERENCES tenancies(id) ON DELETE CASCADE,
+    date_received DATE NOT NULL,
+    amount NUMERIC(12,2) NOT NULL,
+    method payment_method NOT NULL,
+    reference TEXT,
+    external_txn_id TEXT,
+    notes TEXT
+);
+
+CREATE TABLE ledger_entries (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenancy_id UUID NOT NULL REFERENCES tenancies(id) ON DELETE CASCADE,
+    entry_date DATE NOT NULL,
+    type ledger_entry_type NOT NULL,
+    amount_debit NUMERIC(12,2) DEFAULT 0,
+    amount_credit NUMERIC(12,2) DEFAULT 0,
+    balance_after NUMERIC(12,2) NOT NULL,
+    linked_payment_id UUID REFERENCES payments(id)
+);
+
+-- Maintenance & Comms
+CREATE TABLE maintenance_jobs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    property_id UUID NOT NULL REFERENCES properties(id) ON DELETE CASCADE,
+    tenancy_id UUID REFERENCES tenancies(id) ON DELETE SET NULL,
+    created_by_user_id UUID NOT NULL REFERENCES users(id),
+    title TEXT NOT NULL,
+    description TEXT,
+    priority job_priority NOT NULL DEFAULT 'NORMAL',
+    status job_status NOT NULL DEFAULT 'SUBMITTED',
+    spend_cap NUMERIC(12,2),
+    due_date DATE
+);
+
+CREATE TABLE vendors (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    business_name TEXT NOT NULL,
+    contact_name TEXT,
+    email TEXT,
+    phone TEXT,
+    abn TEXT,
+    license_no TEXT,
+    insurance_expiry DATE
+);
+
+CREATE TABLE maintenance_quotes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    job_id UUID NOT NULL REFERENCES maintenance_jobs(id) ON DELETE CASCADE,
+    vendor_id UUID NOT NULL REFERENCES vendors(id) ON DELETE CASCADE,
+    amount NUMERIC(12,2) NOT NULL,
+    notes TEXT,
+    status quote_status NOT NULL DEFAULT 'REQUESTED'
+);
+
+CREATE TABLE messages (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    thread_type message_thread_type NOT NULL,
+    thread_id UUID NOT NULL,
+    sender_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    body TEXT NOT NULL,
+    sent_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    channel message_channel NOT NULL,
+    has_attachments BOOLEAN DEFAULT FALSE
+);
+
+-- Documents & Compliance
+CREATE TABLE documents (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    owner_type document_owner_type NOT NULL,
+    owner_id UUID NOT NULL,
+    name TEXT NOT NULL,
+    file_url TEXT NOT NULL,
+    file_type TEXT,
+    uploaded_by UUID REFERENCES users(id),
+    uploaded_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+CREATE TABLE compliance_items (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    property_id UUID NOT NULL REFERENCES properties(id) ON DELETE CASCADE,
+    type compliance_type NOT NULL,
+    due_date DATE NOT NULL,
+    status compliance_status NOT NULL DEFAULT 'DUE',
+    document_id UUID REFERENCES documents(id)
+);
+
+-- Notifications
+CREATE TABLE notifications (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    type TEXT NOT NULL,
+    payload_json JSONB,
+    channel notification_channel NOT NULL,
+    status notification_status NOT NULL DEFAULT 'PENDING',
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+CREATE TABLE user_notification_settings (
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    type TEXT NOT NULL,
+    email BOOLEAN DEFAULT TRUE,
+    push BOOLEAN DEFAULT TRUE,
+    sms BOOLEAN DEFAULT FALSE,
+    quiet_hours_start TIME,
+    quiet_hours_end TIME,
+    PRIMARY KEY (user_id, type)
+);
+
+-- Indexes
+CREATE INDEX idx_payments_tenancy ON payments(tenancy_id, date_received);
+CREATE INDEX idx_ledger_entries_tenancy ON ledger_entries(tenancy_id, entry_date);
+CREATE INDEX idx_jobs_property ON maintenance_jobs(property_id);
+CREATE INDEX idx_messages_thread ON messages(thread_type, thread_id);
+CREATE INDEX idx_documents_owner ON documents(owner_type, owner_id);
+CREATE INDEX idx_compliance_property ON compliance_items(property_id);
+CREATE INDEX idx_notifications_user ON notifications(user_id, status);
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "prop-tech-test",
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "prisma": "prisma",
+    "seed": "node --loader ts-node/esm prisma/seed.ts"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.13.0"
+  },
+  "devDependencies": {
+    "prisma": "^5.13.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.3.3"
+  }
+}

--- a/prisma/migrations/README.md
+++ b/prisma/migrations/README.md
@@ -1,0 +1,1 @@
+Migrations are generated via `npx prisma migrate dev`.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,336 @@
+// Prisma schema
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+// Enums
+enum RoleCode {
+  OWNER
+  CO_OWNER
+  ACCOUNTANT
+  TENANT
+  TRADIE
+}
+
+enum ScopeType {
+  GLOBAL
+  PROPERTY
+  TENANCY
+  JOB
+}
+
+enum TenancyStatus {
+  ACTIVE
+  ENDED
+}
+
+enum RentFrequency {
+  WEEKLY
+  FORTNIGHTLY
+  MONTHLY
+}
+
+enum PaymentMethod {
+  BANK_TRANSFER
+  CARD
+  CASH
+}
+
+enum LedgerEntryType {
+  RENT
+  ARREARS
+  ADJUSTMENT
+  FEE
+}
+
+enum JobPriority {
+  LOW
+  NORMAL
+  URGENT
+}
+
+enum JobStatus {
+  SUBMITTED
+  APPROVED
+  IN_PROGRESS
+  DONE
+}
+
+enum QuoteStatus {
+  REQUESTED
+  RECEIVED
+  APPROVED
+  REJECTED
+}
+
+enum MessageThreadType {
+  TENANCY
+  JOB
+}
+
+enum MessageChannel {
+  IN_APP
+  EMAIL
+  SMS
+}
+
+enum DocumentOwnerType {
+  PROPERTY
+  TENANCY
+  LEASE
+  JOB
+}
+
+enum ComplianceType {
+  SMOKE_ALARM
+  ROUTINE_INSPECTION
+  INSURANCE_RENEWAL
+  POOL_CERT
+}
+
+enum ComplianceStatus {
+  DUE
+  OK
+  OVERDUE
+}
+
+enum NotificationChannel {
+  IN_APP
+  EMAIL
+  PUSH
+}
+
+enum NotificationStatus {
+  PENDING
+  SENT
+  READ
+}
+
+model User {
+  id             String    @id @default(uuid()) @db.Uuid
+  name           String
+  email          String    @unique
+  phone          String?
+  auth_provider  String?
+  status         String?
+  properties     Property[] @relation("OwnerProperties")
+  roles          UserRole[]
+  messages       Message[]
+  notifications  Notification[]
+  documents      Document[] @relation("UploadedDocuments")
+}
+
+model Role {
+  id          String   @id @default(uuid()) @db.Uuid
+  code        RoleCode @unique
+  description String?
+  users       UserRole[]
+}
+
+model UserRole {
+  id        String    @id @default(uuid()) @db.Uuid
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    String    @db.Uuid
+  role      Role      @relation(fields: [roleId], references: [id], onDelete: Cascade)
+  roleId    String    @db.Uuid
+  scopeType ScopeType
+  scopeId   String?   @db.Uuid
+
+  @@unique([userId, roleId, scopeType, scopeId])
+}
+
+model Property {
+  id            String     @id @default(uuid()) @db.Uuid
+  owner         User       @relation("OwnerProperties", fields: [ownerUserId], references: [id], onDelete: Cascade)
+  ownerUserId   String     @db.Uuid
+  address_line1 String?
+  suburb        String?
+  state         String?
+  postcode      String?
+  bedrooms      Int?
+  bathrooms     Int?
+  parking       Int?
+  notes         String?
+  tenancies     Tenancy[]
+  jobs          MaintenanceJob[]
+  complianceItems ComplianceItem[]
+  documents     Document[] @relation("PropertyDocuments")
+}
+
+model Tenant {
+  id              String   @id @default(uuid()) @db.Uuid
+  first_name      String
+  last_name       String
+  email           String?
+  phone           String?
+  emergency_contact String?
+  bank_ref        String?
+  tenancies       Tenancy[] @relation("TenantTenancies")
+}
+
+model Tenancy {
+  id               String     @id @default(uuid()) @db.Uuid
+  property         Property   @relation(fields: [propertyId], references: [id], onDelete: Cascade)
+  propertyId       String     @db.Uuid
+  primaryTenant    Tenant     @relation("TenantTenancies", fields: [primaryTenantId], references: [id], onDelete: Cascade)
+  primaryTenantId  String     @db.Uuid
+  start_date       DateTime   @db.Date
+  end_date         DateTime?  @db.Date
+  rent_amount      Decimal    @db.Decimal(12,2)
+  rent_frequency   RentFrequency
+  bond_amount      Decimal?   @db.Decimal(12,2)
+  payment_day_of_week Int?
+  status           TenancyStatus @default(ACTIVE)
+  leases           Lease[]
+  payments         Payment[]
+  ledgerEntries    LedgerEntry[]
+  jobs             MaintenanceJob[]
+  messages         Message[]    @relation("TenancyMessages")
+}
+
+model Lease {
+  id             String   @id @default(uuid()) @db.Uuid
+  tenancy        Tenancy  @relation(fields: [tenancyId], references: [id], onDelete: Cascade)
+  tenancyId      String   @db.Uuid
+  start_date     DateTime @db.Date
+  end_date       DateTime? @db.Date
+  terms_url      String?
+  bond_lodged    Boolean  @default(false)
+  bond_number    String?
+  rent_review_date DateTime? @db.Date
+}
+
+model Payment {
+  id            String    @id @default(uuid()) @db.Uuid
+  tenancy       Tenancy   @relation(fields: [tenancyId], references: [id], onDelete: Cascade)
+  tenancyId     String    @db.Uuid
+  date_received DateTime  @db.Date
+  amount        Decimal   @db.Decimal(12,2)
+  method        PaymentMethod
+  reference     String?
+  external_txn_id String?
+  notes         String?
+  ledgerEntries LedgerEntry[]
+}
+
+model LedgerEntry {
+  id               String    @id @default(uuid()) @db.Uuid
+  tenancy          Tenancy   @relation(fields: [tenancyId], references: [id], onDelete: Cascade)
+  tenancyId        String    @db.Uuid
+  entry_date       DateTime  @db.Date
+  type             LedgerEntryType
+  amount_debit     Decimal?  @db.Decimal(12,2)
+  amount_credit    Decimal?  @db.Decimal(12,2)
+  balance_after    Decimal   @db.Decimal(12,2)
+  payment          Payment?  @relation(fields: [linked_payment_id], references: [id])
+  linked_payment_id String?  @db.Uuid
+}
+
+model MaintenanceJob {
+  id             String   @id @default(uuid()) @db.Uuid
+  property       Property @relation(fields: [propertyId], references: [id], onDelete: Cascade)
+  propertyId     String   @db.Uuid
+  tenancy        Tenancy? @relation(fields: [tenancyId], references: [id], onDelete: SetNull)
+  tenancyId      String?  @db.Uuid
+  created_by     User     @relation(fields: [createdByUserId], references: [id])
+  createdByUserId String  @db.Uuid
+  title          String
+  description    String?
+  priority       JobPriority @default(NORMAL)
+  status         JobStatus   @default(SUBMITTED)
+  spend_cap      Decimal?    @db.Decimal(12,2)
+  due_date       DateTime?   @db.Date
+  quotes         MaintenanceQuote[]
+  messages       Message[]   @relation("JobMessages")
+}
+
+model Vendor {
+  id             String   @id @default(uuid()) @db.Uuid
+  business_name  String
+  contact_name   String?
+  email          String?
+  phone          String?
+  abn            String?
+  license_no     String?
+  insurance_expiry DateTime? @db.Date
+  quotes         MaintenanceQuote[]
+}
+
+model MaintenanceQuote {
+  id        String   @id @default(uuid()) @db.Uuid
+  job       MaintenanceJob @relation(fields: [jobId], references: [id], onDelete: Cascade)
+  jobId     String   @db.Uuid
+  vendor    Vendor   @relation(fields: [vendorId], references: [id], onDelete: Cascade)
+  vendorId  String   @db.Uuid
+  amount    Decimal  @db.Decimal(12,2)
+  notes     String?
+  status    QuoteStatus @default(REQUESTED)
+}
+
+model Message {
+  id            String   @id @default(uuid()) @db.Uuid
+  thread_type   MessageThreadType
+  thread_id     String   @db.Uuid
+  sender        User     @relation(fields: [senderUserId], references: [id], onDelete: Cascade)
+  senderUserId  String   @db.Uuid
+  body          String
+  sent_at       DateTime @default(now()) @db.Timestamptz(6)
+  channel       MessageChannel
+  has_attachments Boolean? @default(false)
+  tenancy       Tenancy?  @relation("TenancyMessages", fields: [thread_id], references: [id])
+  job           MaintenanceJob? @relation("JobMessages", fields: [thread_id], references: [id])
+}
+
+model Document {
+  id           String   @id @default(uuid()) @db.Uuid
+  owner_type   DocumentOwnerType
+  owner_id     String   @db.Uuid
+  name         String
+  file_url     String
+  file_type    String?
+  uploaded_by  User?    @relation("UploadedDocuments", fields: [uploadedBy], references: [id])
+  uploadedBy   String?  @db.Uuid
+  uploaded_at  DateTime @default(now()) @db.Timestamptz(6)
+  compliance_items ComplianceItem[]
+}
+
+model ComplianceItem {
+  id          String   @id @default(uuid()) @db.Uuid
+  property    Property @relation(fields: [propertyId], references: [id], onDelete: Cascade)
+  propertyId  String   @db.Uuid
+  type        ComplianceType
+  due_date    DateTime @db.Date
+  status      ComplianceStatus @default(DUE)
+  document    Document? @relation(fields: [documentId], references: [id])
+  documentId  String?  @db.Uuid
+}
+
+model Notification {
+  id         String   @id @default(uuid()) @db.Uuid
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId     String   @db.Uuid
+  type       String
+  payload_json Json?
+  channel    NotificationChannel
+  status     NotificationStatus @default(PENDING)
+  created_at DateTime @default(now()) @db.Timestamptz(6)
+}
+
+model UserNotificationSetting {
+  user       User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId     String @db.Uuid
+  type       String
+  email      Boolean? @default(true)
+  push       Boolean? @default(true)
+  sms        Boolean? @default(false)
+  quiet_hours_start DateTime? @db.Time
+  quiet_hours_end   DateTime? @db.Time
+
+  @@id([userId, type])
+}
+

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,104 @@
+import { PrismaClient } from '@prisma/client';
+import { randomUUID } from 'crypto';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const userId = randomUUID();
+  const propertyId = randomUUID();
+  const tenantId = randomUUID();
+  const tenancyId = randomUUID();
+  const paymentId = randomUUID();
+  const job1Id = randomUUID();
+  const job2Id = randomUUID();
+  const complianceId = randomUUID();
+
+  await prisma.user.create({
+    data: { id: userId, name: 'Ava Owner', email: 'ava@example.com' }
+  });
+
+  await prisma.property.create({
+    data: {
+      id: propertyId,
+      ownerUserId: userId,
+      address_line1: '10 Rose St',
+      suburb: 'Parramatta',
+      state: 'NSW',
+      postcode: '2150'
+    }
+  });
+
+  await prisma.tenant.create({
+    data: {
+      id: tenantId,
+      first_name: 'Liam',
+      last_name: 'Tenant',
+      email: 'liam@example.com'
+    }
+  });
+
+  await prisma.tenancy.create({
+    data: {
+      id: tenancyId,
+      propertyId,
+      primaryTenantId: tenantId,
+      start_date: new Date('2025-07-01'),
+      rent_amount: '650.00',
+      rent_frequency: 'WEEKLY',
+      status: 'ACTIVE'
+    }
+  });
+
+  await prisma.payment.create({
+    data: {
+      id: paymentId,
+      tenancyId,
+      date_received: new Date('2025-08-25'),
+      amount: '650.00',
+      method: 'BANK_TRANSFER'
+    }
+  });
+
+  await prisma.maintenanceJob.create({
+    data: {
+      id: job1Id,
+      propertyId,
+      tenancyId,
+      createdByUserId: userId,
+      title: 'Leaking tap',
+      priority: 'URGENT',
+      status: 'IN_PROGRESS'
+    }
+  });
+
+  await prisma.maintenanceJob.create({
+    data: {
+      id: job2Id,
+      propertyId,
+      createdByUserId: userId,
+      title: 'Loose fence panel',
+      priority: 'NORMAL',
+      status: 'SUBMITTED'
+    }
+  });
+
+  await prisma.complianceItem.create({
+    data: {
+      id: complianceId,
+      propertyId,
+      type: 'SMOKE_ALARM',
+      due_date: new Date('2025-09-15'),
+      status: 'DUE'
+    }
+  });
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary
- add PostgreSQL schema covering users, properties, tenancies, payments, maintenance, and notifications
- mirror structure in Prisma schema with seed data and migrations scaffolding
- provide Makefile and README for database operations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx prisma validate` *(fails: 403 Forbidden fetching prisma package)*

------
https://chatgpt.com/codex/tasks/task_e_68b587b30f18832c9a3e1d58482399ee