### PR TITLE
Return totals in PnL API

### DIFF
--- a/app/api/properties/[id]/pnl/route.ts
+++ b/app/api/properties/[id]/pnl/route.ts
@@ -5,8 +5,17 @@ export async function GET(_: Request, { params }: { params: { id: string } }) {
   const expRows = await prisma.mockData.findMany({ where: { type: 'expense' } });
   const propertyExpenses = expRows.map((r) => r.data).filter((e: any) => e.propertyId === params.id);
   const totalExpenses = propertyExpenses.reduce((sum, e: any) => sum + (e.amount || 0), 0);
-  const income = property ? (property.data as any).rent * 12 : 0;
-  const net = income - totalExpenses;
-  const series = propertyExpenses.map((e: any) => ({ date: e.date, amount: e.amount }));
-  return Response.json({ income, expenses: totalExpenses, net, series });
+  const monthlyIncome = property ? (property.data as any).rent : 0;
+  const totalIncome = monthlyIncome * 12;
+  const net = totalIncome - totalExpenses;
+  const expenseByMonth: Record<string, number> = {};
+  for (const e of propertyExpenses) {
+    const month = (e.date as string).slice(0, 7);
+    expenseByMonth[month] = (expenseByMonth[month] || 0) + (e.amount || 0);
+  }
+  const monthly = Object.entries(expenseByMonth).map(([month, exp]) => ({
+    month,
+    net: monthlyIncome - exp,
+  }));
+  return Response.json({ totalIncome, totalExpenses, net, monthly });
 }


### PR DESCRIPTION
## Summary
- compute monthly profits and return totalIncome and totalExpenses from PnL API

## Testing
- `npm test` *(fails: playwright: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tanstack%2freact-query)*

------
https://chatgpt.com/codex/tasks/task_e_68bad4fdc7d8832c8ee6d46efe7b9a73