### PR TITLE
feat: add income tracking for pnl

### DIFF
--- a/app/api/properties/[id]/income/[incomeId]/route.ts
+++ b/app/api/properties/[id]/income/[incomeId]/route.ts
@@ -1,0 +1,41 @@
+import { prisma } from '../../../../../../lib/prisma';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string; incomeId: string } }
+) {
+  const row = await prisma.mockData.findUnique({ where: { id: params.incomeId } });
+  if (row && (row.data as any).propertyId === params.id) {
+    return Response.json(row.data);
+  }
+  return Response.json(null);
+}
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: { id: string; incomeId: string } }
+) {
+  const body = await req.json();
+  const row = await prisma.mockData.findUnique({ where: { id: params.incomeId } });
+  if (!row || (row.data as any).propertyId !== params.id) {
+    return Response.json(null);
+  }
+  const data = { ...row.data, ...body } as any;
+  await prisma.mockData.update({
+    where: { id: params.incomeId },
+    data: { data },
+  });
+  return Response.json(data);
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: { id: string; incomeId: string } }
+) {
+  const row = await prisma.mockData.findUnique({ where: { id: params.incomeId } });
+  if (!row || (row.data as any).propertyId !== params.id) {
+    return new Response(null, { status: 404 });
+  }
+  await prisma.mockData.delete({ where: { id: params.incomeId } });
+  return new Response(null, { status: 204 });
+}

--- a/app/api/properties/[id]/income/route.ts
+++ b/app/api/properties/[id]/income/route.ts
@@ -1,0 +1,18 @@
+import { randomUUID } from 'crypto';
+import { prisma } from '../../../../../lib/prisma';
+
+export async function GET(_: Request, { params }: { params: { id: string } }) {
+  const rows = await prisma.mockData.findMany({ where: { type: 'income' } });
+  return Response.json(
+    rows.map((r) => r.data).filter((i: any) => i.propertyId === params.id)
+  );
+}
+
+export async function POST(req: Request, { params }: { params: { id: string } }) {
+  const body = await req.json();
+  const income = { id: randomUUID(), propertyId: params.id, ...body };
+  await prisma.mockData.create({
+    data: { id: income.id, type: 'income', data: income },
+  });
+  return Response.json(income);
+}

--- a/app/api/properties/[id]/pnl/route.ts
+++ b/app/api/properties/[id]/pnl/route.ts
@@ -1,12 +1,40 @@
 import { prisma } from '../../../../../lib/prisma';
 
 export async function GET(_: Request, { params }: { params: { id: string } }) {
-  const property = await prisma.mockData.findUnique({ where: { id: params.id } });
-  const expRows = await prisma.mockData.findMany({ where: { type: 'expense' } });
-  const propertyExpenses = expRows.map((r) => r.data).filter((e: any) => e.propertyId === params.id);
-  const totalExpenses = propertyExpenses.reduce((sum, e: any) => sum + (e.amount || 0), 0);
-  const income = property ? (property.data as any).rent * 12 : 0;
-  const net = income - totalExpenses;
-  const series = propertyExpenses.map((e: any) => ({ date: e.date, amount: e.amount }));
-  return Response.json({ income, expenses: totalExpenses, net, series });
+  const incomeRows = await prisma.mockData.findMany({ where: { type: 'income' } });
+  const expenseRows = await prisma.mockData.findMany({ where: { type: 'expense' } });
+
+  const propertyIncome = incomeRows
+    .map((r) => r.data)
+    .filter((i: any) => i.propertyId === params.id);
+  const propertyExpenses = expenseRows
+    .map((r) => r.data)
+    .filter((e: any) => e.propertyId === params.id);
+
+  const totalIncome = propertyIncome.reduce(
+    (sum, i: any) => sum + (i.amount || 0),
+    0
+  );
+  const totalExpenses = propertyExpenses.reduce(
+    (sum, e: any) => sum + (e.amount || 0),
+    0
+  );
+  const net = totalIncome - totalExpenses;
+
+  const monthlyMap: Record<string, { income: number; expenses: number }> = {};
+  for (const i of propertyIncome) {
+    const month = i.date.slice(0, 7);
+    monthlyMap[month] = monthlyMap[month] || { income: 0, expenses: 0 };
+    monthlyMap[month].income += i.amount || 0;
+  }
+  for (const e of propertyExpenses) {
+    const month = e.date.slice(0, 7);
+    monthlyMap[month] = monthlyMap[month] || { income: 0, expenses: 0 };
+    monthlyMap[month].expenses += e.amount || 0;
+  }
+  const monthly = Object.entries(monthlyMap)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([month, m]) => ({ month, net: m.income - m.expenses }));
+
+  return Response.json({ totalIncome, totalExpenses, net, monthly });
 }

--- a/app/finance/[propertyId]/pnl/page.tsx
+++ b/app/finance/[propertyId]/pnl/page.tsx
@@ -3,6 +3,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { useParams } from "next/navigation";
 import PnLChart from "../../../../components/PnLChart";
+import IncomeForm from "../../../../components/IncomeForm";
+import IncomesTable from "../../../../components/IncomesTable";
 import { getPnLSummary, type PnLSummary } from "../../../../lib/api";
 import { exportCSV, exportPDF } from "../../../../lib/export";
 import { logEvent } from "../../../../lib/log";
@@ -70,6 +72,8 @@ export default function PnLPage() {
           Export PDF
         </button>
       </div>
+      <IncomeForm />
+      <IncomesTable />
     </div>
   );
 }

--- a/components/IncomeForm.tsx
+++ b/components/IncomeForm.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useParams } from "next/navigation";
+import { createIncome } from "../lib/api";
+import { useToast } from "./ui/use-toast";
+
+export default function IncomeForm({ onCreated }: { onCreated?: () => void }) {
+  const { propertyId } = useParams<{ propertyId: string }>();
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState({ date: "", source: "", amount: "", notes: "" });
+  const [error, setError] = useState<string | null>(null);
+  const { toast } = useToast();
+
+  const mutation = useMutation({
+    mutationFn: (payload: any) => createIncome(propertyId, payload),
+    onSuccess: () => {
+      toast({ title: "Income saved" });
+      setOpen(false);
+      setForm({ date: "", source: "", amount: "", notes: "" });
+      setError(null);
+      queryClient.invalidateQueries({ queryKey: ["income", propertyId] });
+      queryClient.invalidateQueries({ queryKey: ["pnl", propertyId] });
+      onCreated?.();
+    },
+    onError: (err: any) => {
+      const message = err instanceof Error ? err.message : "Failed to save income";
+      setError(message);
+      toast({ title: "Failed to save income", description: message });
+    },
+  });
+
+  return (
+    <div>
+      <button className="px-2 py-1 bg-blue-500 text-white" onClick={() => setOpen(true)}>
+        Add Income
+      </button>
+
+      {open && (
+        <div className="fixed inset-0 bg-black/50 flex justify-end">
+          <form
+            className="bg-white w-96 h-full p-4 space-y-2 overflow-y-auto"
+            onSubmit={(e) => {
+              e.preventDefault();
+              setError(null);
+              if (!form.date || !form.source || !form.amount) {
+                setError("Please fill in all required fields");
+                return;
+              }
+              if (isNaN(parseFloat(form.amount))) {
+                setError("Amount must be a number");
+                return;
+              }
+              mutation.mutate({
+                date: form.date,
+                source: form.source,
+                amount: parseFloat(form.amount),
+                notes: form.notes,
+              });
+            }}
+          >
+            <label className="block">
+              Date
+              <input
+                type="date"
+                className="border p-1 w-full"
+                value={form.date}
+                onChange={(e) => setForm({ ...form, date: e.target.value })}
+              />
+            </label>
+            <label className="block">
+              Source
+              <input
+                className="border p-1 w-full"
+                value={form.source}
+                onChange={(e) => setForm({ ...form, source: e.target.value })}
+              />
+            </label>
+            <label className="block">
+              Amount
+              <input
+                type="number"
+                className="border p-1 w-full"
+                value={form.amount}
+                onChange={(e) => setForm({ ...form, amount: e.target.value })}
+              />
+            </label>
+            <label className="block">
+              Notes
+              <textarea
+                className="border p-1 w-full"
+                value={form.notes}
+                onChange={(e) => setForm({ ...form, notes: e.target.value })}
+              />
+            </label>
+            {error && <p className="text-red-600 text-sm">{error}</p>}
+            <div className="flex justify-end gap-2 pt-2">
+              <button
+                type="button"
+                className="px-2 py-1 bg-gray-100"
+                onClick={() => setOpen(false)}
+              >
+                Cancel
+              </button>
+              <button type="submit" className="px-2 py-1 bg-green-500 text-white">
+                Save
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/IncomesTable.tsx
+++ b/components/IncomesTable.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { useParams } from "next/navigation";
+import { listIncome, deleteIncome } from "../lib/api";
+import type { IncomeRow } from "../types/income";
+
+export default function IncomesTable() {
+  const { propertyId } = useParams<{ propertyId: string }>();
+  const queryClient = useQueryClient();
+  const { data = [] } = useQuery<IncomeRow[]>({
+    queryKey: ["income", propertyId],
+    queryFn: () => listIncome(propertyId),
+  });
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteIncome(propertyId, id),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["income", propertyId] }),
+  });
+  const [from, setFrom] = useState("");
+  const [to, setTo] = useState("");
+  const [source, setSource] = useState("");
+
+  const rows = data.filter((r) => {
+    const afterFrom = from ? new Date(r.date) >= new Date(from) : true;
+    const beforeTo = to ? new Date(r.date) <= new Date(to) : true;
+    const sourceMatch = source
+      ? r.source.toLowerCase().includes(source.toLowerCase())
+      : true;
+    return afterFrom && beforeTo && sourceMatch;
+  });
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap gap-2">
+        <input
+          type="date"
+          className="border p-1"
+          value={from}
+          onChange={(e) => setFrom(e.target.value)}
+          placeholder="From"
+        />
+        <input
+          type="date"
+          className="border p-1"
+          value={to}
+          onChange={(e) => setTo(e.target.value)}
+          placeholder="To"
+        />
+        <input
+          className="border p-1"
+          placeholder="Source"
+          value={source}
+          onChange={(e) => setSource(e.target.value)}
+        />
+      </div>
+      <table className="min-w-full border">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="p-2 text-left">Date</th>
+            <th className="p-2 text-left">Source</th>
+            <th className="p-2 text-left">Amount</th>
+            <th className="p-2 text-left">Notes</th>
+            <th className="p-2 text-left">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.id} className="border-t">
+              <td className="p-2">{r.date}</td>
+              <td className="p-2">{r.source}</td>
+              <td className="p-2">{r.amount}</td>
+              <td className="p-2">{r.notes}</td>
+              <td className="p-2">
+                <button
+                  className="text-red-600 underline"
+                  onClick={() => {
+                    if (confirm("Delete this income?")) {
+                      deleteMutation.mutate(r.id);
+                    }
+                  }}
+                >
+                  Delete
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,6 +1,7 @@
 import type { ApplicationRow } from '../components/ApplicationsTable';
 import type { ExpenseRow } from '../components/ExpensesTable';
 import type { Listing } from '../types/listing';
+import type { IncomeRow } from '../types/income';
 
 export interface Inspection {
   id: string;
@@ -155,6 +156,7 @@ export const generateNotice = (payload: any) =>
 
 // Expenses & PnL
 export interface Expense extends ExpenseRow {}
+export interface Income extends IncomeRow {}
 
 export interface PnLSummary {
   totalIncome: number;
@@ -197,6 +199,25 @@ export const uploadExpenseReceipt = (
 };
 export const getPnLSummary = (propertyId: string) =>
   api<PnLSummary>(`/properties/${propertyId}/pnl`);
+
+export const listIncome = (propertyId: string) =>
+  api<IncomeRow[]>(`/properties/${propertyId}/income`);
+export const createIncome = (propertyId: string, payload: any) =>
+  api(`/properties/${propertyId}/income`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+export const updateIncome = (
+  propertyId: string,
+  id: string,
+  payload: any
+) =>
+  api(`/properties/${propertyId}/income/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(payload),
+  });
+export const deleteIncome = (propertyId: string, id: string) =>
+  api(`/properties/${propertyId}/income/${id}`, { method: 'DELETE' });
 
 // Vendors
 export const listVendors = () => api<Vendor[]>('/vendors');

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -16,6 +16,13 @@ export const expenseSchema = z.object({
   receiptUrl: z.string().optional(),
 });
 
+export const incomeSchema = z.object({
+  amount: z.number(),
+  source: z.string(),
+  date: z.string(),
+  notes: z.string().optional(),
+});
+
 export const vendorSchema = z.object({
   name: z.string(),
   tags: z.array(z.string()).default([]),
@@ -24,3 +31,4 @@ export const vendorSchema = z.object({
 export type InspectionInput = z.infer<typeof inspectionSchema>;
 export type ExpenseInput = z.infer<typeof expenseSchema>;
 export type VendorInput = z.infer<typeof vendorSchema>;
+export type IncomeInput = z.infer<typeof incomeSchema>;

--- a/tests/income-delete.spec.ts
+++ b/tests/income-delete.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+test('user can add and delete an income', async ({ page }) => {
+  const propertyId = 'test-property';
+
+  await page.goto(`/finance/${propertyId}/pnl`);
+
+  await page.getByRole('button', { name: 'Add Income' }).click();
+  await page.getByLabel('Date').fill('2024-01-15');
+  await page.getByLabel('Source').fill('Rent');
+  await page.getByLabel('Amount').fill('2000');
+  await page.getByLabel('Notes').fill('January rent');
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  const row = page.getByRole('row', { has: page.getByText('Rent') });
+  await expect(row).toBeVisible();
+
+  await row.getByRole('button', { name: 'Delete' }).click();
+  await expect(page.getByRole('cell', { name: 'Rent' })).toHaveCount(0);
+});

--- a/types/income.ts
+++ b/types/income.ts
@@ -1,0 +1,7 @@
+export interface IncomeRow {
+  id: string;
+  date: string;
+  source: string;
+  amount: number;
+  notes?: string;
+}


### PR DESCRIPTION
## Summary
- add API routes and model for property income entries
- render income form and table on P&L page
- compute P&L totals from recorded income and expenses

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bad4ff0660832cb777e00382778d04