### PR TITLE
chore: centralize application and expense types

### DIFF
--- a/app/applications/page.tsx
+++ b/app/applications/page.tsx
@@ -2,10 +2,9 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { useState, useMemo } from "react";
-import ApplicationsTable, {
-  ApplicationRow,
-} from "../../components/ApplicationsTable";
+import ApplicationsTable from "../../components/ApplicationsTable";
 import { listApplications } from "../../lib/api";
+import type { ApplicationRow } from "../../types/application";
 
 export default function ApplicationsPage() {
   const { data: rows } = useQuery<ApplicationRow[]>({

--- a/components/ApplicationsTable.tsx
+++ b/components/ApplicationsTable.tsx
@@ -1,13 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-
-export interface ApplicationRow {
-  id: string;
-  applicant: string;
-  property: string;
-  status: string;
-}
+import type { ApplicationRow } from "../types/application";
 
 export default function ApplicationsTable({ rows }: { rows: ApplicationRow[] }) {
   const router = useRouter();

--- a/components/ExpensesTable.tsx
+++ b/components/ExpensesTable.tsx
@@ -4,17 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import { useParams } from "next/navigation";
 import { listExpenses } from "../lib/api";
-
-export interface ExpenseRow {
-  id: string;
-  date: string;
-  category: string;
-  vendor: string;
-  amount: number;
-  gst: number;
-  notes?: string;
-  receiptUrl?: string;
-}
+import type { ExpenseRow } from "../types/expense";
 
 export default function ExpensesTable() {
   const { propertyId } = useParams<{ propertyId: string }>();

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,5 +1,5 @@
-import type { ApplicationRow } from '../components/ApplicationsTable';
-import type { ExpenseRow } from '../components/ExpensesTable';
+import type { ApplicationRow } from '../types/application';
+import type { ExpenseRow } from '../types/expense';
 
 export interface Inspection {
   id: string;

--- a/types/application.ts
+++ b/types/application.ts
@@ -1,0 +1,6 @@
+export interface ApplicationRow {
+  id: string;
+  applicant: string;
+  property: string;
+  status: string;
+}

--- a/types/expense.ts
+++ b/types/expense.ts
@@ -1,0 +1,10 @@
+export interface ExpenseRow {
+  id: string;
+  date: string;
+  category: string;
+  vendor: string;
+  amount: number;
+  gst: number;
+  notes?: string;
+  receiptUrl?: string;
+}


### PR DESCRIPTION
## Summary
- add shared `ApplicationRow` and `ExpenseRow` interfaces under `types`
- update API and component imports to use shared types

## Testing
- `npm test`
- `npm run build` *(fails: sh: 1: next: not found)*
- `npm ci` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68ba65021ca4832ca1e190e67cff6fea