### PR TITLE
Refine mock seed data for demo properties and records

### DIFF
--- a/app/api/store.ts
+++ b/app/api/store.ts
@@ -6,14 +6,12 @@
 const initialProperties = [
   { id: '1', address: '123 Main St', owner: 'Alice', rent: 500 },
   { id: '2', address: '55 Side Ave', owner: 'Bob', rent: 650 },
-  { id: '3', address: '78 Circular Rd', owner: 'Carol', rent: 550 },
 ];
 export const properties: any[] = [...initialProperties];
 
 const initialTenancies = [
   { id: '1', propertyId: '1', currentRent: 500, nextReview: '2024-07-01' },
   { id: '2', propertyId: '2', currentRent: 650, nextReview: '2024-08-15' },
-  { id: '3', propertyId: '3', currentRent: 550, nextReview: '2024-09-30' },
 ];
 export const tenancies: any[] = [...initialTenancies];
 
@@ -28,8 +26,8 @@ export const inspections: any[] = [...initialInspections];
 // --- Applications ---
 const initialApplications = [
   { id: '1', applicant: 'John Doe', property: '1', status: 'New' },
-  { id: '2', applicant: 'Jane Smith', property: '2', status: 'Reviewed' },
-  { id: '3', applicant: 'Mike Johnson', property: '3', status: 'Rejected' },
+  { id: '2', applicant: 'Jane Smith', property: '1', status: 'In Review' },
+  { id: '3', applicant: 'Mike Johnson', property: '2', status: 'Accepted' },
 ];
 export const applications: any[] = [...initialApplications];
 
@@ -62,15 +60,71 @@ const initialVendors = [
     avgResponseTime: 8,
     documents: [],
   },
+  {
+    id: '4',
+    name: 'Rapid Roofing',
+    tags: ['roofer'],
+    insured: true,
+    licensed: true,
+    favourite: true,
+    avgResponseTime: 4,
+    documents: ['warranty.pdf'],
+  },
 ];
 export const vendors: any[] = [...initialVendors];
 
 // --- Expenses ---
 const initialExpenses = [
-  { id: '1', propertyId: '1', date: '2024-01-01', category: 'Repairs', amount: 120 },
-  { id: '2', propertyId: '1', date: '2024-02-15', category: 'Utilities', amount: 80 },
-  { id: '3', propertyId: '2', date: '2024-02-20', category: 'Maintenance', amount: 200 },
-  { id: '4', propertyId: '3', date: '2024-03-10', category: 'Gardening', amount: 60 },
+  {
+    id: '1',
+    propertyId: '1',
+    date: '2024-01-05',
+    category: 'Repairs',
+    vendor: 'ACME Plumbing',
+    amount: 120,
+    gst: 12,
+    receiptUrl: '/receipts/1.pdf',
+  },
+  {
+    id: '2',
+    propertyId: '1',
+    date: '2024-02-15',
+    category: 'Utilities',
+    vendor: 'Energy Co',
+    amount: 80,
+    gst: 8,
+    receiptUrl: '/receipts/2.pdf',
+  },
+  {
+    id: '3',
+    propertyId: '2',
+    date: '2024-02-20',
+    category: 'Maintenance',
+    vendor: 'Clean & Co',
+    amount: 200,
+    gst: 20,
+    receiptUrl: '/receipts/3.pdf',
+  },
+  {
+    id: '4',
+    propertyId: '2',
+    date: '2024-03-10',
+    category: 'Gardening',
+    vendor: 'Gardeners Inc',
+    amount: 60,
+    gst: 6,
+    receiptUrl: '/receipts/4.pdf',
+  },
+  {
+    id: '5',
+    propertyId: '1',
+    date: '2024-03-25',
+    category: 'Insurance',
+    vendor: 'ABC Insurance',
+    amount: 300,
+    gst: 30,
+    receiptUrl: '/receipts/5.pdf',
+  },
 ];
 export const expenses: any[] = [...initialExpenses];
 
@@ -78,7 +132,17 @@ export const notificationSettings = { email: true, sms: false, inApp: true };
 
 export const listings: any[] = [];
 
-export const rentReviews: any[] = [];
+const initialRentReviews = [
+  {
+    id: '1',
+    tenancyId: '1',
+    reviewDate: '2024-06-15',
+    proposedRent: 520,
+    status: 'Pending',
+    noticeUrl: '/docs/rent-review-notice.pdf',
+  },
+];
+export const rentReviews: any[] = [...initialRentReviews];
 
 // Helper to reset all data back to its initial state
 export function resetStore() {
@@ -89,5 +153,5 @@ export function resetStore() {
   vendors.splice(0, vendors.length, ...initialVendors);
   expenses.splice(0, expenses.length, ...initialExpenses);
   listings.splice(0, listings.length);
-  rentReviews.splice(0, rentReviews.length);
+  rentReviews.splice(0, rentReviews.length, ...initialRentReviews);
 }


### PR DESCRIPTION
## Summary
- limit initial property mocks to two demo properties
- expand application statuses to New, In Review and Accepted
- grow vendor, expense and rent review seeds with richer details

## Testing
- `npm test`
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba651000bc832c8eee3f1118cb90b5