### PR TITLE
feat: add application filters and detail view

### DIFF
--- a/app/applications/[id]/page.tsx
+++ b/app/applications/[id]/page.tsx
@@ -17,10 +17,12 @@ export default function ApplicationDetail({ params }: { params: { id: string } }
   });
 
   const update = useMutation({
-    mutationFn: (status: string) =>
-      updateApplication(params.id, { status }),
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: ["application", params.id] }),
+    mutationFn: (payload: { status: string; message?: string }) =>
+      updateApplication(params.id, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["application", params.id] });
+      queryClient.invalidateQueries({ queryKey: ["applications"] });
+    },
   });
 
   const score = useMutation({
@@ -28,7 +30,8 @@ export default function ApplicationDetail({ params }: { params: { id: string } }
   });
 
   const handleDecision = (decision: "Accepted" | "Rejected") => {
-    update.mutate(decision);
+    const message = prompt("Optional message to applicant:") || undefined;
+    update.mutate({ status: decision, message });
     score.mutate(decision);
   };
 

--- a/app/applications/page.tsx
+++ b/app/applications/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
+import { useState, useMemo } from "react";
 import ApplicationsTable, {
   ApplicationRow,
 } from "../../components/ApplicationsTable";
@@ -12,10 +13,57 @@ export default function ApplicationsPage() {
     queryFn: listApplications,
   });
 
+  const [status, setStatus] = useState("");
+  const [property, setProperty] = useState("");
+
+  const statuses = useMemo(
+    () => Array.from(new Set(rows?.map((r) => r.status) || [])),
+    [rows]
+  );
+  const properties = useMemo(
+    () => Array.from(new Set(rows?.map((r) => r.property) || [])),
+    [rows]
+  );
+
+  const filteredRows = useMemo(
+    () =>
+      (rows || []).filter(
+        (r) =>
+          (!status || r.status === status) && (!property || r.property === property)
+      ),
+    [rows, status, property]
+  );
+
   return (
     <div className="p-6">
       <h1 className="text-2xl font-semibold mb-4">Applications</h1>
-      <ApplicationsTable rows={rows || []} />
+      <div className="flex space-x-4 mb-4">
+        <select
+          className="border p-2"
+          value={status}
+          onChange={(e) => setStatus(e.target.value)}
+        >
+          <option value="">All Statuses</option>
+          {statuses.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+        <select
+          className="border p-2"
+          value={property}
+          onChange={(e) => setProperty(e.target.value)}
+        >
+          <option value="">All Properties</option>
+          {properties.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+      </div>
+      <ApplicationsTable rows={filteredRows} />
     </div>
   );
 }

--- a/components/ApplicantTabs.tsx
+++ b/components/ApplicantTabs.tsx
@@ -23,25 +23,33 @@ export default function ApplicantTabs({ application }: { application?: Applicati
           }`}
           onClick={() => setTab("docs")}
         >
-          Docs
+          Documents
         </button>
         <button
           className={`px-4 py-2 ${
-            tab === "checklist" ? "border-b-2 border-blue-500" : ""
+            tab === "criteria" ? "border-b-2 border-blue-500" : ""
           }`}
-          onClick={() => setTab("checklist")}
+          onClick={() => setTab("criteria")}
         >
-          Checklist
+          Criteria/Score
         </button>
       </div>
       {tab === "profile" && (
-        <div className="p-4">Applicant: {application?.applicant}</div>
+        <div className="p-4 space-y-2">
+          <div>Applicant: {application?.applicant}</div>
+          <div>Property: {application?.property}</div>
+          <div>Status: {application?.status}</div>
+        </div>
       )}
       {tab === "docs" && (
-        <div className="p-4">Documents tab placeholder</div>
+        <div className="p-4 space-y-2">
+          <div>ID Document</div>
+          <div>Payslips</div>
+          <div>References</div>
+        </div>
       )}
-      {tab === "checklist" && (
-        <div className="p-4">Checklist tab placeholder</div>
+      {tab === "criteria" && (
+        <div className="p-4">Criteria and score details placeholder</div>
       )}
     </div>
   );

--- a/components/ApplicationsTable.tsx
+++ b/components/ApplicationsTable.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
 export interface ApplicationRow {
   id: string;
   applicant: string;
@@ -6,6 +10,7 @@ export interface ApplicationRow {
 }
 
 export default function ApplicationsTable({ rows }: { rows: ApplicationRow[] }) {
+  const router = useRouter();
   return (
     <table className="min-w-full border">
       <thead>
@@ -17,7 +22,11 @@ export default function ApplicationsTable({ rows }: { rows: ApplicationRow[] }) 
       </thead>
       <tbody>
         {rows.map((r) => (
-          <tr key={r.id} className="border-t">
+          <tr
+            key={r.id}
+            className="border-t cursor-pointer hover:bg-gray-50"
+            onClick={() => router.push(`/applications/${r.id}`)}
+          >
             <td className="p-2">{r.applicant}</td>
             <td className="p-2">{r.property}</td>
             <td className="p-2">{r.status}</td>


### PR DESCRIPTION
## Summary
- add status and property filters to applications inbox
- make application rows link to their detail page
- flesh out application detail view with tabs and accept/reject flow

## Testing
- `npm test`
- `npm run build` *(fails: next: not found)*
- `npm install` *(fails: 403 Forbidden for @tanstack/react-query)*

------
https://chatgpt.com/codex/tasks/task_e_68ba52eda058832cb694ef48b61997fb