### PR TITLE
Handle multipart file uploads with validation

### DIFF
--- a/app/api/store.ts
+++ b/app/api/store.ts
@@ -80,6 +80,8 @@ export const listings: any[] = [];
 
 export const rentReviews: any[] = [];
 
+export const uploads: string[] = [];
+
 // Helper to reset all data back to its initial state
 export function resetStore() {
   properties.splice(0, properties.length, ...initialProperties);
@@ -90,4 +92,5 @@ export function resetStore() {
   expenses.splice(0, expenses.length, ...initialExpenses);
   listings.splice(0, listings.length);
   rentReviews.splice(0, rentReviews.length);
+  uploads.splice(0, uploads.length);
 }

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,3 +1,27 @@
-export async function POST() {
-  return Response.json({ url: '/uploads/mock.jpg' });
+import { randomUUID } from 'crypto';
+import { uploads } from '../store';
+
+const MAX_UPLOAD_MB = Number(process.env.MAX_UPLOAD_MB) || 5;
+const ALLOWED_MIME = ['image/jpeg', 'image/png', 'application/pdf'];
+
+export async function POST(req: Request) {
+  try {
+    const form = await req.formData();
+    const file = form.get('file');
+    if (!file || !(file instanceof File)) {
+      return Response.json({ error: 'File is required' }, { status: 400 });
+    }
+    if (!ALLOWED_MIME.includes(file.type)) {
+      return Response.json({ error: 'Invalid file type' }, { status: 400 });
+    }
+    const sizeMb = file.size / (1024 * 1024);
+    if (sizeMb > MAX_UPLOAD_MB) {
+      return Response.json({ error: 'File too large' }, { status: 400 });
+    }
+    const url = `/uploads/${randomUUID()}`;
+    uploads.push(url);
+    return Response.json({ url });
+  } catch {
+    return Response.json({ error: 'Invalid multipart payload' }, { status: 400 });
+  }
 }

--- a/components/VendorForm.tsx
+++ b/components/VendorForm.tsx
@@ -50,8 +50,8 @@ export default function VendorForm({
 
   const handleUpload = async (files: File[]) => {
     const uploaded: string[] = [];
-    for (const _ of files) {
-      const res = await uploadDocument();
+    for (const file of files) {
+      const res = await uploadDocument(file);
       uploaded.push(res.url);
     }
     setDocuments((d) => [...d, ...uploaded]);

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -197,7 +197,11 @@ export const updateVendor = (id: string, payload: Partial<Vendor>) =>
   api(`/vendors/${id}`, { method: 'PATCH', body: JSON.stringify(payload) });
 export const deleteVendor = (id: string) =>
   api(`/vendors/${id}`, { method: 'DELETE' });
-export const uploadDocument = () => api<{ url: string }>('/upload', { method: 'POST' });
+export const uploadDocument = (file: File) => {
+  const form = new FormData();
+  form.append('file', file);
+  return api<{ url: string }>('/upload', { method: 'POST', body: form, headers: {} });
+};
 export const addVendorDocument = (id: string, url: string) =>
   api(`/vendors/${id}/documents`, { method: 'POST', body: JSON.stringify({ url }) });
 export const removeVendorDocument = (id: string, url: string) =>


### PR DESCRIPTION
## Summary
- parse multipart form uploads and validate MIME type/size in upload API
- store generated upload URLs in mock store
- wire client upload helper and form to send files

## Testing
- `npm test`
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6508b080832cafe4d429b17938b0