### PR TITLE
fix: update react query hooks to v5 syntax

### DIFF
--- a/components/ExpenseForm.tsx
+++ b/components/ExpenseForm.tsx
@@ -14,7 +14,8 @@ export default function ExpenseForm({
   const [open, setOpen] = useState(false);
   const [form, setForm] = useState({ date: "", category: "", amount: "" });
 
-  const mutation = useMutation((payload: any) => createExpense(propertyId, payload), {
+  const mutation = useMutation({
+    mutationFn: (payload: any) => createExpense(propertyId, payload),
     onSuccess: () => {
       setOpen(false);
       setForm({ date: "", category: "", amount: "" });

--- a/components/ExpensesTable.tsx
+++ b/components/ExpensesTable.tsx
@@ -12,10 +12,10 @@ export interface ExpenseRow {
 }
 
 export default function ExpensesTable({ propertyId }: { propertyId: string }) {
-  const { data = [] } = useQuery<ExpenseRow[]>([
-    "expenses",
-    propertyId,
-  ], () => listExpenses(propertyId));
+  const { data = [] } = useQuery<ExpenseRow[]>({
+    queryKey: ["expenses", propertyId],
+    queryFn: () => listExpenses(propertyId),
+  });
   const [filter, setFilter] = useState("");
 
   const rows = data.filter((r) =>


### PR DESCRIPTION
## Summary
- use options-object syntax for fetching expenses
- convert expense form mutation to options-object syntax

## Testing
- `npm test`
- `npm run build` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ba300e7400832c91b83324826dc1e3