### PR TITLE
refactor: use esm export for postcss config

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},


### PR DESCRIPTION
## Summary
- refactor postcss config to use ESM export

## Testing
- `npm test`
- `npm run dev` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c283257c832ca47c2b1d50ea78b1