### PR TITLE
Add Playwright tests for key flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,13 @@ make reset
 
 ## Development
 
-Type-check the TypeScript sources:
+### Tests
+
+Install Playwright browsers and run the end-to-end tests:
 
 ```bash
+npm install
+npx playwright install
 npm test
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
       "devDependencies": {
         "prisma": "^5.13.0",
         "ts-node": "^10.9.1",
-        "typescript": "^5.3.3"
+        "typescript": "^5.3.3",
+        "@playwright/test": "^1.44.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -338,6 +339,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.44.0",
+      "dev": true,
+      "license": "Apache-2.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "echo \"No tests\""
+    "test": "playwright test"
   },
   "dependencies": {
     "@prisma/client": "^5.13.0",
@@ -25,6 +25,7 @@
     "typescript": "^5.3.3",
     "tailwindcss": "^3.4.1",
     "postcss": "^8.4.31",
-    "autoprefixer": "^10.4.16"
+    "autoprefixer": "^10.4.16",
+    "@playwright/test": "^1.44.0"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  webServer: {
+    command: 'npm run dev',
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: true,
+  },
+});

--- a/tests/applications.spec.ts
+++ b/tests/applications.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('Applications page has heading', async ({ page }) => {
+  await page.goto('/applications');
+  await expect(page.getByRole('heading', { name: 'Applications' })).toBeVisible();
+});

--- a/tests/finance.spec.ts
+++ b/tests/finance.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('Finance page has heading', async ({ page }) => {
+  await page.goto('/finance');
+  await expect(page.getByRole('heading', { name: 'Finance' })).toBeVisible();
+});

--- a/tests/inspections.spec.ts
+++ b/tests/inspections.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('Inspections page has heading', async ({ page }) => {
+  await page.goto('/inspections');
+  await expect(page.getByRole('heading', { name: 'Inspections' })).toBeVisible();
+});

--- a/tests/listings.spec.ts
+++ b/tests/listings.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('Listings page has heading', async ({ page }) => {
+  await page.goto('/listings');
+  await expect(page.getByRole('heading', { name: 'Listings' })).toBeVisible();
+});

--- a/tests/rent-review.spec.ts
+++ b/tests/rent-review.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('Rent Review page has heading', async ({ page }) => {
+  await page.goto('/rent-review');
+  await expect(page.getByRole('heading', { name: 'Rent Reviews' })).toBeVisible();
+});

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('Settings page has heading', async ({ page }) => {
+  await page.goto('/settings');
+  await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+});

--- a/tests/vendors.spec.ts
+++ b/tests/vendors.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('Vendors page has heading', async ({ page }) => {
+  await page.goto('/vendors');
+  await expect(page.getByRole('heading', { name: 'Vendors' })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- install Playwright test runner and add config
- write basic end-to-end specs for inspections, applications, listings, rent review, finance, vendors, and settings
- document Playwright setup and test command

## Testing
- `npm install -D @playwright/test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*
- `npx playwright install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm test` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba650d308c832cbff6fe1e7c8d67df