### PR TITLE
Pass propertyId to PnL chart

### DIFF
--- a/app/finance/pnl/page.tsx
+++ b/app/finance/pnl/page.tsx
@@ -1,10 +1,13 @@
 import PnLChart from '../../../components/PnLChart';
 
 export default function PnLPage() {
+  // TODO: replace hard-coded property ID with route param when available
+  const propertyId = "1";
+
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-semibold mb-4">P&amp;L</h1>
-      <PnLChart />
+      <h1 className="text-2xl font-semibold mb-4">P&L</h1>
+      <PnLChart propertyId={propertyId} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- supply a propertyId to the PnL chart component on the P&L page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b813807ba8832c90f697921ef873ca