### PR TITLE
feat: add property expense routes

### DIFF
--- a/app/api/properties/[id]/expenses/[expenseId]/route.ts
+++ b/app/api/properties/[id]/expenses/[expenseId]/route.ts
@@ -1,0 +1,30 @@
+import { prisma } from '../../../../../../lib/prisma';
+
+export async function GET(_req: Request, { params }: { params: { id: string; expenseId: string } }) {
+  const row = await prisma.mockData.findUnique({ where: { id: params.expenseId } });
+  if (row && (row.data as any).propertyId === params.id) {
+    return Response.json(row.data);
+  }
+  return Response.json(null);
+}
+
+export async function PATCH(req: Request, { params }: { params: { id: string; expenseId: string } }) {
+  const body = await req.json();
+  const row = await prisma.mockData.findUnique({ where: { id: params.expenseId } });
+  if (!row || (row.data as any).propertyId !== params.id) {
+    return Response.json(null);
+  }
+  const data = { ...row.data, ...body } as any;
+  await prisma.mockData.update({ where: { id: params.expenseId }, data: { data } });
+  return Response.json(data);
+}
+
+export async function DELETE(_req: Request, { params }: { params: { id: string; expenseId: string } }) {
+  const row = await prisma.mockData.findUnique({ where: { id: params.expenseId } });
+  if (!row || (row.data as any).propertyId !== params.id) {
+    return new Response(null, { status: 404 });
+  }
+  await prisma.mockData.delete({ where: { id: params.expenseId } });
+  return new Response(null, { status: 204 });
+}
+


### PR DESCRIPTION
## Summary
- add GET/PATCH/DELETE handlers for single property expenses

## Testing
- `npm test` *(fails: playwright: not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bad28d01c8832cb75d2314c1d58eb1