### PR TITLE
chore: remove experimental next config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,3 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  experimental: { appDir: true },
-};
-
+const nextConfig = {};
 export default nextConfig;


### PR DESCRIPTION
## Summary
- remove experimental block from next.config.mjs

## Testing
- `npm run dev` *(fails: sh: 1: next: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tanstack%2freact-query)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7c2fcad20832cba4c2e33e21000f3