### PR TITLE
feat: add notification settings interface

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -23,6 +23,14 @@ export interface PnLPoint {
   expenses: number;
 }
 
+export interface NotificationSettings {
+  email: boolean;
+  sms: boolean;
+  inApp: boolean;
+  quietHoursStart?: string;
+  quietHoursEnd?: string;
+}
+
 export async function api<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch((process.env.NEXT_PUBLIC_API_BASE || '') + path, {
     ...init,


### PR DESCRIPTION
## Summary
- declare `NotificationSettings` interface in API module
- keep notification settings API methods strongly typed

## Testing
- `npm run build` *(fails: next not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tanstack%2freact-query)*
- `npx tsc --noEmit` *(fails: Cannot find module 'react' and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ba3d9a8f40832c8c24ce0a232e24bc