### PR TITLE
Guard vendor documents mapping

### DIFF
--- a/components/VendorCard.tsx
+++ b/components/VendorCard.tsx
@@ -34,9 +34,9 @@ export default function VendorCard({
           ))}
         </div>
       )}
-      {vendor.documents?.length > 0 && (
+      {vendor.documents && vendor.documents.length > 0 && (
         <div className="flex flex-wrap gap-2">
-          {vendor.documents.map((doc: string) => (
+          {(vendor.documents ?? []).map((doc: string) => (
             <span
               key={doc}
               className="px-2 py-1 bg-blue-100 rounded text-xs"


### PR DESCRIPTION
## Summary
- Safely render vendor documents by guarding for existence and using a nullish-coalesced map

## Testing
- `npm test`
- `npx tsc` *(fails: Cannot find module 'react' or its corresponding type declarations, etc.)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tanstack%2freact-query)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4119330c832cbd25c24bf134db0d