### PR TITLE
Add expense deletion Playwright test

### DIFF
--- a/tests/expense-delete.spec.ts
+++ b/tests/expense-delete.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+
+test('user can add and delete an expense', async ({ page }) => {
+  const propertyId = 'test-property';
+
+  // Navigate to the expenses page for a property
+  await page.goto(`/finance/${propertyId}/expenses`);
+
+  // Add a new expense via the form
+  await page.getByRole('button', { name: 'Add Expense' }).click();
+  await page.getByLabel('Date').fill('2024-01-01');
+  await page.getByLabel('Category').fill('Utilities');
+  await page.getByLabel('Vendor').fill('Acme Corp');
+  await page.getByLabel('Amount').fill('100');
+  await page.getByLabel('GST').fill('10');
+  await page.getByLabel('Notes').fill('Test expense');
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  // Ensure the expense appears in the table
+  const row = page.getByRole('row', { has: page.getByText('Acme Corp') });
+  await expect(row).toBeVisible();
+
+  // Delete the expense
+  await row.getByRole('button', { name: 'Delete' }).click();
+
+  // Verify the expense no longer appears
+  await expect(page.getByRole('cell', { name: 'Acme Corp' })).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary
- add Playwright test to create and delete an expense

## Testing
- `npx playwright test` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68bad290ba48832ca75b9ebb0e93ca55