### PR TITLE
Use typed PnL data in chart

### DIFF
--- a/components/PnLChart.tsx
+++ b/components/PnLChart.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { getPnL } from "../lib/api";
+import { getPnL, type PnLPoint } from "../lib/api";
 import {
   LineChart,
   Line,
@@ -14,7 +14,7 @@ import {
 } from "recharts";
 
 export default function PnLChart({ propertyId }: { propertyId: string }) {
-  const { data = [] } = useQuery<any[]>({
+  const { data = [] } = useQuery<PnLPoint[]>({
     queryKey: ["pnl", propertyId],
     queryFn: () => getPnL(propertyId),
   });

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -17,6 +17,12 @@ export interface Vendor {
   documents?: string[];
 }
 
+export interface PnLPoint {
+  month: string;
+  income: number;
+  expenses: number;
+}
+
 export async function api<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch((process.env.NEXT_PUBLIC_API_BASE || '') + path, {
     ...init,
@@ -62,7 +68,7 @@ export const postRentReview = (tenancyId: string, payload: any) => api(`/tenanci
 // Expenses & PnL
 export const listExpenses = (propertyId: string) => api<ExpenseRow[]>(`/properties/${propertyId}/expenses`);
 export const createExpense = (propertyId: string, payload: any) => api(`/properties/${propertyId}/expenses`, { method: 'POST', body: JSON.stringify(payload) });
-export const getPnL = (propertyId: string) => api<any[]>(`/properties/${propertyId}/pnl`);
+export const getPnL = (propertyId: string) => api<PnLPoint[]>(`/properties/${propertyId}/pnl`);
 
 // Vendors
 export const listVendors = () => api<Vendor[]>('/vendors');


### PR DESCRIPTION
## Summary
- add `PnLPoint` interface for profit and loss data
- type `getPnL` to return `api<PnLPoint[]>`
- update `PnLChart` to use `useQuery<PnLPoint[]>`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba3a90109c832cbf18eca0fa5241ee