### PR TITLE
Switch to object-based useMutation in ListingWizard

### DIFF
--- a/components/ListingWizard.tsx
+++ b/components/ListingWizard.tsx
@@ -23,15 +23,16 @@ export default function ListingWizard() {
     description: "",
   });
 
-  const mutation = useMutation(() =>
-    createListing({
-      property: form.property,
-      photos: form.photos.map((f) => f.name),
-      features: form.features,
-      rent: parseFloat(form.rent),
-      description: form.description,
-    })
-  );
+  const mutation = useMutation({
+    mutationFn: () =>
+      createListing({
+        property: form.property,
+        photos: form.photos.map((f) => f.name),
+        features: form.features,
+        rent: parseFloat(form.rent),
+        description: form.description,
+      }),
+  });
 
   const next = () => setStep((s) => Math.min(s + 1, 4));
   const back = () => setStep((s) => Math.max(s - 1, 0));


### PR DESCRIPTION
## Summary
- use object form of `useMutation` for listing creation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba36115038832c98d0597f0bc548b8