### PR TITLE
feat: add limits and validation for photo uploads

### DIFF
--- a/components/PhotoUpload.tsx
+++ b/components/PhotoUpload.tsx
@@ -1,17 +1,46 @@
-import { useState } from 'react';
+import { useId, useState } from 'react';
 
-export default function PhotoUpload({ onUpload }: { onUpload?: (files: File[]) => void }) {
+interface Props {
+  onUpload?: (files: File[]) => void;
+  maxSizeMb?: number;
+}
+
+const ACCEPTED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+
+export default function PhotoUpload({
+  onUpload,
+  maxSizeMb = Number(process.env.MAX_UPLOAD_MB) || Infinity,
+}: Props) {
   const [files, setFiles] = useState<File[]>([]);
+  const inputId = useId();
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const list = Array.from(e.target.files || []);
+    const valid = list.filter(
+      (f) =>
+        ACCEPTED_TYPES.includes(f.type) &&
+        f.size <= maxSizeMb * 1024 * 1024
+    );
+
+    if (valid.length) {
+      setFiles(valid);
+      onUpload?.(valid);
+    } else {
+      setFiles([]);
+    }
+  };
+
   return (
     <div>
+      <label htmlFor={inputId} className="block mb-1">
+        Upload Photos
+      </label>
       <input
+        id={inputId}
         type="file"
         multiple
-        onChange={(e) => {
-          const list = Array.from(e.target.files || []);
-          setFiles(list);
-          onUpload?.(list);
-        }}
+        accept={ACCEPTED_TYPES.join(',')}
+        onChange={handleChange}
       />
       <div className="flex gap-2 mt-2 flex-wrap">
         {files.map((f, i) => (


### PR DESCRIPTION
## Summary
- add label tied to file input for photo uploads
- validate file types and sizes before calling `onUpload`
- handle missing max size env variable safely

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba65075744832ca15cd4b9130e9d3e