### PR TITLE
Define inspection interface and type getInspections

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,5 +1,13 @@
 import type { ApplicationRow } from '../components/ApplicationsTable';
 
+export interface Inspection {
+  id: string;
+  propertyId: string;
+  type: string;
+  status: string;
+  date: string;
+}
+
 export async function api<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch((process.env.NEXT_PUBLIC_API_BASE || '') + path, {
     ...init,
@@ -15,7 +23,7 @@ export async function api<T>(path: string, init?: RequestInit): Promise<T> {
 }
 
 // Inspections
-export const getInspections = () => api('/inspections');
+export const getInspections = () => api<Inspection[]>('/inspections');
 export const createInspection = (payload: any) =>
   api('/inspections', { method: 'POST', body: JSON.stringify(payload) });
 export const patchInspection = (id: string, payload: any) =>


### PR DESCRIPTION
## Summary
- add an `Inspection` interface in API utilities
- type `getInspections` to return `Inspection[]`

## Testing
- `npm test`
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b81464f0a0832cbe05bb11f96c5b6f