### PR TITLE
Add notification preferences form with validation and previews

### DIFF
--- a/components/NotificationPrefsForm.tsx
+++ b/components/NotificationPrefsForm.tsx
@@ -1,3 +1,139 @@
+"use client";
+
+import { useState, useEffect, FormEvent } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { getNotificationSettings, updateNotificationSettings } from "../lib/api";
+import { z } from "zod";
+import { Input } from "./ui/input";
+import { Switch } from "./ui/switch";
+import { Button } from "./ui/button";
+import { useToast } from "./ui/use-toast";
+
+const formSchema = z.object({
+  email: z.boolean(),
+  sms: z.boolean(),
+  inApp: z.boolean(),
+  quietHoursStart: z.string(),
+  quietHoursEnd: z.string(),
+});
+
 export default function NotificationPrefsForm() {
-  return <div className="p-4">Notification preferences form placeholder</div>;
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  const { data } = useQuery({
+    queryKey: ["notificationSettings"],
+    queryFn: getNotificationSettings,
+  });
+
+  const mutation = useMutation({
+    mutationFn: updateNotificationSettings,
+    onSuccess: () => {
+      toast({ title: "Settings saved" });
+      queryClient.invalidateQueries({ queryKey: ["notificationSettings"] });
+    },
+  });
+
+  const [values, setValues] = useState<z.infer<typeof formSchema>>({
+    email: false,
+    sms: false,
+    inApp: false,
+    quietHoursStart: "",
+    quietHoursEnd: "",
+  });
+
+  useEffect(() => {
+    if (data) {
+      setValues({
+        email: !!data.email,
+        sms: !!data.sms,
+        inApp: !!data.inApp,
+        quietHoursStart: data.quietHoursStart || "",
+        quietHoursEnd: data.quietHoursEnd || "",
+      });
+    }
+  }, [data]);
+
+  const handleChange = <K extends keyof typeof values>(key: K, value: typeof values[K]) => {
+    setValues((v) => ({ ...v, [key]: value }));
+  };
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    try {
+      const parsed = formSchema.parse(values);
+      mutation.mutate(parsed);
+    } catch (err) {
+      if (err instanceof z.ZodError) {
+        toast({ title: "Validation error", description: err.errors.map((e) => e.message).join(", ") });
+      }
+    }
+  };
+
+  const preview = (channel: string) => {
+    toast({ title: `${channel} preview`, description: `This is a sample ${channel.toLowerCase()} notification.` });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 p-4">
+      <div className="flex items-center justify-between">
+        <label className="font-medium">Email</label>
+        <div className="flex items-center gap-2">
+          <Switch
+            checked={values.email}
+            onCheckedChange={(v) => handleChange("email", v)}
+          />
+          <Button type="button" onClick={() => preview("Email")}>
+            Preview
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <label className="font-medium">SMS</label>
+        <div className="flex items-center gap-2">
+          <Switch
+            checked={values.sms}
+            onCheckedChange={(v) => handleChange("sms", v)}
+          />
+          <Button type="button" onClick={() => preview("SMS")}>
+            Preview
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <label className="font-medium">In-app</label>
+        <div className="flex items-center gap-2">
+          <Switch
+            checked={values.inApp}
+            onCheckedChange={(v) => handleChange("inApp", v)}
+          />
+          <Button type="button" onClick={() => preview("In-app")}>
+            Preview
+          </Button>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <label className="font-medium">Quiet Hours</label>
+        <div className="flex gap-2">
+          <Input
+            type="time"
+            value={values.quietHoursStart}
+            onChange={(e) => handleChange("quietHoursStart", e.target.value)}
+          />
+          <Input
+            type="time"
+            value={values.quietHoursEnd}
+            onChange={(e) => handleChange("quietHoursEnd", e.target.value)}
+          />
+        </div>
+      </div>
+
+      <Button type="submit" disabled={mutation.isPending}>
+        Save
+      </Button>
+    </form>
+  );
 }

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,12 @@
+import * as React from "react";
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export function Button({ className = "", ...props }: ButtonProps) {
+  return (
+    <button
+      className={"px-3 py-1 rounded bg-blue-600 text-white disabled:opacity-50 " + className}
+      {...props}
+    />
+  );
+}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,12 @@
+import * as React from "react";
+
+export const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>( 
+  ({ className = "", ...props }, ref) => (
+    <input
+      ref={ref}
+      className={"border rounded px-2 py-1 w-full " + className}
+      {...props}
+    />
+  )
+);
+Input.displayName = "Input";

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+
+interface SwitchProps {
+  checked?: boolean;
+  onCheckedChange?(checked: boolean): void;
+  className?: string;
+}
+
+export function Switch({ checked, onCheckedChange, className = "" }: SwitchProps) {
+  return (
+    <input
+      type="checkbox"
+      className={"w-10 h-6 " + className}
+      checked={checked}
+      onChange={(e) => onCheckedChange?.(e.target.checked)}
+    />
+  );
+}

--- a/components/ui/use-toast.ts
+++ b/components/ui/use-toast.ts
@@ -1,0 +1,9 @@
+export function useToast() {
+  return {
+    toast: ({ title, description }: { title: string; description?: string }) => {
+      if (typeof window !== "undefined") {
+        alert(title + (description ? "\n" + description : ""));
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- build NotificationPrefsForm with shadcn-style inputs and Zod validation
- load and persist notification settings via React Query
- add preview buttons triggering example toasts for each channel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7cd7aafcc832ca7e99f07e45b59e9