### PR TITLE
feat: extend inspections flow

### DIFF
--- a/app/inspections/[id]/page.tsx
+++ b/app/inspections/[id]/page.tsx
@@ -3,7 +3,12 @@ import { useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import InspectionRoomList from "../../../components/InspectionRoomList";
 import InspectionItemCard, { ItemState } from "../../../components/InspectionItemCard";
-import { patchInspection, postInspectionItems } from "../../../lib/api";
+import {
+  patchInspection,
+  postInspectionItems,
+  getInspectionReport,
+  shareInspectionReport,
+} from "../../../lib/api";
 
 const rooms: Record<string, string[]> = {
   Kitchen: ["Floor", "Walls"],
@@ -11,6 +16,7 @@ const rooms: Record<string, string[]> = {
 };
 
 export default function InspectionDetail({ params }: { params: { id: string } }) {
+  const [tab, setTab] = useState<"capture" | "report">("capture");
   const [currentRoom, setCurrentRoom] = useState(Object.keys(rooms)[0]);
   const [form, setForm] = useState<Record<string, ItemState>>({});
 
@@ -43,48 +49,101 @@ export default function InspectionDetail({ params }: { params: { id: string } })
   };
 
   const generateReport = async () => {
-    const res = await fetch(`/inspections/${params.id}/report`);
-    const blob = await res.blob();
+    const blob = await getInspectionReport(params.id);
     const url = URL.createObjectURL(blob);
     window.open(url);
   };
+
+  const shareReport = () => {
+    shareInspectionReport(params.id);
+  };
+
+  const reportEntries = Object.entries(form).map(([key, val]) => {
+    const [room, name] = key.split(":");
+    return { room, name, ...val };
+  });
 
   return (
     <div className="p-6 space-y-4">
       <div className="flex justify-between items-center">
         <h1 className="text-2xl font-semibold">Inspection {params.id}</h1>
+        {tab === "capture" && (
+          <button
+            onClick={handleSave}
+            className="px-3 py-1 rounded bg-green-600 text-white"
+          >
+            Save
+          </button>
+        )}
+      </div>
+      <div className="flex gap-4 border-b pb-2">
         <button
-          onClick={handleSave}
-          className="px-3 py-1 rounded bg-green-600 text-white"
+          className={`px-2 ${tab === "capture" ? "border-b-2 border-blue-600" : ""}`}
+          onClick={() => setTab("capture")}
         >
-          Save
+          Capture
+        </button>
+        <button
+          className={`px-2 ${tab === "report" ? "border-b-2 border-blue-600" : ""}`}
+          onClick={() => setTab("report")}
+        >
+          Report
         </button>
       </div>
-      <div className="grid grid-cols-2 gap-4">
-        <InspectionRoomList
-          rooms={Object.keys(rooms)}
-          current={currentRoom}
-          onSelect={setCurrentRoom}
-        />
-        <div className="grid gap-2">
-          {items.map((item) => (
-            <InspectionItemCard
-              key={item}
-              name={item}
-              value={
-                form[`${currentRoom}:${item}`] || { photos: [] as File[] }
-              }
-              onChange={updateItem(item)}
-            />
-          ))}
+      {tab === "capture" ? (
+        <div className="grid grid-cols-2 gap-4">
+          <InspectionRoomList
+            rooms={Object.keys(rooms)}
+            current={currentRoom}
+            onSelect={setCurrentRoom}
+          />
+          <div className="grid gap-2">
+            {items.map((item) => (
+              <InspectionItemCard
+                key={item}
+                name={item}
+                value={
+                  form[`${currentRoom}:${item}`] || { photos: [] as File[] }
+                }
+                onChange={updateItem(item)}
+              />
+            ))}
+          </div>
         </div>
-      </div>
-      <button
-        onClick={generateReport}
-        className="px-3 py-1 rounded bg-blue-600 text-white"
-      >
-        Generate Report
-      </button>
+      ) : (
+        <div className="space-y-4">
+          <div className="space-y-2">
+            {reportEntries.map((entry, idx) => (
+              <div
+                key={idx}
+                className="p-2 border rounded flex flex-col gap-1"
+              >
+                <div className="font-medium">
+                  {entry.room} - {entry.name}
+                </div>
+                <div className="text-sm">Result: {entry.result}</div>
+                {entry.notes && (
+                  <div className="text-sm">Notes: {entry.notes}</div>
+                )}
+              </div>
+            ))}
+          </div>
+          <div className="flex gap-2">
+            <button
+              onClick={generateReport}
+              className="px-3 py-1 rounded bg-blue-600 text-white"
+            >
+              Generate PDF
+            </button>
+            <button
+              onClick={shareReport}
+              className="px-3 py-1 rounded bg-green-600 text-white"
+            >
+              Share with Tenant
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/InspectionCreateModal.tsx
+++ b/components/InspectionCreateModal.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { createInspection } from "../lib/api";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onCreated?: () => void;
+}
+
+export default function InspectionCreateModal({ open, onClose, onCreated }: Props) {
+  const [form, setForm] = useState({
+    propertyId: "",
+    type: "Entry",
+    date: "",
+    inspector: "",
+    template: "Default",
+  });
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      createInspection({
+        propertyId: form.propertyId,
+        type: form.type,
+        status: "Scheduled",
+        date: form.date,
+        inspector: form.inspector,
+        template: form.template,
+      }),
+    onSuccess: () => {
+      onCreated?.();
+      onClose();
+      setForm({ propertyId: "", type: "Entry", date: "", inspector: "", template: "Default" });
+    },
+  });
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
+      <form
+        className="bg-white p-4 rounded space-y-2 w-80"
+        onSubmit={(e) => {
+          e.preventDefault();
+          mutation.mutate();
+        }}
+      >
+        <label className="block text-sm">
+          Property
+          <input
+            className="border p-1 w-full"
+            value={form.propertyId}
+            onChange={(e) => setForm({ ...form, propertyId: e.target.value })}
+          />
+        </label>
+        <label className="block text-sm">
+          Type
+          <select
+            className="border p-1 w-full"
+            value={form.type}
+            onChange={(e) => setForm({ ...form, type: e.target.value })}
+          >
+            <option>Entry</option>
+            <option>Routine</option>
+            <option>Exit</option>
+          </select>
+        </label>
+        <label className="block text-sm">
+          Date/Time
+          <input
+            type="datetime-local"
+            className="border p-1 w-full"
+            value={form.date}
+            onChange={(e) => setForm({ ...form, date: e.target.value })}
+          />
+        </label>
+        <label className="block text-sm">
+          Inspector
+          <input
+            className="border p-1 w-full"
+            value={form.inspector}
+            onChange={(e) => setForm({ ...form, inspector: e.target.value })}
+          />
+        </label>
+        <label className="block text-sm">
+          Template
+          <select
+            className="border p-1 w-full"
+            value={form.template}
+            onChange={(e) => setForm({ ...form, template: e.target.value })}
+          >
+            <option>Default</option>
+            <option>Detailed</option>
+          </select>
+        </label>
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            className="px-2 py-1 bg-gray-100"
+            onClick={onClose}
+          >
+            Cancel
+          </button>
+          <button type="submit" className="px-2 py-1 bg-blue-600 text-white">
+            Create
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -54,13 +54,42 @@ export async function api<T>(path: string, init?: RequestInit): Promise<T> {
 }
 
 // Inspections
-export const getInspections = () => api<Inspection[]>('/inspections');
+export const getInspections = (params?: {
+  propertyId?: string;
+  type?: string;
+  status?: string;
+}) => {
+  const query = params
+    ? new URLSearchParams(
+        Object.entries(params).filter(([, v]) => v) as [string, string][]
+      ).toString()
+    : "";
+  const path = `/inspections${query ? `?${query}` : ""}`;
+  return api<Inspection[]>(path);
+};
 export const createInspection = (payload: any) =>
   api('/inspections', { method: 'POST', body: JSON.stringify(payload) });
 export const patchInspection = (id: string, payload: any) =>
   api(`/inspections/${id}`, { method: 'PATCH', body: JSON.stringify(payload) });
 export const postInspectionItems = (id: string, payload: any) =>
   api(`/inspections/${id}/items`, { method: 'POST', body: JSON.stringify(payload) });
+export const getInspectionReport = async (id: string) => {
+  const res = await fetch(
+    (process.env.NEXT_PUBLIC_API_BASE || '') + `/inspections/${id}/report`,
+    {
+      headers: {
+        Authorization: `Bearer ${
+          typeof window !== 'undefined' ? localStorage.getItem('token') || '' : ''
+        }`,
+      },
+      cache: 'no-store',
+    }
+  );
+  if (!res.ok) throw new Error(await res.text());
+  return res.blob();
+};
+export const shareInspectionReport = (id: string) =>
+  api(`/inspections/${id}/share`, { method: 'POST' });
 
 // Applications
 export const listApplications = () =>


### PR DESCRIPTION
## Summary
- add inspection list filters and creation modal
- introduce capture/report tabs with sharing & PDF generation
- expand API helper for filtered queries and reports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba52ecdef8832c8bdbf064b7c55591