### PR TITLE
Add Prisma deploy script and document migrations

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/proptech"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules/
-.env
 npm-debug.log*
 .DS_Store
 prisma/dev.db

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ make seed
 make reset
 ```
 
+To apply migrations and seed the database using Prisma, run:
+
+```bash
+npx prisma migrate deploy
+npx prisma db seed
+```
+
 ## Development
 
 ### Tests

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "deploy": "bash -ac 'source .env && npx prisma migrate deploy && npx prisma db seed && next start'",
     "test": "playwright test"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- track `.env` with database URL sample
- document Prisma migration and seed commands
- add `deploy` script that sources `.env`, runs migrations and seeds, then starts Next.js

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68babb770080832ca77b56466f9b79de