### PR TITLE
Add responsive sidebar navigation

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css';
 import type { ReactNode } from 'react';
 import Providers from './providers';
+import Sidebar from '../components/Sidebar';
 
 export const metadata = { title: 'PropTech' };
 
@@ -9,13 +10,8 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <html lang="en">
       <body className="min-h-screen bg-gray-50">
         <Providers>
-          <nav className="p-4 border-b bg-white flex gap-4">
-            <a href="/" className="font-semibold">Dashboard</a>
-            <a href="/inspections">Inspections</a>
-            <a href="/applications">Applications</a>
-            <a href="/vendors">Vendors</a>
-          </nav>
-          <main>{children}</main>
+          <Sidebar />
+          <main className="md:ml-64">{children}</main>
         </Providers>
       </body>
     </html>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Button } from "./ui/button";
+
+const links = [
+  { href: "/", label: "Dashboard" },
+  { href: "/inspections", label: "Inspections" },
+  { href: "/applications", label: "Applications" },
+  { href: "/listings", label: "Listings" },
+  { href: "/rent-review", label: "Rent Review" },
+  { href: "/finance", label: "Finance (Expenses/P&L)" },
+  { href: "/vendors", label: "Vendors" },
+  { href: "/settings", label: "Settings" }
+];
+
+export default function Sidebar() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button className="m-2 md:hidden" onClick={() => setOpen(true)}>
+        Menu
+      </Button>
+      <div
+        className={`fixed inset-y-0 left-0 z-40 w-64 bg-white border-r transform transition-transform md:translate-x-0 ${open ? "translate-x-0" : "-translate-x-full md:translate-x-0"}`}
+      >
+        <div className="p-4 space-y-2">
+          {links.map(link => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="block px-4 py-2 rounded hover:bg-gray-100"
+              onClick={() => setOpen(false)}
+            >
+              {link.label}
+            </Link>
+          ))}
+        </div>
+      </div>
+      {open && (
+        <div
+          className="fixed inset-0 z-30 bg-black/50 md:hidden"
+          onClick={() => setOpen(false)}
+        />
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Replace top navbar with a responsive sidebar component
- Include navigation links for dashboard, inspections, applications, listings, rent review, finance, vendors, and settings
- Support mobile toggle with overlay using Tailwind and shadcn Button

## Testing
- `npm test`
- `npm run build` *(fails: next not found; attempted `npm install` but received 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ba52eb1490832ca44a5b242ab14d59