### PR TITLE
chore: type vendors

### DIFF
--- a/app/vendors/page.tsx
+++ b/app/vendors/page.tsx
@@ -2,35 +2,35 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import VendorCard from '../../components/VendorCard';
-import { listVendors, createVendor, updateVendor } from '../../lib/api';
+import { listVendors, createVendor, updateVendor, type Vendor } from '../../lib/api';
 
 export default function VendorsPage() {
   const queryClient = useQueryClient();
-  const { data: vendors = [] } = useQuery<any[]>({
+  const { data: vendors = [] } = useQuery<Vendor[]>({
     queryKey: ['vendors'],
     queryFn: listVendors,
   });
 
   const create = useMutation({
-    mutationFn: (payload: any) => createVendor(payload),
+    mutationFn: (payload: Vendor) => createVendor(payload),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ['vendors'] }),
   });
 
   const update = useMutation({
-    mutationFn: ({ id, data }: { id: string; data: any }) =>
+    mutationFn: ({ id, data }: { id: string; data: Partial<Vendor> }) =>
       updateVendor(id, data),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ['vendors'] }),
   });
 
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [editing, setEditing] = useState<any>(null);
+  const [editing, setEditing] = useState<Vendor | null>(null);
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const formData = new FormData(e.currentTarget);
-    const payload = {
+    const payload: Vendor = {
       name: formData.get('name') as string,
       tags: (formData.get('tags') as string || '')
         .split(',')
@@ -38,7 +38,7 @@ export default function VendorsPage() {
         .filter(Boolean),
     };
     if (editing) {
-      update.mutate({ id: editing.id, data: payload });
+      update.mutate({ id: editing.id!, data: payload });
     } else {
       create.mutate(payload);
     }
@@ -61,7 +61,7 @@ export default function VendorsPage() {
         </button>
       </div>
       <div className="grid gap-4 md:grid-cols-2">
-        {vendors?.map((vendor: any) => (
+        {vendors?.map((vendor) => (
           <VendorCard
             key={vendor.id}
             vendor={vendor}
@@ -70,7 +70,7 @@ export default function VendorsPage() {
               setDrawerOpen(true);
             }}
             onToggleFavourite={(fav) =>
-              update.mutate({ id: vendor.id, data: { favourite: fav } })
+              update.mutate({ id: vendor.id!, data: { favourite: fav } })
             }
           />
         ))}

--- a/components/VendorCard.tsx
+++ b/components/VendorCard.tsx
@@ -1,9 +1,11 @@
+import type { Vendor } from '../lib/api';
+
 export default function VendorCard({
   vendor,
   onEdit,
   onToggleFavourite,
 }: {
-  vendor: any;
+  vendor: Vendor;
   onEdit: () => void;
   onToggleFavourite?: (fav: boolean) => void;
 }) {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -8,6 +8,14 @@ export interface Inspection {
   date: string;
 }
 
+export interface Vendor {
+  id?: string;
+  name: string;
+  tags: string[];
+  favourite?: boolean;
+  documents?: string[];
+}
+
 export async function api<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch((process.env.NEXT_PUBLIC_API_BASE || '') + path, {
     ...init,
@@ -56,9 +64,11 @@ export const createExpense = (propertyId: string, payload: any) => api(`/propert
 export const getPnL = (propertyId: string) => api(`/properties/${propertyId}/pnl`);
 
 // Vendors
-export const listVendors = () => api('/vendors');
-export const createVendor = (payload: any) => api('/vendors', { method: 'POST', body: JSON.stringify(payload) });
-export const updateVendor = (id: string, payload: any) => api(`/vendors/${id}`, { method: 'PATCH', body: JSON.stringify(payload) });
+export const listVendors = () => api<Vendor[]>('/vendors');
+export const createVendor = (payload: Vendor) =>
+  api('/vendors', { method: 'POST', body: JSON.stringify(payload) });
+export const updateVendor = (id: string, payload: Partial<Vendor>) =>
+  api(`/vendors/${id}`, { method: 'PATCH', body: JSON.stringify(payload) });
 
 // Notification settings
 export const getNotificationSettings = () => api('/me/notification-settings');


### PR DESCRIPTION
## Summary
- define `Vendor` interface and type vendor API helpers
- add strict `Vendor` props for `VendorCard`
- type vendor page state, queries, and mutations with `Vendor`

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module '@tanstack/react-query' or its corresponding type declarations, and many JSX intrinsic elements errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b81a87c854832c9c30926a2dd8f525