### PR TITLE
Handle FormData Content-Type in API helper

### DIFF
--- a/lib/api.test.ts
+++ b/lib/api.test.ts
@@ -1,0 +1,37 @@
+import { api, uploadExpenseReceipt } from './api';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// JSON requests should include application/json Content-Type by default
+
+test('api uses JSON Content-Type when body is JSON', async () => {
+  (globalThis as any).fetch = async (_input: RequestInfo, init?: RequestInit) => {
+    const headers = init?.headers as any;
+    if (headers instanceof Headers) {
+      assert.equal(headers.get('Content-Type'), 'application/json');
+    } else {
+      assert.equal(headers['Content-Type'], 'application/json');
+    }
+    return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+  };
+
+  await api('/test', { method: 'POST', body: JSON.stringify({ ok: true }) });
+});
+
+// Multipart requests should omit the Content-Type header so the browser can set it
+
+test('api omits Content-Type for FormData uploads', async () => {
+  (globalThis as any).fetch = async (_input: RequestInfo, init?: RequestInit) => {
+    const headers = init?.headers as any;
+    if (headers instanceof Headers) {
+      assert.ok(!headers.has('Content-Type'));
+    } else {
+      assert.ok(!('Content-Type' in headers));
+    }
+    assert.ok(init?.body instanceof FormData);
+    return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+  };
+
+  const file = new File(['hello'], 'receipt.txt', { type: 'text/plain' });
+  await uploadExpenseReceipt('p1', 'e1', file);
+});

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "echo \"No tests\""
+    "test": "node --loader ts-node/esm --test"
   },
   "dependencies": {
     "@prisma/client": "^5.13.0",


### PR DESCRIPTION
## Summary
- Skip default JSON Content-Type when sending FormData via `api`
- Simplify `uploadExpenseReceipt` to rely on `api` header logic
- Add tests covering JSON and multipart requests

## Testing
- `npm test` *(fails: Cannot find package 'ts-node' imported, dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6503f108832cba06ca5d577bae7a