### PR TITLE
feat: add shared listing type

### DIFF
--- a/app/api/listings/[id]/export/route.ts
+++ b/app/api/listings/[id]/export/route.ts
@@ -1,7 +1,8 @@
 import { listings } from '../../../store';
+import type { Listing } from '../../../../../types/listing';
 
 export async function GET(_: Request, { params }: { params: { id: string } }) {
-  const listing = listings.find((l) => l.id === params.id);
+  const listing: Listing | undefined = listings.find((l) => l.id === params.id);
   const content = `Listing pack for property ${listing?.property || ''}`;
   const data = new TextEncoder().encode(content);
   return new Response(data, {

--- a/app/api/listings/route.ts
+++ b/app/api/listings/route.ts
@@ -1,4 +1,5 @@
 import { listings } from '../store';
+import type { Listing } from '../../../types/listing';
 
 export async function GET() {
   return Response.json(listings);
@@ -6,7 +7,7 @@ export async function GET() {
 
 export async function POST(req: Request) {
   const body = await req.json();
-  const listing = { id: String(listings.length + 1), ...body };
+  const listing: Listing = { id: String(listings.length + 1), ...body };
   listings.push(listing);
   return Response.json(listing);
 }

--- a/app/api/store.ts
+++ b/app/api/store.ts
@@ -1,3 +1,5 @@
+import type { Listing } from '../../types/listing';
+
 // In-memory store for mock API routes during Phase-2 development.
 // Data resets when the server restarts. Use resetStore() to restore defaults
 // or replace these mocks with real persistence when a backend is available.
@@ -76,7 +78,7 @@ export const expenses: any[] = [...initialExpenses];
 
 export const notificationSettings = { email: true, sms: false, inApp: true };
 
-export const listings: any[] = [];
+export const listings: Listing[] = [];
 
 export const rentReviews: any[] = [];
 

--- a/app/listings/page.tsx
+++ b/app/listings/page.tsx
@@ -3,9 +3,10 @@
 import Link from 'next/link';
 import { useQuery } from '@tanstack/react-query';
 import { listListings } from '../../lib/api';
+import type { Listing } from '../../types/listing';
 
 export default function ListingsPage() {
-  const { data: listings } = useQuery({ queryKey: ['listings'], queryFn: listListings });
+  const { data: listings } = useQuery<Listing[]>({ queryKey: ['listings'], queryFn: listListings });
 
   return (
     <div className="p-6">

--- a/components/ListingWizard.tsx
+++ b/components/ListingWizard.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import PhotoUpload from "./PhotoUpload";
 import { createListing, generateListingCopy, exportListingPack } from "../lib/api";
+import type { Listing } from "../types/listing";
 
 interface FormState {
   property: string;
@@ -25,7 +26,7 @@ export default function ListingWizard() {
   const [adCopy, setAdCopy] = useState("");
   const [listingId, setListingId] = useState<string | null>(null);
 
-  const createMutation = useMutation({
+  const createMutation = useMutation<Listing>({
     mutationFn: () =>
       createListing({
         property: form.property,
@@ -34,7 +35,7 @@ export default function ListingWizard() {
         rent: parseFloat(form.rent),
         description: adCopy || form.description,
       }),
-    onSuccess: (data: any) => setListingId(data.id),
+    onSuccess: (data) => setListingId(data.id),
   });
 
   const copyMutation = useMutation({

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,5 +1,6 @@
 import type { ApplicationRow } from '../components/ApplicationsTable';
 import type { ExpenseRow } from '../components/ExpensesTable';
+import type { Listing } from '../types/listing';
 
 export interface Inspection {
   id: string;
@@ -117,7 +118,8 @@ export const postScore = (id: string, payload: any) =>
   });
 
 // Listings
-export const createListing = (payload: any) => api('/listings', { method: 'POST', body: JSON.stringify(payload) });
+export const createListing = (payload: Omit<Listing, 'id'>) =>
+  api<Listing>('/listings', { method: 'POST', body: JSON.stringify(payload) });
 export const listListings = () => api<Listing[]>('/listings');
 export const generateListingCopy = (features: string) =>
   api<{ text: string }>("/ai/listing-copy", {

--- a/types/listing.ts
+++ b/types/listing.ts
@@ -1,0 +1,8 @@
+export interface Listing {
+  id: string;
+  property: string;
+  photos: string[];
+  features: string;
+  rent: number;
+  description: string;
+}


### PR DESCRIPTION
## Summary
- add shared `Listing` interface
- type listing APIs with shared interface
- use `Listing` type across listing components and routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba65031144832c9875288fdd1db2f5