### PR TITLE
fix: update useMutation for react-query v5

### DIFF
--- a/components/ExpenseForm.tsx
+++ b/components/ExpenseForm.tsx
@@ -14,7 +14,8 @@ export default function ExpenseForm({
   const [open, setOpen] = useState(false);
   const [form, setForm] = useState({ date: "", category: "", amount: "" });
 
-  const mutation = useMutation((payload: any) => createExpense(propertyId, payload), {
+  const mutation = useMutation({
+    mutationFn: (payload: any) => createExpense(propertyId, payload),
     onSuccess: () => {
       setOpen(false);
       setForm({ date: "", category: "", amount: "" });


### PR DESCRIPTION
## Summary
- adjust ExpenseForm's useMutation to the v5 options-object API

## Testing
- `npm test`
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba300e7400832c91b83324826dc1e3