### PR TITLE
Add finance and settings landing pages

### DIFF
--- a/app/finance/page.tsx
+++ b/app/finance/page.tsx
@@ -1,0 +1,17 @@
+import Link from "next/link";
+
+export default function FinancePage() {
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">Finance</h1>
+      <ul className="list-disc pl-6 space-y-1">
+        <li>
+          <Link href="/finance/expenses">Expenses</Link>
+        </li>
+        <li>
+          <Link href="/finance/pnl">P&amp;L</Link>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+
+export default function SettingsPage() {
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">Settings</h1>
+      <ul className="list-disc pl-6 space-y-1">
+        <li>
+          <Link href="/settings/notifications">Notifications</Link>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -10,7 +10,7 @@ const links = [
   { href: "/applications", label: "Applications" },
   { href: "/listings", label: "Listings" },
   { href: "/rent-review", label: "Rent Review" },
-  { href: "/finance", label: "Finance (Expenses/P&L)" },
+  { href: "/finance", label: "Finance" },
   { href: "/vendors", label: "Vendors" },
   { href: "/settings", label: "Settings" }
 ];


### PR DESCRIPTION
## Summary
- add landing pages for finance and settings with navigation links to child routes
- update sidebar link labels to point to new landings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba59b7f8f4832c9f0f919a3b5648a5