### PR TITLE
Add expenses management and P&L summary

### DIFF
--- a/app/finance/pnl/page.tsx
+++ b/app/finance/pnl/page.tsx
@@ -1,13 +1,85 @@
-import PnLChart from '../../../components/PnLChart';
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import PnLChart from "../../../components/PnLChart";
+import { getPnLSummary, type PnLSummary } from "../../../lib/api";
 
 export default function PnLPage() {
   // TODO: replace hard-coded property ID with route param when available
   const propertyId = "1";
+  const { data } = useQuery<PnLSummary>({
+    queryKey: ["pnl", propertyId],
+    queryFn: () => getPnLSummary(propertyId),
+  });
+
+  const handleExportCSV = () => {
+    if (!data) return;
+    const rows = [
+      ["Month", "Net"],
+      ...data.monthly.map((m) => [m.month, m.net.toString()]),
+    ];
+    const csv = rows.map((r) => r.join(",")).join("\n");
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "pnl.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleExportPDF = () => {
+    if (!data) return;
+    const win = window.open("", "_blank");
+    if (win) {
+      const rows = data.monthly
+        .map((m) => `<tr><td>${m.month}</td><td>${m.net}</td></tr>`) // simple table
+        .join("");
+      win.document.write(
+        `<table border='1'><tr><th>Month</th><th>Net</th></tr>${rows}</table>`
+      );
+      win.document.close();
+      win.print();
+      win.close();
+    }
+  };
 
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-semibold mb-4">P&L</h1>
-      <PnLChart propertyId={propertyId} />
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">P&L</h1>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="p-4 bg-white shadow">
+          <div className="text-sm text-gray-500">Total Income</div>
+          <div className="text-xl font-semibold">
+            {data?.totalIncome ?? 0}
+          </div>
+        </div>
+        <div className="p-4 bg-white shadow">
+          <div className="text-sm text-gray-500">Total Expenses</div>
+          <div className="text-xl font-semibold">
+            {data?.totalExpenses ?? 0}
+          </div>
+        </div>
+        <div className="p-4 bg-white shadow">
+          <div className="text-sm text-gray-500">Net</div>
+          <div className="text-xl font-semibold">{data?.net ?? 0}</div>
+        </div>
+      </div>
+      <PnLChart data={data?.monthly ?? []} />
+      <div className="flex gap-2">
+        <button
+          className="px-2 py-1 bg-gray-200"
+          onClick={handleExportCSV}
+        >
+          Export CSV
+        </button>
+        <button
+          className="px-2 py-1 bg-gray-200"
+          onClick={handleExportPDF}
+        >
+          Export PDF
+        </button>
+      </div>
     </div>
   );
 }

--- a/components/ExpensesTable.tsx
+++ b/components/ExpensesTable.tsx
@@ -8,7 +8,11 @@ export interface ExpenseRow {
   id: string;
   date: string;
   category: string;
+  vendor: string;
   amount: number;
+  gst: number;
+  notes?: string;
+  receiptUrl?: string;
 }
 
 export default function ExpensesTable({ propertyId }: { propertyId: string }) {
@@ -16,26 +20,63 @@ export default function ExpensesTable({ propertyId }: { propertyId: string }) {
     queryKey: ["expenses", propertyId],
     queryFn: () => listExpenses(propertyId),
   });
-  const [filter, setFilter] = useState("");
+  const [from, setFrom] = useState("");
+  const [to, setTo] = useState("");
+  const [category, setCategory] = useState("");
+  const [vendor, setVendor] = useState("");
 
-  const rows = data.filter((r) =>
-    r.category.toLowerCase().includes(filter.toLowerCase())
-  );
+  const rows = data.filter((r) => {
+    const afterFrom = from ? new Date(r.date) >= new Date(from) : true;
+    const beforeTo = to ? new Date(r.date) <= new Date(to) : true;
+    const categoryMatch = category
+      ? r.category.toLowerCase().includes(category.toLowerCase())
+      : true;
+    const vendorMatch = vendor
+      ? r.vendor.toLowerCase().includes(vendor.toLowerCase())
+      : true;
+    return afterFrom && beforeTo && categoryMatch && vendorMatch;
+  });
 
   return (
     <div className="space-y-2">
-      <input
-        className="border p-1"
-        placeholder="Filter by category"
-        value={filter}
-        onChange={(e) => setFilter(e.target.value)}
-      />
+      <div className="flex flex-wrap gap-2">
+        <input
+          type="date"
+          className="border p-1"
+          value={from}
+          onChange={(e) => setFrom(e.target.value)}
+          placeholder="From"
+        />
+        <input
+          type="date"
+          className="border p-1"
+          value={to}
+          onChange={(e) => setTo(e.target.value)}
+          placeholder="To"
+        />
+        <input
+          className="border p-1"
+          placeholder="Category"
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+        />
+        <input
+          className="border p-1"
+          placeholder="Vendor"
+          value={vendor}
+          onChange={(e) => setVendor(e.target.value)}
+        />
+      </div>
       <table className="min-w-full border">
         <thead>
           <tr className="bg-gray-100">
             <th className="p-2 text-left">Date</th>
             <th className="p-2 text-left">Category</th>
+            <th className="p-2 text-left">Vendor</th>
             <th className="p-2 text-left">Amount</th>
+            <th className="p-2 text-left">GST</th>
+            <th className="p-2 text-left">Notes</th>
+            <th className="p-2 text-left">Receipt</th>
           </tr>
         </thead>
         <tbody>
@@ -43,7 +84,22 @@ export default function ExpensesTable({ propertyId }: { propertyId: string }) {
             <tr key={r.id} className="border-t">
               <td className="p-2">{r.date}</td>
               <td className="p-2">{r.category}</td>
+              <td className="p-2">{r.vendor}</td>
               <td className="p-2">{r.amount}</td>
+              <td className="p-2">{r.gst}</td>
+              <td className="p-2">{r.notes}</td>
+              <td className="p-2">
+                {r.receiptUrl && (
+                  <a
+                    href={r.receiptUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-blue-600 underline"
+                  >
+                    View
+                  </a>
+                )}
+              </td>
             </tr>
           ))}
         </tbody>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -82,9 +82,50 @@ export const getRentReview = (tenancyId: string) => api(`/tenancies/${tenancyId}
 export const postRentReview = (tenancyId: string, payload: any) => api(`/tenancies/${tenancyId}/rent-review`, { method: 'POST', body: JSON.stringify(payload) });
 
 // Expenses & PnL
-export const listExpenses = (propertyId: string) => api<ExpenseRow[]>(`/properties/${propertyId}/expenses`);
-export const createExpense = (propertyId: string, payload: any) => api(`/properties/${propertyId}/expenses`, { method: 'POST', body: JSON.stringify(payload) });
-export const getPnL = (propertyId: string) => api<PnLPoint[]>(`/properties/${propertyId}/pnl`);
+export interface Expense extends ExpenseRow {}
+
+export interface PnLSummary {
+  totalIncome: number;
+  totalExpenses: number;
+  net: number;
+  monthly: { month: string; net: number }[];
+}
+
+export const listExpenses = (propertyId: string) =>
+  api<ExpenseRow[]>(`/properties/${propertyId}/expenses`);
+export const getExpense = (propertyId: string, id: string) =>
+  api<Expense>(`/properties/${propertyId}/expenses/${id}`);
+export const createExpense = (propertyId: string, payload: any) =>
+  api(`/properties/${propertyId}/expenses`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+export const updateExpense = (
+  propertyId: string,
+  id: string,
+  payload: any
+) =>
+  api(`/properties/${propertyId}/expenses/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(payload),
+  });
+export const deleteExpense = (propertyId: string, id: string) =>
+  api(`/properties/${propertyId}/expenses/${id}`, { method: 'DELETE' });
+export const uploadExpenseReceipt = (
+  propertyId: string,
+  id: string,
+  file: File
+) => {
+  const form = new FormData();
+  form.append('receipt', file);
+  return api(`/properties/${propertyId}/expenses/${id}/receipt`, {
+    method: 'POST',
+    body: form,
+    headers: {},
+  });
+};
+export const getPnLSummary = (propertyId: string) =>
+  api<PnLSummary>(`/properties/${propertyId}/pnl`);
 
 // Vendors
 export const listVendors = () => api<Vendor[]>('/vendors');


### PR DESCRIPTION
## Summary
- Add expense drawer with vendor, GST, notes and receipt upload
- Expand expenses table with date range, category and vendor filters
- Build P&L dashboard with KPI tiles, monthly net chart and CSV/PDF exports
- Extend API helpers for expense CRUD, receipt upload and P&L summary

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba52f24424832c8d8e2acb52a60f53