### PR TITLE
feat: expand mock store and link API routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,11 @@ export NEXT_PUBLIC_API_BASE=http://localhost:3001
 
 and restart the dev server.
 
+### Mock API store
+
+During Phase‑2 development the routes under `app/api` use an in‑memory store
+defined in [`app/api/store.ts`](app/api/store.ts). The data resets whenever the
+Next.js server restarts or when `resetStore()` is called. Once a real backend
+is available, point `NEXT_PUBLIC_API_BASE` to it and remove or replace the
+mock API routes to disable the in‑memory store.
+

--- a/app/api/applications/route.ts
+++ b/app/api/applications/route.ts
@@ -3,3 +3,10 @@ import { applications } from '../store';
 export async function GET() {
   return Response.json(applications);
 }
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const app = { id: String(applications.length + 1), ...body };
+  applications.push(app);
+  return Response.json(app);
+}

--- a/app/api/properties/[id]/pnl/route.ts
+++ b/app/api/properties/[id]/pnl/route.ts
@@ -1,3 +1,11 @@
+import { properties, expenses } from '../../../store';
+
 export async function GET(_: Request, { params }: { params: { id: string } }) {
-  return Response.json({ income: 1000, expenses: 500, net: 500, series: [] });
+  const property = properties.find((p) => p.id === params.id);
+  const propertyExpenses = expenses.filter((e) => e.propertyId === params.id);
+  const totalExpenses = propertyExpenses.reduce((sum, e) => sum + e.amount, 0);
+  const income = property ? property.rent * 12 : 0;
+  const net = income - totalExpenses;
+  const series = propertyExpenses.map((e) => ({ date: e.date, amount: e.amount }));
+  return Response.json({ income, expenses: totalExpenses, net, series });
 }

--- a/app/api/store.ts
+++ b/app/api/store.ts
@@ -1,19 +1,69 @@
-export const inspections: any[] = [
-  { id: '1', propertyId: '1', type: 'Entry', status: 'Scheduled' },
-];
+// In-memory store for mock API routes during Phase-2 development.
+// Data resets when the server restarts. Use resetStore() to restore defaults
+// or replace these mocks with real persistence when a backend is available.
 
-export const applications: any[] = [
+// --- Properties & Tenancies ---
+const initialProperties = [
+  { id: '1', address: '123 Main St', owner: 'Alice', rent: 500 },
+  { id: '2', address: '55 Side Ave', owner: 'Bob', rent: 650 },
+  { id: '3', address: '78 Circular Rd', owner: 'Carol', rent: 550 },
+];
+export const properties: any[] = [...initialProperties];
+
+const initialTenancies = [
+  { id: '1', propertyId: '1', currentRent: 500 },
+  { id: '2', propertyId: '2', currentRent: 650 },
+  { id: '3', propertyId: '3', currentRent: 550 },
+];
+export const tenancies: any[] = [...initialTenancies];
+
+// --- Inspections ---
+const initialInspections = [
+  { id: '1', propertyId: '1', type: 'Entry', status: 'Scheduled', date: '2024-05-01' },
+  { id: '2', propertyId: '1', type: 'Exit', status: 'Completed', date: '2024-03-15' },
+  { id: '3', propertyId: '2', type: 'Routine', status: 'Scheduled', date: '2024-05-10' },
+];
+export const inspections: any[] = [...initialInspections];
+
+// --- Applications ---
+const initialApplications = [
   { id: '1', applicant: 'John Doe', property: '1', status: 'New' },
+  { id: '2', applicant: 'Jane Smith', property: '2', status: 'Reviewed' },
+  { id: '3', applicant: 'Mike Johnson', property: '3', status: 'Rejected' },
 ];
+export const applications: any[] = [...initialApplications];
 
-export const vendors: any[] = [
+// --- Vendors ---
+const initialVendors = [
   { id: '1', name: 'ACME Plumbing', tags: ['plumber'] },
+  { id: '2', name: 'Bright Electrics', tags: ['electrician'] },
+  { id: '3', name: 'Clean & Co', tags: ['cleaner'] },
 ];
+export const vendors: any[] = [...initialVendors];
 
-export const expenses: any[] = [
+// --- Expenses ---
+const initialExpenses = [
   { id: '1', propertyId: '1', date: '2024-01-01', category: 'Repairs', amount: 120 },
+  { id: '2', propertyId: '1', date: '2024-02-15', category: 'Utilities', amount: 80 },
+  { id: '3', propertyId: '2', date: '2024-02-20', category: 'Maintenance', amount: 200 },
+  { id: '4', propertyId: '3', date: '2024-03-10', category: 'Gardening', amount: 60 },
 ];
+export const expenses: any[] = [...initialExpenses];
 
 export const notificationSettings = { email: true, sms: false, inApp: true };
 
 export const listings: any[] = [];
+
+export const rentReviews: any[] = [];
+
+// Helper to reset all data back to its initial state
+export function resetStore() {
+  properties.splice(0, properties.length, ...initialProperties);
+  tenancies.splice(0, tenancies.length, ...initialTenancies);
+  inspections.splice(0, inspections.length, ...initialInspections);
+  applications.splice(0, applications.length, ...initialApplications);
+  vendors.splice(0, vendors.length, ...initialVendors);
+  expenses.splice(0, expenses.length, ...initialExpenses);
+  listings.splice(0, listings.length);
+  rentReviews.splice(0, rentReviews.length);
+}

--- a/app/api/tenancies/[id]/rent-review/route.ts
+++ b/app/api/tenancies/[id]/rent-review/route.ts
@@ -1,8 +1,15 @@
+import { tenancies, rentReviews } from '../../../store';
+
 export async function GET(_: Request, { params }: { params: { id: string } }) {
-  return Response.json({ tenancyId: params.id, currentRent: 400 });
+  const tenancy = tenancies.find((t) => t.id === params.id);
+  return Response.json({ tenancyId: tenancy?.id, currentRent: tenancy?.currentRent });
 }
 
 export async function POST(req: Request, { params }: { params: { id: string } }) {
   const body = await req.json();
-  return Response.json({ tenancyId: params.id, ...body, noticeUrl: '/docs/notice.pdf' });
+  const tenancy = tenancies.find((t) => t.id === params.id);
+  if (tenancy && body.newRent) tenancy.currentRent = body.newRent;
+  const review = { tenancyId: params.id, ...body, noticeUrl: '/docs/notice.pdf' };
+  rentReviews.push(review);
+  return Response.json(review);
 }

--- a/app/api/vendors/[id]/route.ts
+++ b/app/api/vendors/[id]/route.ts
@@ -1,5 +1,10 @@
 import { vendors } from '../../store';
 
+export async function GET(_: Request, { params }: { params: { id: string } }) {
+  const vendor = vendors.find((v) => v.id === params.id);
+  return Response.json(vendor);
+}
+
 export async function PATCH(req: Request, { params }: { params: { id: string } }) {
   const body = await req.json();
   const vendor = vendors.find((v) => v.id === params.id);


### PR DESCRIPTION
## Summary
- seed in-memory store with sample properties, tenancies, inspections, applications, vendors and expenses
- compute property P&L and tenancy rent reviews from the shared store
- expose POST/GET endpoints for applications and vendors and document resetting the store

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7cd7de99c832cb0bee4491fbfa8d5