### PR TITLE
Add environment variable sample and documentation

### DIFF
--- a/.env.local.sample
+++ b/.env.local.sample
@@ -1,0 +1,5 @@
+NEXT_PUBLIC_API_BASE=
+MOCK_MODE=true
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/propertylite
+MAX_UPLOAD_MB=8
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # PropTechTest
 
+## Environment variables
+
+Copy `.env.local.sample` to `.env.local` and adjust as needed.
+
+* `NEXT_PUBLIC_API_BASE` - Base URL for backend API.
+* `MOCK_MODE` - Enables mocked API responses when set to `true`.
+* `DATABASE_URL` - PostgreSQL connection string.
+* `MAX_UPLOAD_MB` - Maximum upload size in megabytes.
+
 ## Database Setup
 
 Ensure `DATABASE_URL` is set to your PostgreSQL connection string. To create the schema run:


### PR DESCRIPTION
## Summary
- add `.env.local.sample` with default environment keys
- document environment variables and sample file in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba650b9290832ca210026b0fa3c366