### PR TITLE
Specify vendors query type and default array

### DIFF
--- a/app/vendors/page.tsx
+++ b/app/vendors/page.tsx
@@ -6,7 +6,7 @@ import { listVendors, createVendor, updateVendor } from '../../lib/api';
 
 export default function VendorsPage() {
   const queryClient = useQueryClient();
-  const { data: vendors } = useQuery({
+  const { data: vendors = [] } = useQuery<any[]>({
     queryKey: ['vendors'],
     queryFn: listVendors,
   });


### PR DESCRIPTION
## Summary
- ensure vendor query returns an array by typing useQuery
- default vendor data to empty array to avoid undefined mapping

## Testing
- `npm run build` *(fails: next not found, dependencies unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68b81772120c832caead5a46464d9ca8