### PR TITLE
feat: expand vendor management

### DIFF
--- a/app/api/store.ts
+++ b/app/api/store.ts
@@ -35,9 +35,33 @@ export const applications: any[] = [...initialApplications];
 
 // --- Vendors ---
 const initialVendors = [
-  { id: '1', name: 'ACME Plumbing', tags: ['plumber'] },
-  { id: '2', name: 'Bright Electrics', tags: ['electrician'] },
-  { id: '3', name: 'Clean & Co', tags: ['cleaner'] },
+  {
+    id: '1',
+    name: 'ACME Plumbing',
+    tags: ['plumber'],
+    insured: true,
+    licensed: true,
+    avgResponseTime: 2,
+    documents: ['licence.pdf'],
+  },
+  {
+    id: '2',
+    name: 'Bright Electrics',
+    tags: ['electrician'],
+    insured: false,
+    licensed: true,
+    avgResponseTime: 5,
+    documents: ['insurance.pdf'],
+  },
+  {
+    id: '3',
+    name: 'Clean & Co',
+    tags: ['cleaner'],
+    insured: true,
+    licensed: false,
+    avgResponseTime: 8,
+    documents: [],
+  },
 ];
 export const vendors: any[] = [...initialVendors];
 

--- a/app/api/vendors/[id]/documents/route.ts
+++ b/app/api/vendors/[id]/documents/route.ts
@@ -1,0 +1,20 @@
+import { vendors } from '../../store';
+
+export async function POST(req: Request, { params }: { params: { id: string } }) {
+  const { url } = await req.json();
+  const vendor = vendors.find((v) => v.id === params.id);
+  if (vendor) {
+    vendor.documents = vendor.documents || [];
+    vendor.documents.push(url);
+  }
+  return Response.json(vendor);
+}
+
+export async function DELETE(req: Request, { params }: { params: { id: string } }) {
+  const { url } = await req.json();
+  const vendor = vendors.find((v) => v.id === params.id);
+  if (vendor && vendor.documents) {
+    vendor.documents = vendor.documents.filter((d: string) => d !== url);
+  }
+  return Response.json(vendor);
+}

--- a/app/api/vendors/[id]/route.ts
+++ b/app/api/vendors/[id]/route.ts
@@ -11,3 +11,9 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
   if (vendor) Object.assign(vendor, body);
   return Response.json(vendor);
 }
+
+export async function DELETE(_: Request, { params }: { params: { id: string } }) {
+  const idx = vendors.findIndex((v) => v.id === params.id);
+  if (idx !== -1) vendors.splice(idx, 1);
+  return new Response(null, { status: 204 });
+}

--- a/app/api/vendors/route.ts
+++ b/app/api/vendors/route.ts
@@ -6,7 +6,14 @@ export async function GET() {
 
 export async function POST(req: Request) {
   const body = await req.json();
-  const vendor = { id: String(vendors.length + 1), ...body };
+  const vendor = {
+    id: String(vendors.length + 1),
+    insured: false,
+    licensed: false,
+    avgResponseTime: undefined,
+    documents: [],
+    ...body,
+  };
   vendors.push(vendor);
   return Response.json(vendor);
 }

--- a/app/vendors/page.tsx
+++ b/app/vendors/page.tsx
@@ -2,19 +2,14 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import VendorCard from '../../components/VendorCard';
-import { listVendors, createVendor, updateVendor, type Vendor } from '../../lib/api';
+import VendorForm from '../../components/VendorForm';
+import { listVendors, updateVendor, type Vendor } from '../../lib/api';
 
 export default function VendorsPage() {
   const queryClient = useQueryClient();
   const { data: vendors = [] } = useQuery<Vendor[]>({
     queryKey: ['vendors'],
     queryFn: listVendors,
-  });
-
-  const create = useMutation({
-    mutationFn: (payload: Vendor) => createVendor(payload),
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: ['vendors'] }),
   });
 
   const update = useMutation({
@@ -26,25 +21,6 @@ export default function VendorsPage() {
 
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [editing, setEditing] = useState<Vendor | null>(null);
-
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    const formData = new FormData(e.currentTarget);
-    const payload: Vendor = {
-      name: formData.get('name') as string,
-      tags: (formData.get('tags') as string || '')
-        .split(',')
-        .map((t) => t.trim())
-        .filter(Boolean),
-    };
-    if (editing) {
-      update.mutate({ id: editing.id!, data: payload });
-    } else {
-      create.mutate(payload);
-    }
-    setDrawerOpen(false);
-    setEditing(null);
-  };
 
   return (
     <div className="p-6">
@@ -77,50 +53,13 @@ export default function VendorsPage() {
       </div>
       {drawerOpen && (
         <div className="fixed inset-0 bg-black/50 flex justify-end">
-          <form
-            onSubmit={handleSubmit}
-            className="bg-white w-full max-w-md p-4 space-y-4"
-          >
-            <h2 className="text-lg font-semibold">
-              {editing ? 'Edit Vendor' : 'New Vendor'}
-            </h2>
-            <div>
-              <label className="block text-sm font-medium">Name</label>
-              <input
-                name="name"
-                defaultValue={editing?.name || ''}
-                className="border p-2 w-full"
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium">
-                Tags (comma separated)
-              </label>
-              <input
-                name="tags"
-                defaultValue={editing?.tags?.join(', ') || ''}
-                className="border p-2 w-full"
-              />
-            </div>
-            <div className="flex justify-end gap-2 pt-2">
-              <button
-                type="button"
-                className="px-3 py-1"
-                onClick={() => {
-                  setDrawerOpen(false);
-                  setEditing(null);
-                }}
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                className="px-3 py-1 bg-blue-600 text-white rounded"
-              >
-                {editing ? 'Update' : 'Create'}
-              </button>
-            </div>
-          </form>
+          <VendorForm
+            vendor={editing || undefined}
+            onClose={() => {
+              setDrawerOpen(false);
+              setEditing(null);
+            }}
+          />
         </div>
       )}
     </div>

--- a/components/VendorCard.tsx
+++ b/components/VendorCard.tsx
@@ -1,4 +1,5 @@
 import type { Vendor } from '../lib/api';
+import { openInviteModal } from '../lib/invite';
 
 export default function VendorCard({
   vendor,
@@ -34,6 +35,27 @@ export default function VendorCard({
           ))}
         </div>
       )}
+      <div className="flex flex-wrap gap-2">
+        <span
+          className={`px-2 py-1 rounded text-xs ${
+            vendor.insured ? 'bg-green-100' : 'bg-red-100'
+          }`}
+        >
+          {vendor.insured ? 'Insured' : 'No Insurance'}
+        </span>
+        <span
+          className={`px-2 py-1 rounded text-xs ${
+            vendor.licensed ? 'bg-green-100' : 'bg-red-100'
+          }`}
+        >
+          {vendor.licensed ? 'Licensed' : 'No Licence'}
+        </span>
+      </div>
+      {vendor.avgResponseTime !== undefined && (
+        <div className="text-xs text-gray-600">
+          Avg response: {vendor.avgResponseTime}h
+        </div>
+      )}
       {vendor.documents && vendor.documents.length > 0 && (
         <div className="flex flex-wrap gap-2">
           {(vendor.documents ?? []).map((doc: string) => (
@@ -50,7 +72,10 @@ export default function VendorCard({
         <button className="px-2 py-1 border rounded text-sm" onClick={onEdit}>
           Edit
         </button>
-        <button className="px-2 py-1 border rounded text-sm">
+        <button
+          className="px-2 py-1 border rounded text-sm"
+          onClick={() => vendor.id && openInviteModal(vendor.id)}
+        >
           Invite to Quote
         </button>
       </div>

--- a/components/VendorForm.tsx
+++ b/components/VendorForm.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import PhotoUpload from './PhotoUpload';
+import {
+  createVendor,
+  updateVendor,
+  type Vendor,
+  uploadDocument,
+} from '../lib/api';
+
+export default function VendorForm({
+  vendor,
+  onClose,
+}: {
+  vendor?: Vendor;
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState(vendor?.name ?? '');
+  const [tags, setTags] = useState(vendor?.tags.join(', ') ?? '');
+  const [insured, setInsured] = useState<boolean>(vendor?.insured ?? false);
+  const [licensed, setLicensed] = useState<boolean>(vendor?.licensed ?? false);
+  const [avgResponseTime, setAvgResponseTime] = useState<string>(
+    vendor?.avgResponseTime?.toString() ?? ''
+  );
+  const [documents, setDocuments] = useState<string[]>(vendor?.documents ?? []);
+
+  const mutation = useMutation({
+    mutationFn: (payload: Vendor) =>
+      vendor && vendor.id
+        ? updateVendor(vendor.id, payload)
+        : createVendor(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['vendors'] });
+      onClose();
+    },
+  });
+
+  const handleUpload = async (files: File[]) => {
+    const uploaded: string[] = [];
+    for (const _ of files) {
+      const res = await uploadDocument();
+      uploaded.push(res.url);
+    }
+    setDocuments((d) => [...d, ...uploaded]);
+  };
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        const payload: Vendor = {
+          name,
+          tags: tags
+            .split(',')
+            .map((t) => t.trim())
+            .filter(Boolean),
+          insured,
+          licensed,
+          avgResponseTime: avgResponseTime
+            ? parseFloat(avgResponseTime)
+            : undefined,
+          documents,
+        };
+        mutation.mutate(payload);
+      }}
+      className="bg-white w-full max-w-md p-4 space-y-4"
+    >
+      <h2 className="text-lg font-semibold">
+        {vendor ? 'Edit Vendor' : 'New Vendor'}
+      </h2>
+      <div>
+        <label className="block text-sm font-medium">Name</label>
+        <input
+          className="border p-2 w-full"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium">Tags (comma separated)</label>
+        <input
+          className="border p-2 w-full"
+          value={tags}
+          onChange={(e) => setTags(e.target.value)}
+        />
+      </div>
+      <div className="flex gap-4">
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={insured}
+            onChange={(e) => setInsured(e.target.checked)}
+          />
+          Insured
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={licensed}
+            onChange={(e) => setLicensed(e.target.checked)}
+          />
+          Licensed
+        </label>
+      </div>
+      <div>
+        <label className="block text-sm font-medium">Average response time (hours)</label>
+        <input
+          type="number"
+          className="border p-2 w-full"
+          value={avgResponseTime}
+          onChange={(e) => setAvgResponseTime(e.target.value)}
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium">Documents</label>
+        <PhotoUpload onUpload={handleUpload} />
+        {documents.length > 0 && (
+          <div className="flex flex-wrap gap-2 mt-2">
+            {documents.map((doc) => (
+              <span key={doc} className="text-xs bg-blue-100 p-1 rounded">
+                {doc}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+      <div className="flex justify-end gap-2 pt-2">
+        <button type="button" className="px-3 py-1" onClick={onClose}>
+          Cancel
+        </button>
+        <button
+          type="submit"
+          className="px-3 py-1 bg-blue-600 text-white rounded"
+        >
+          {vendor ? 'Update' : 'Create'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -14,6 +14,9 @@ export interface Vendor {
   name: string;
   tags: string[];
   favourite?: boolean;
+  insured?: boolean;
+  licensed?: boolean;
+  avgResponseTime?: number;
   documents?: string[];
 }
 
@@ -92,6 +95,13 @@ export const createVendor = (payload: Vendor) =>
   api('/vendors', { method: 'POST', body: JSON.stringify(payload) });
 export const updateVendor = (id: string, payload: Partial<Vendor>) =>
   api(`/vendors/${id}`, { method: 'PATCH', body: JSON.stringify(payload) });
+export const deleteVendor = (id: string) =>
+  api(`/vendors/${id}`, { method: 'DELETE' });
+export const uploadDocument = () => api<{ url: string }>('/upload', { method: 'POST' });
+export const addVendorDocument = (id: string, url: string) =>
+  api(`/vendors/${id}/documents`, { method: 'POST', body: JSON.stringify({ url }) });
+export const removeVendorDocument = (id: string, url: string) =>
+  api(`/vendors/${id}/documents`, { method: 'DELETE', body: JSON.stringify({ url }) });
 
 // Notification settings
 export const getNotificationSettings = () =>

--- a/lib/invite.ts
+++ b/lib/invite.ts
@@ -1,0 +1,8 @@
+export function openInviteModal(vendorId: string, jobId?: string) {
+  if (typeof window !== 'undefined') {
+    const event = new CustomEvent('open-invite-modal', {
+      detail: { vendorId, jobId },
+    });
+    window.dispatchEvent(event);
+  }
+}


### PR DESCRIPTION
## Summary
- display vendor trade tags, insurance/licence status and response time
- add vendor drawer form with document upload
- implement vendor CRUD API and document endpoints, expose invite helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba52f34710832c89fe15e82582fc84