### PR TITLE
Add listing wizard and financial tools

### DIFF
--- a/components/ExpenseForm.tsx
+++ b/components/ExpenseForm.tsx
@@ -1,3 +1,93 @@
-export default function ExpenseForm() {
-  return <div className="p-4">Expense form placeholder</div>;
+"use client";
+
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { createExpense } from "../lib/api";
+
+export default function ExpenseForm({
+  propertyId,
+  onCreated,
+}: {
+  propertyId: string;
+  onCreated?: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState({ date: "", category: "", amount: "" });
+
+  const mutation = useMutation((payload: any) => createExpense(propertyId, payload), {
+    onSuccess: () => {
+      setOpen(false);
+      setForm({ date: "", category: "", amount: "" });
+      onCreated?.();
+    },
+  });
+
+  return (
+    <div>
+      <button
+        className="px-2 py-1 bg-blue-500 text-white"
+        onClick={() => setOpen(true)}
+      >
+        Add Expense
+      </button>
+
+      {open && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
+          <form
+            className="bg-white p-4 rounded space-y-2"
+            onSubmit={(e) => {
+              e.preventDefault();
+              mutation.mutate({
+                date: form.date,
+                category: form.category,
+                amount: parseFloat(form.amount),
+              });
+            }}
+          >
+            <label className="block">
+              Date
+              <input
+                type="date"
+                className="border p-1 w-full"
+                value={form.date}
+                onChange={(e) => setForm({ ...form, date: e.target.value })}
+              />
+            </label>
+            <label className="block">
+              Category
+              <input
+                className="border p-1 w-full"
+                value={form.category}
+                onChange={(e) => setForm({ ...form, category: e.target.value })}
+              />
+            </label>
+            <label className="block">
+              Amount
+              <input
+                type="number"
+                className="border p-1 w-full"
+                value={form.amount}
+                onChange={(e) => setForm({ ...form, amount: e.target.value })}
+              />
+            </label>
+            <div className="flex justify-end gap-2 pt-2">
+              <button
+                type="button"
+                className="px-2 py-1 bg-gray-100"
+                onClick={() => setOpen(false)}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="px-2 py-1 bg-green-500 text-white"
+              >
+                Save
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/components/ExpensesTable.tsx
+++ b/components/ExpensesTable.tsx
@@ -1,3 +1,9 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { listExpenses } from "../lib/api";
+
 export interface ExpenseRow {
   id: string;
   date: string;
@@ -5,25 +11,43 @@ export interface ExpenseRow {
   amount: number;
 }
 
-export default function ExpensesTable({ rows }: { rows: ExpenseRow[] }) {
+export default function ExpensesTable({ propertyId }: { propertyId: string }) {
+  const { data = [] } = useQuery<ExpenseRow[]>([
+    "expenses",
+    propertyId,
+  ], () => listExpenses(propertyId));
+  const [filter, setFilter] = useState("");
+
+  const rows = data.filter((r) =>
+    r.category.toLowerCase().includes(filter.toLowerCase())
+  );
+
   return (
-    <table className="min-w-full border">
-      <thead>
-        <tr className="bg-gray-100">
-          <th className="p-2 text-left">Date</th>
-          <th className="p-2 text-left">Category</th>
-          <th className="p-2 text-left">Amount</th>
-        </tr>
-      </thead>
-      <tbody>
-        {rows.map((r) => (
-          <tr key={r.id} className="border-t">
-            <td className="p-2">{r.date}</td>
-            <td className="p-2">{r.category}</td>
-            <td className="p-2">{r.amount}</td>
+    <div className="space-y-2">
+      <input
+        className="border p-1"
+        placeholder="Filter by category"
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+      />
+      <table className="min-w-full border">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="p-2 text-left">Date</th>
+            <th className="p-2 text-left">Category</th>
+            <th className="p-2 text-left">Amount</th>
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.id} className="border-t">
+              <td className="p-2">{r.date}</td>
+              <td className="p-2">{r.category}</td>
+              <td className="p-2">{r.amount}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }

--- a/components/ListingWizard.tsx
+++ b/components/ListingWizard.tsx
@@ -1,3 +1,143 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import PhotoUpload from "./PhotoUpload";
+import { createListing } from "../lib/api";
+
+interface FormState {
+  property: string;
+  photos: File[];
+  features: string;
+  rent: string;
+  description: string;
+}
+
 export default function ListingWizard() {
-  return <div className="p-4">Listing wizard placeholder</div>;
+  const [step, setStep] = useState(0);
+  const [form, setForm] = useState<FormState>({
+    property: "",
+    photos: [],
+    features: "",
+    rent: "",
+    description: "",
+  });
+
+  const mutation = useMutation(() =>
+    createListing({
+      property: form.property,
+      photos: form.photos.map((f) => f.name),
+      features: form.features,
+      rent: parseFloat(form.rent),
+      description: form.description,
+    })
+  );
+
+  const next = () => setStep((s) => Math.min(s + 1, 4));
+  const back = () => setStep((s) => Math.max(s - 1, 0));
+
+  return (
+    <div className="p-4 space-y-4 border rounded">
+      {step === 0 && (
+        <div className="space-y-2">
+          <label className="block">
+            Property
+            <input
+              className="border p-1 w-full"
+              value={form.property}
+              onChange={(e) => setForm({ ...form, property: e.target.value })}
+            />
+          </label>
+        </div>
+      )}
+
+      {step === 1 && (
+        <PhotoUpload onUpload={(files) => setForm({ ...form, photos: files })} />
+      )}
+
+      {step === 2 && (
+        <div className="space-y-2">
+          <label className="block">
+            Features
+            <input
+              className="border p-1 w-full"
+              value={form.features}
+              onChange={(e) => setForm({ ...form, features: e.target.value })}
+            />
+          </label>
+        </div>
+      )}
+
+      {step === 3 && (
+        <div className="space-y-2">
+          <label className="block">
+            Rent
+            <input
+              type="number"
+              className="border p-1 w-full"
+              value={form.rent}
+              onChange={(e) => setForm({ ...form, rent: e.target.value })}
+            />
+          </label>
+        </div>
+      )}
+
+      {step === 4 && (
+        <div className="space-y-2">
+          <label className="block">
+            Description
+            <textarea
+              className="border p-1 w-full"
+              value={form.description}
+              onChange={(e) =>
+                setForm({ ...form, description: e.target.value })
+              }
+            />
+          </label>
+          <button
+            type="button"
+            className="px-2 py-1 bg-gray-200 rounded"
+            onClick={() =>
+              setForm({
+                ...form,
+                description: `Beautiful property with ${form.features}`,
+              })
+            }
+          >
+            Generate Copy
+          </button>
+        </div>
+      )}
+
+      <div className="flex justify-between">
+      {step > 0 && (
+        <button className="px-2 py-1 bg-gray-100" onClick={back}>
+          Back
+        </button>
+      )}
+
+      {step < 4 && (
+        <button className="ml-auto px-2 py-1 bg-blue-500 text-white" onClick={next}>
+          Next
+        </button>
+      )}
+
+      {step === 4 && (
+        <button
+          className="ml-auto px-2 py-1 bg-green-500 text-white"
+          onClick={() => mutation.mutate()}
+        >
+          Submit
+        </button>
+      )}
+      </div>
+
+      {mutation.isSuccess && (
+        <p className="text-green-600">Listing created</p>
+      )}
+      {mutation.error && (
+        <p className="text-red-600">{(mutation.error as Error).message}</p>
+      )}
+    </div>
+  );
 }

--- a/components/PnLChart.tsx
+++ b/components/PnLChart.tsx
@@ -1,3 +1,36 @@
-export default function PnLChart() {
-  return <div className="h-40 bg-gray-100">PnL chart placeholder</div>;
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { getPnL } from "../lib/api";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+
+export default function PnLChart({ propertyId }: { propertyId: string }) {
+  const { data = [] } = useQuery<any[]>(["pnl", propertyId], () =>
+    getPnL(propertyId)
+  );
+
+  return (
+    <div className="h-64">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="month" />
+          <YAxis />
+          <Tooltip />
+          <Legend />
+          <Line type="monotone" dataKey="income" stroke="#4ade80" />
+          <Line type="monotone" dataKey="expenses" stroke="#f87171" />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
 }

--- a/components/RentReviewCalc.tsx
+++ b/components/RentReviewCalc.tsx
@@ -1,3 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { postRentReview } from "../lib/api";
+
 export default function RentReviewCalc() {
-  return <div className="p-4">Rent review calculator placeholder</div>;
+  const [tenancyId, setTenancyId] = useState("");
+  const [currentRent, setCurrentRent] = useState("0");
+  const [cpi, setCpi] = useState("0");
+  const [targetPercent, setTargetPercent] = useState("0");
+  const [targetAmount, setTargetAmount] = useState("0");
+
+  const newRent = targetPercent
+    ? parseFloat(currentRent || "0") * (1 + parseFloat(targetPercent || "0") / 100)
+    : parseFloat(currentRent || "0") + parseFloat(targetAmount || "0");
+
+  const mutation = useMutation(() =>
+    postRentReview(tenancyId, {
+      currentRent: parseFloat(currentRent),
+      cpiPercent: parseFloat(cpi),
+      targetPercent: parseFloat(targetPercent),
+      targetAmount: parseFloat(targetAmount),
+      newRent,
+    })
+  );
+
+  return (
+    <div className="p-4 space-y-2 border rounded">
+      <label className="block">
+        Tenancy ID
+        <input
+          className="border p-1 w-full"
+          value={tenancyId}
+          onChange={(e) => setTenancyId(e.target.value)}
+        />
+      </label>
+      <label className="block">
+        Current Rent
+        <input
+          type="number"
+          className="border p-1 w-full"
+          value={currentRent}
+          onChange={(e) => setCurrentRent(e.target.value)}
+        />
+      </label>
+      <label className="block">
+        CPI %
+        <input
+          type="number"
+          className="border p-1 w-full"
+          value={cpi}
+          onChange={(e) => setCpi(e.target.value)}
+        />
+      </label>
+      <label className="block">
+        Target Increase %
+        <input
+          type="number"
+          className="border p-1 w-full"
+          value={targetPercent}
+          onChange={(e) => setTargetPercent(e.target.value)}
+        />
+      </label>
+      <label className="block">
+        or Target Amount
+        <input
+          type="number"
+          className="border p-1 w-full"
+          value={targetAmount}
+          onChange={(e) => setTargetAmount(e.target.value)}
+        />
+      </label>
+      <div>New rent: {isNaN(newRent) ? "-" : newRent.toFixed(2)}</div>
+      <button
+        className="px-2 py-1 bg-blue-500 text-white"
+        onClick={() => mutation.mutate()}
+        disabled={!tenancyId}
+      >
+        Generate Notice
+      </button>
+      {mutation.isSuccess && <p className="text-green-600">Notice generated</p>}
+      {mutation.error && (
+        <p className="text-red-600">{(mutation.error as Error).message}</p>
+      )}
+    </div>
+  );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "prop-tech-test",
       "version": "0.0.1",
       "dependencies": {
-        "@prisma/client": "^5.13.0"
+        "@prisma/client": "^5.13.0",
+        "recharts": "^2.8.0"
       },
       "devDependencies": {
         "prisma": "^5.13.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "@tanstack/react-query": "^5.0.0",
-    "zod": "^3.23.0"
+    "zod": "^3.23.0",
+    "recharts": "^2.8.0"
   },
   "devDependencies": {
     "prisma": "^5.13.0",


### PR DESCRIPTION
## Summary
- implement multi-step listing creation wizard with optional generated description
- add rent review calculator that posts rent review notices
- build expense management modal/table and PnL chart using recharts

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden to registry)*

------
https://chatgpt.com/codex/tasks/task_e_68b7cd7cc98c832c850e1625010cf573