### PR TITLE
Type vendor list API

### DIFF
--- a/app/vendors/page.tsx
+++ b/app/vendors/page.tsx
@@ -3,10 +3,11 @@ import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import VendorCard from '../../components/VendorCard';
 import { listVendors, createVendor, updateVendor } from '../../lib/api';
+import type { Vendor } from '../../lib/api';
 
 export default function VendorsPage() {
   const queryClient = useQueryClient();
-  const { data: vendors = [] } = useQuery<any[]>({
+  const { data: vendors = [] } = useQuery<Vendor[]>({
     queryKey: ['vendors'],
     queryFn: listVendors,
   });
@@ -61,7 +62,7 @@ export default function VendorsPage() {
         </button>
       </div>
       <div className="grid gap-4 md:grid-cols-2">
-        {vendors?.map((vendor: any) => (
+        {vendors?.map((vendor: Vendor) => (
           <VendorCard
             key={vendor.id}
             vendor={vendor}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -8,6 +8,14 @@ export interface Inspection {
   date: string;
 }
 
+export interface Vendor {
+  id: string;
+  name: string;
+  tags: string[];
+  documents?: string[];
+  favourite?: boolean;
+}
+
 export async function api<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch((process.env.NEXT_PUBLIC_API_BASE || '') + path, {
     ...init,
@@ -56,7 +64,7 @@ export const createExpense = (propertyId: string, payload: any) => api(`/propert
 export const getPnL = (propertyId: string) => api(`/properties/${propertyId}/pnl`);
 
 // Vendors
-export const listVendors = () => api('/vendors');
+export const listVendors = () => api<Vendor[]>('/vendors');
 export const createVendor = (payload: any) => api('/vendors', { method: 'POST', body: JSON.stringify(payload) });
 export const updateVendor = (id: string, payload: any) => api(`/vendors/${id}`, { method: 'PATCH', body: JSON.stringify(payload) });
 


### PR DESCRIPTION
## Summary
- define `Vendor` interface for API results
- type the vendors API and query

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b81a8647e4832c9a6fe47230b81374