### PR TITLE
Add inspection detail UI with room navigation and mutations

### DIFF
--- a/app/inspections/[id]/page.tsx
+++ b/app/inspections/[id]/page.tsx
@@ -1,14 +1,90 @@
-import InspectionRoomList from '../../../components/InspectionRoomList';
-import InspectionItemCard from '../../../components/InspectionItemCard';
+"use client";
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import InspectionRoomList from "../../../components/InspectionRoomList";
+import InspectionItemCard, { ItemState } from "../../../components/InspectionItemCard";
+import { patchInspection, postInspectionItems } from "../../../lib/api";
+
+const rooms: Record<string, string[]> = {
+  Kitchen: ["Floor", "Walls"],
+  Bathroom: ["Sink", "Toilet"],
+};
 
 export default function InspectionDetail({ params }: { params: { id: string } }) {
+  const [currentRoom, setCurrentRoom] = useState(Object.keys(rooms)[0]);
+  const [form, setForm] = useState<Record<string, ItemState>>({});
+
+  const patch = useMutation({
+    mutationFn: (payload: any) => patchInspection(params.id, payload),
+  });
+  const postItems = useMutation({
+    mutationFn: (payload: any) => postInspectionItems(params.id, payload),
+  });
+
+  const items = rooms[currentRoom];
+
+  const updateItem = (item: string) => (state: ItemState) => {
+    setForm((f) => ({ ...f, [`${currentRoom}:${item}`]: state }));
+  };
+
+  const handleSave = () => {
+    const payload = Object.entries(form).map(([key, val]) => {
+      const [room, name] = key.split(":");
+      return {
+        room,
+        name,
+        result: val.result,
+        notes: val.notes,
+        photos: val.photos.map((f) => f.name),
+      };
+    });
+    patch.mutate({ status: "Completed" });
+    postItems.mutate(payload);
+  };
+
+  const generateReport = async () => {
+    const res = await fetch(`/inspections/${params.id}/report`);
+    const blob = await res.blob();
+    const url = URL.createObjectURL(blob);
+    window.open(url);
+  };
+
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-semibold mb-4">Inspection {params.id}</h1>
-      <div className="grid grid-cols-2 gap-4">
-        <InspectionRoomList />
-        <InspectionItemCard />
+    <div className="p-6 space-y-4">
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-semibold">Inspection {params.id}</h1>
+        <button
+          onClick={handleSave}
+          className="px-3 py-1 rounded bg-green-600 text-white"
+        >
+          Save
+        </button>
       </div>
+      <div className="grid grid-cols-2 gap-4">
+        <InspectionRoomList
+          rooms={Object.keys(rooms)}
+          current={currentRoom}
+          onSelect={setCurrentRoom}
+        />
+        <div className="grid gap-2">
+          {items.map((item) => (
+            <InspectionItemCard
+              key={item}
+              name={item}
+              value={
+                form[`${currentRoom}:${item}`] || { photos: [] as File[] }
+              }
+              onChange={updateItem(item)}
+            />
+          ))}
+        </div>
+      </div>
+      <button
+        onClick={generateReport}
+        className="px-3 py-1 rounded bg-blue-600 text-white"
+      >
+        Generate Report
+      </button>
     </div>
   );
 }

--- a/app/inspections/page.tsx
+++ b/app/inspections/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import Link from "next/link";
 import { getInspections, createInspection } from "../../lib/api";
 
 export default function InspectionsPage() {
@@ -28,12 +29,14 @@ export default function InspectionsPage() {
       </div>
       <ul className="space-y-2">
         {data?.map((insp: any) => (
-          <li
-            key={insp.id}
-            className="p-4 bg-white rounded border flex justify-between"
-          >
-            <span>Property {insp.propertyId}</span>
-            <span className="text-sm text-gray-500">{insp.status}</span>
+          <li key={insp.id} className="p-4 bg-white rounded border">
+            <Link
+              href={`/inspections/${insp.id}`}
+              className="flex justify-between"
+            >
+              <span>Property {insp.propertyId}</span>
+              <span className="text-sm text-gray-500">{insp.status}</span>
+            </Link>
           </li>
         ))}
       </ul>

--- a/components/InspectionItemCard.tsx
+++ b/components/InspectionItemCard.tsx
@@ -1,3 +1,49 @@
-export default function InspectionItemCard() {
-  return <div className="border rounded p-2">Item card</div>;
+import React from "react";
+import PhotoUpload from "./PhotoUpload";
+
+export interface ItemState {
+  result?: "pass" | "fail" | "na";
+  notes?: string;
+  photos: File[];
+}
+
+interface Props {
+  name: string;
+  value: ItemState;
+  onChange: (state: ItemState) => void;
+}
+
+export default function InspectionItemCard({ name, value, onChange }: Props) {
+  const { result = undefined, notes = "", photos = [] } = value;
+  return (
+    <div className="border rounded p-2 space-y-2">
+      <h3 className="font-medium">{name}</h3>
+      <div className="flex gap-2">
+        {["pass", "fail", "na"].map((r) => (
+          <button
+            key={r}
+            type="button"
+            onClick={() => onChange({ ...value, result: r as any })}
+            className={`px-2 py-1 rounded border ${
+              result === r ? "bg-blue-600 text-white" : "bg-white"
+            }`}
+          >
+            {r.toUpperCase()}
+          </button>
+        ))}
+      </div>
+      <textarea
+        placeholder="Notes"
+        className="w-full border rounded p-1"
+        value={notes}
+        onChange={(e) => onChange({ ...value, notes: e.target.value })}
+      />
+      <PhotoUpload onUpload={(files) => onChange({ ...value, photos: files })} />
+      {photos.length > 0 && (
+        <div className="text-xs text-gray-500">
+          {photos.length} file{photos.length > 1 ? "s" : ""} selected
+        </div>
+      )}
+    </div>
+  );
 }

--- a/components/InspectionRoomList.tsx
+++ b/components/InspectionRoomList.tsx
@@ -1,3 +1,27 @@
-export default function InspectionRoomList() {
-  return <div className="p-4">Room list placeholder</div>;
+import React from "react";
+
+interface Props {
+  rooms: string[];
+  current: string;
+  onSelect: (room: string) => void;
+}
+
+export default function InspectionRoomList({ rooms, current, onSelect }: Props) {
+  return (
+    <ul className="space-y-2">
+      {rooms.map((room) => (
+        <li key={room}>
+          <button
+            type="button"
+            onClick={() => onSelect(room)}
+            className={`w-full text-left p-2 rounded border ${
+              room === current ? "bg-blue-600 text-white" : "bg-white"
+            }`}
+          >
+            {room}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
 }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -16,6 +16,10 @@ export async function api<T>(path: string, init?: RequestInit): Promise<T> {
 export const getInspections = () => api('/inspections');
 export const createInspection = (payload: any) =>
   api('/inspections', { method: 'POST', body: JSON.stringify(payload) });
+export const patchInspection = (id: string, payload: any) =>
+  api(`/inspections/${id}`, { method: 'PATCH', body: JSON.stringify(payload) });
+export const postInspectionItems = (id: string, payload: any) =>
+  api(`/inspections/${id}/items`, { method: 'POST', body: JSON.stringify(payload) });
 
 // Applications
 export const listApplications = () => api('/applications');


### PR DESCRIPTION
## Summary
- link inspection list items to detail pages
- add room navigation and item card components for inspections
- wire inspection detail to React Query mutations and add report generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7cd73732c832c8daea75219851202