### PR TITLE
Default to /api for expense API calls

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -53,7 +53,8 @@ export interface Lease {
 }
 
 export async function api<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch((process.env.NEXT_PUBLIC_API_BASE || '') + path, {
+  const base = process.env.NEXT_PUBLIC_API_BASE ?? '/api';
+  const res = await fetch(base + path, {
     ...init,
     headers: {
       'Content-Type': 'application/json',
@@ -88,7 +89,7 @@ export const postInspectionItems = (id: string, payload: any) =>
   api(`/inspections/${id}/items`, { method: 'POST', body: JSON.stringify(payload) });
 export const getInspectionReport = async (id: string) => {
   const res = await fetch(
-    (process.env.NEXT_PUBLIC_API_BASE || '') + `/inspections/${id}/report`,
+    (process.env.NEXT_PUBLIC_API_BASE ?? '/api') + `/inspections/${id}/report`,
     {
       headers: {
         Authorization: `Bearer ${
@@ -124,7 +125,7 @@ export const generateListingCopy = (features: string) =>
     body: JSON.stringify({ features }),
   });
 export const exportListingPack = async (id: string) => {
-  const res = await fetch((process.env.NEXT_PUBLIC_API_BASE || "") + `/listings/${id}/export`, {
+  const res = await fetch((process.env.NEXT_PUBLIC_API_BASE ?? '/api') + `/listings/${id}/export`, {
     headers: {
       Authorization: `Bearer ${typeof window !== "undefined" ? localStorage.getItem("token") || "" : ""}`,
     },


### PR DESCRIPTION
## Summary
- default api helper to `/api` when `NEXT_PUBLIC_API_BASE` is unset
- ensure inspection report and listing export helpers use same base

## Testing
- `node <<'NODE'
global.fetch = (url, init) => { console.log('FETCH', url); return Promise.resolve({ ok: true, json: async () => ({ id: '1' }), text: async () => '' }); };
const api = async (path, init) => {
  const base = process.env.NEXT_PUBLIC_API_BASE ?? '/api';
  const res = await fetch(base + path, { ...init });
  if (!res.ok) throw new Error(await res.text());
  return res.json();
};
const createExpense = (propertyId, payload) => api(`/properties/${propertyId}/expenses`, { method: 'POST', body: JSON.stringify(payload) });
await createExpense('abc123', { amount: 1 });
NODE`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba5c3f5a9c832cacc1056074221311