### PR TITLE
Use mutation options object in RentReviewCalc

### DIFF
--- a/components/RentReviewCalc.tsx
+++ b/components/RentReviewCalc.tsx
@@ -15,15 +15,16 @@ export default function RentReviewCalc() {
     ? parseFloat(currentRent || "0") * (1 + parseFloat(targetPercent || "0") / 100)
     : parseFloat(currentRent || "0") + parseFloat(targetAmount || "0");
 
-  const mutation = useMutation(() =>
-    postRentReview(tenancyId, {
-      currentRent: parseFloat(currentRent),
-      cpiPercent: parseFloat(cpi),
-      targetPercent: parseFloat(targetPercent),
-      targetAmount: parseFloat(targetAmount),
-      newRent,
-    })
-  );
+  const mutation = useMutation({
+    mutationFn: () =>
+      postRentReview(tenancyId, {
+        currentRent: parseFloat(currentRent),
+        cpiPercent: parseFloat(cpi),
+        targetPercent: parseFloat(targetPercent),
+        targetAmount: parseFloat(targetAmount),
+        newRent,
+      }),
+  });
 
   return (
     <div className="p-4 space-y-2 border rounded">


### PR DESCRIPTION
## Summary
- refactor RentReviewCalc useMutation to use options object

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba36130118832c98ff8166b427f2c0