### PR TITLE
Add vendor management with drawer form

### DIFF
--- a/app/vendors/page.tsx
+++ b/app/vendors/page.tsx
@@ -1,13 +1,128 @@
+'use client';
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import VendorCard from '../../components/VendorCard';
+import { listVendors, createVendor, updateVendor } from '../../lib/api';
 
 export default function VendorsPage() {
+  const queryClient = useQueryClient();
+  const { data: vendors } = useQuery({
+    queryKey: ['vendors'],
+    queryFn: listVendors,
+  });
+
+  const create = useMutation({
+    mutationFn: (payload: any) => createVendor(payload),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ['vendors'] }),
+  });
+
+  const update = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: any }) =>
+      updateVendor(id, data),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ['vendors'] }),
+  });
+
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [editing, setEditing] = useState<any>(null);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    const payload = {
+      name: formData.get('name') as string,
+      tags: (formData.get('tags') as string || '')
+        .split(',')
+        .map((t) => t.trim())
+        .filter(Boolean),
+    };
+    if (editing) {
+      update.mutate({ id: editing.id, data: payload });
+    } else {
+      create.mutate(payload);
+    }
+    setDrawerOpen(false);
+    setEditing(null);
+  };
+
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-semibold mb-4">Vendors</h1>
-      <div className="grid gap-4 md:grid-cols-2">
-        <VendorCard />
-        <VendorCard />
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-2xl font-semibold">Vendors</h1>
+        <button
+          className="px-3 py-1 rounded bg-blue-600 text-white"
+          onClick={() => {
+            setEditing(null);
+            setDrawerOpen(true);
+          }}
+        >
+          New Vendor
+        </button>
       </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        {vendors?.map((vendor: any) => (
+          <VendorCard
+            key={vendor.id}
+            vendor={vendor}
+            onEdit={() => {
+              setEditing(vendor);
+              setDrawerOpen(true);
+            }}
+            onToggleFavourite={(fav) =>
+              update.mutate({ id: vendor.id, data: { favourite: fav } })
+            }
+          />
+        ))}
+      </div>
+      {drawerOpen && (
+        <div className="fixed inset-0 bg-black/50 flex justify-end">
+          <form
+            onSubmit={handleSubmit}
+            className="bg-white w-full max-w-md p-4 space-y-4"
+          >
+            <h2 className="text-lg font-semibold">
+              {editing ? 'Edit Vendor' : 'New Vendor'}
+            </h2>
+            <div>
+              <label className="block text-sm font-medium">Name</label>
+              <input
+                name="name"
+                defaultValue={editing?.name || ''}
+                className="border p-2 w-full"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium">
+                Tags (comma separated)
+              </label>
+              <input
+                name="tags"
+                defaultValue={editing?.tags?.join(', ') || ''}
+                className="border p-2 w-full"
+              />
+            </div>
+            <div className="flex justify-end gap-2 pt-2">
+              <button
+                type="button"
+                className="px-3 py-1"
+                onClick={() => {
+                  setDrawerOpen(false);
+                  setEditing(null);
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="px-3 py-1 bg-blue-600 text-white rounded"
+              >
+                {editing ? 'Update' : 'Create'}
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/VendorCard.tsx
+++ b/components/VendorCard.tsx
@@ -1,3 +1,57 @@
-export default function VendorCard() {
-  return <div className="p-4 border rounded">Vendor card placeholder</div>;
+export default function VendorCard({
+  vendor,
+  onEdit,
+  onToggleFavourite,
+}: {
+  vendor: any;
+  onEdit: () => void;
+  onToggleFavourite?: (fav: boolean) => void;
+}) {
+  return (
+    <div className="p-4 border rounded space-y-2">
+      <div className="flex justify-between items-start">
+        <h2 className="font-semibold">{vendor.name}</h2>
+        <button
+          onClick={() =>
+            onToggleFavourite && onToggleFavourite(!vendor.favourite)
+          }
+          aria-label="Toggle favourite"
+        >
+          {vendor.favourite ? '★' : '☆'}
+        </button>
+      </div>
+      {vendor.tags?.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {vendor.tags.map((tag: string) => (
+            <span
+              key={tag}
+              className="px-2 py-1 bg-gray-200 rounded text-xs"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+      {vendor.documents?.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {vendor.documents.map((doc: string) => (
+            <span
+              key={doc}
+              className="px-2 py-1 bg-blue-100 rounded text-xs"
+            >
+              {doc}
+            </span>
+          ))}
+        </div>
+      )}
+      <div className="flex gap-2 pt-2">
+        <button className="px-2 py-1 border rounded text-sm" onClick={onEdit}>
+          Edit
+        </button>
+        <button className="px-2 py-1 border rounded text-sm">
+          Invite to Quote
+        </button>
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- fetch vendors with React Query and render VendorCard for each
- expand VendorCard with tags, document badges, favourite toggle and action buttons
- add drawer form to create and update vendors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7cd792808832cadc9473ab5919f12