### PR TITLE
refactor: remove optional tag length check

### DIFF
--- a/components/VendorCard.tsx
+++ b/components/VendorCard.tsx
@@ -22,7 +22,7 @@ export default function VendorCard({
           {vendor.favourite ? '★' : '☆'}
         </button>
       </div>
-      {vendor.tags?.length > 0 && (
+      {vendor.tags.length > 0 && (
         <div className="flex flex-wrap gap-2">
           {vendor.tags.map((tag: string) => (
             <span


### PR DESCRIPTION
## Summary
- remove optional chaining from vendor tag length check in VendorCard

## Testing
- `npm test`
- `npm run build` *(fails: sh: 1: next: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tanstack%2freact-query)*

------
https://chatgpt.com/codex/tasks/task_e_68ba411a9cac832cb5409d88ca3f11ca