### PR TITLE
feat: add typed notification settings

### DIFF
--- a/components/NotificationPrefsForm.tsx
+++ b/components/NotificationPrefsForm.tsx
@@ -2,7 +2,11 @@
 
 import { useState, useEffect, FormEvent } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { getNotificationSettings, updateNotificationSettings } from "../lib/api";
+import {
+  getNotificationSettings,
+  updateNotificationSettings,
+  NotificationSettings,
+} from "../lib/api";
 import { z } from "zod";
 import { Input } from "./ui/input";
 import { Switch } from "./ui/switch";
@@ -21,20 +25,21 @@ export default function NotificationPrefsForm() {
   const queryClient = useQueryClient();
   const { toast } = useToast();
 
-  const { data } = useQuery({
+  const { data } = useQuery<NotificationSettings>({
     queryKey: ["notificationSettings"],
     queryFn: getNotificationSettings,
   });
 
   const mutation = useMutation({
-    mutationFn: updateNotificationSettings,
+    mutationFn: (payload: NotificationSettings) =>
+      updateNotificationSettings(payload),
     onSuccess: () => {
       toast({ title: "Settings saved" });
       queryClient.invalidateQueries({ queryKey: ["notificationSettings"] });
     },
   });
 
-  const [values, setValues] = useState<z.infer<typeof formSchema>>({
+  const [values, setValues] = useState<NotificationSettings>({
     email: false,
     sms: false,
     inApp: false,
@@ -61,7 +66,7 @@ export default function NotificationPrefsForm() {
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
     try {
-      const parsed = formSchema.parse(values);
+      const parsed = formSchema.parse(values) as NotificationSettings;
       mutation.mutate(parsed);
     } catch (err) {
       if (err instanceof z.ZodError) {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -17,6 +17,14 @@ export interface Vendor {
   documents?: string[];
 }
 
+export interface NotificationSettings {
+  email: boolean;
+  sms: boolean;
+  inApp: boolean;
+  quietHoursStart?: string;
+  quietHoursEnd?: string;
+}
+
 export async function api<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch((process.env.NEXT_PUBLIC_API_BASE || '') + path, {
     ...init,
@@ -72,5 +80,10 @@ export const updateVendor = (id: string, payload: Partial<Vendor>) =>
   api(`/vendors/${id}`, { method: 'PATCH', body: JSON.stringify(payload) });
 
 // Notification settings
-export const getNotificationSettings = () => api('/me/notification-settings');
-export const updateNotificationSettings = (payload: any) => api('/me/notification-settings', { method: 'PATCH', body: JSON.stringify(payload) });
+export const getNotificationSettings = () =>
+  api<NotificationSettings>('/me/notification-settings');
+export const updateNotificationSettings = (payload: NotificationSettings) =>
+  api('/me/notification-settings', {
+    method: 'PATCH',
+    body: JSON.stringify(payload),
+  });


### PR DESCRIPTION
## Summary
- add NotificationSettings interface and typed helpers
- use NotificationSettings in notification preferences form

## Testing
- `npm test`
- `npm run build` *(fails: next not found; attempted `npm install` but received 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ba3a8cc5d0832ca4c0c3d9329cf50b