### PR TITLE
Define Application type and apply to applicant components

### DIFF
--- a/app/applications/[id]/page.tsx
+++ b/app/applications/[id]/page.tsx
@@ -7,10 +7,11 @@ import {
   updateApplication,
   postScore,
 } from "../../../lib/api";
+import type { Application } from "../../../lib/api";
 
 export default function ApplicationDetail({ params }: { params: { id: string } }) {
   const queryClient = useQueryClient();
-  const { data: application } = useQuery({
+  const { data: application } = useQuery<Application>({
     queryKey: ["application", params.id],
     queryFn: () => getApplication(params.id),
   });

--- a/components/ApplicantTabs.tsx
+++ b/components/ApplicantTabs.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState } from "react";
+import type { Application } from "../lib/api";
 
-export default function ApplicantTabs({ application }: { application: any }) {
+export default function ApplicantTabs({ application }: { application?: Application }) {
   const [tab, setTab] = useState("profile");
 
   return (

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -17,6 +17,13 @@ export interface Vendor {
   documents?: string[];
 }
 
+export interface Application {
+  id: string;
+  applicant: string;
+  property: string;
+  status: string;
+}
+
 export async function api<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch((process.env.NEXT_PUBLIC_API_BASE || '') + path, {
     ...init,
@@ -43,7 +50,7 @@ export const postInspectionItems = (id: string, payload: any) =>
 // Applications
 export const listApplications = () =>
   api<ApplicationRow[]>('/applications');
-export const getApplication = (id: string) => api(`/applications/${id}`);
+export const getApplication = (id: string) => api<Application>(`/applications/${id}`);
 export const updateApplication = (id: string, payload: any) => api(`/applications/${id}`, { method: 'PATCH', body: JSON.stringify(payload) });
 export const postScore = (id: string, payload: any) =>
   api(`/applications/${id}/score`, {


### PR DESCRIPTION
## Summary
- add `Application` interface to api module
- type `getApplication` response
- use `Application` type across Application detail page and tabs component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba3a8e0050832c87e444ed685dc93b