### PR TITLE
Use react-query for applications and add detail page

### DIFF
--- a/app/api/applications/[id]/score/route.ts
+++ b/app/api/applications/[id]/score/route.ts
@@ -1,0 +1,4 @@
+export async function POST(req: Request, { params }: { params: { id: string } }) {
+  const body = await req.json();
+  return Response.json({ id: params.id, ...body });
+}

--- a/app/applications/[id]/page.tsx
+++ b/app/applications/[id]/page.tsx
@@ -1,10 +1,56 @@
-import ApplicantTabs from '../../../components/ApplicantTabs';
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import ApplicantTabs from "../../../components/ApplicantTabs";
+import {
+  getApplication,
+  updateApplication,
+  postScore,
+} from "../../../lib/api";
 
 export default function ApplicationDetail({ params }: { params: { id: string } }) {
+  const queryClient = useQueryClient();
+  const { data: application } = useQuery({
+    queryKey: ["application", params.id],
+    queryFn: () => getApplication(params.id),
+  });
+
+  const update = useMutation({
+    mutationFn: (status: string) =>
+      updateApplication(params.id, { status }),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["application", params.id] }),
+  });
+
+  const score = useMutation({
+    mutationFn: (decision: string) => postScore(params.id, { decision }),
+  });
+
+  const handleDecision = (decision: "Accepted" | "Rejected") => {
+    update.mutate(decision);
+    score.mutate(decision);
+  };
+
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-semibold mb-4">Application {params.id}</h1>
-      <ApplicantTabs />
+    <div className="p-6 space-y-4">
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-semibold">Application {params.id}</h1>
+        <div className="space-x-2">
+          <button
+            className="px-3 py-1 bg-green-600 text-white rounded"
+            onClick={() => handleDecision("Accepted")}
+          >
+            Accept
+          </button>
+          <button
+            className="px-3 py-1 bg-red-600 text-white rounded"
+            onClick={() => handleDecision("Rejected")}
+          >
+            Reject
+          </button>
+        </div>
+      </div>
+      <ApplicantTabs application={application} />
     </div>
   );
 }

--- a/app/applications/page.tsx
+++ b/app/applications/page.tsx
@@ -1,14 +1,21 @@
-import ApplicationsTable from '../../components/ApplicationsTable';
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import ApplicationsTable, {
+  ApplicationRow,
+} from "../../components/ApplicationsTable";
+import { listApplications } from "../../lib/api";
 
 export default function ApplicationsPage() {
-  const rows = [
-    { id: '1', applicant: 'John Doe', property: '123 Main St', status: 'New' },
-    { id: '2', applicant: 'Jane Smith', property: '456 Oak Ave', status: 'In Review' },
-  ];
+  const { data: rows } = useQuery<ApplicationRow[]>({
+    queryKey: ["applications"],
+    queryFn: listApplications,
+  });
+
   return (
     <div className="p-6">
       <h1 className="text-2xl font-semibold mb-4">Applications</h1>
-      <ApplicationsTable rows={rows} />
+      <ApplicationsTable rows={rows || []} />
     </div>
   );
 }

--- a/components/ApplicantTabs.tsx
+++ b/components/ApplicantTabs.tsx
@@ -1,3 +1,47 @@
-export default function ApplicantTabs() {
-  return <div className="p-4">Applicant detail tabs placeholder</div>;
+"use client";
+
+import { useState } from "react";
+
+export default function ApplicantTabs({ application }: { application: any }) {
+  const [tab, setTab] = useState("profile");
+
+  return (
+    <div>
+      <div className="flex border-b mb-4">
+        <button
+          className={`px-4 py-2 ${
+            tab === "profile" ? "border-b-2 border-blue-500" : ""
+          }`}
+          onClick={() => setTab("profile")}
+        >
+          Profile
+        </button>
+        <button
+          className={`px-4 py-2 ${
+            tab === "docs" ? "border-b-2 border-blue-500" : ""
+          }`}
+          onClick={() => setTab("docs")}
+        >
+          Docs
+        </button>
+        <button
+          className={`px-4 py-2 ${
+            tab === "checklist" ? "border-b-2 border-blue-500" : ""
+          }`}
+          onClick={() => setTab("checklist")}
+        >
+          Checklist
+        </button>
+      </div>
+      {tab === "profile" && (
+        <div className="p-4">Applicant: {application?.applicant}</div>
+      )}
+      {tab === "docs" && (
+        <div className="p-4">Documents tab placeholder</div>
+      )}
+      {tab === "checklist" && (
+        <div className="p-4">Checklist tab placeholder</div>
+      )}
+    </div>
+  );
 }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -21,6 +21,11 @@ export const createInspection = (payload: any) =>
 export const listApplications = () => api('/applications');
 export const getApplication = (id: string) => api(`/applications/${id}`);
 export const updateApplication = (id: string, payload: any) => api(`/applications/${id}`, { method: 'PATCH', body: JSON.stringify(payload) });
+export const postScore = (id: string, payload: any) =>
+  api(`/applications/${id}/score`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
 
 // Listings
 export const createListing = (payload: any) => api('/listings', { method: 'POST', body: JSON.stringify(payload) });


### PR DESCRIPTION
## Summary
- Fetch applications with react-query instead of hardcoded data
- Add application detail page with applicant tabs and accept/reject actions
- Implement score API and client call

## Testing
- `npm test`
- `npm run build` *(fails: sh: 1: next: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tanstack%2freact-query)*

------
https://chatgpt.com/codex/tasks/task_e_68b7cd77db58832c9787d86d7a4cfe65