### PR TITLE
feat: add dashboard components and tests

### DIFF
--- a/app/api/expenses/route.ts
+++ b/app/api/expenses/route.ts
@@ -1,0 +1,15 @@
+let expenses = [
+  { id: 'e1', propertyId: '1', amount: 500, date: '2024-05-01', description: 'Repairs' },
+  { id: 'e2', propertyId: '2', amount: 300, date: '2024-05-10', description: 'Maintenance' }
+];
+
+export async function GET() {
+  return Response.json(expenses);
+}
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const newExpense = { id: `e${expenses.length + 1}`, ...body };
+  expenses.push(newExpense);
+  return Response.json(newExpense);
+}

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,0 +1,9 @@
+export async function POST(req: Request) {
+  const type = req.headers.get('content-type') || '';
+  if (type.includes('multipart/form-data')) {
+    await req.formData();
+    return Response.json({ ok: true });
+  }
+  const body = await req.json();
+  return Response.json({ ok: true, ...body });
+}

--- a/app/api/properties/route.ts
+++ b/app/api/properties/route.ts
@@ -1,0 +1,7 @@
+export async function GET() {
+  return Response.json([
+    { id: '1', address: '123 Main St', tenant: 'Alice', rentStatus: 'Paid', leaseExpiry: '2024-12-31', monthlyRent: 2000 },
+    { id: '2', address: '456 Oak Ave', tenant: 'Bob', rentStatus: 'Due', leaseExpiry: '2025-03-15', monthlyRent: 1800 },
+    { id: '3', address: '789 Pine Rd', tenant: 'Carol', rentStatus: 'Paid', leaseExpiry: '2024-09-30', monthlyRent: 2200 },
+  ]);
+}

--- a/app/api/reminders/route.ts
+++ b/app/api/reminders/route.ts
@@ -1,0 +1,7 @@
+export async function GET() {
+  return Response.json([
+    { id: 'r1', title: 'Rent review for 123 Main St', date: '2024-06-15' },
+    { id: 'r2', title: 'Lease expiry for 456 Oak Ave', date: '2024-08-01' },
+    { id: 'r3', title: 'Insurance renewal for 789 Pine Rd', date: '2024-07-20' }
+  ]);
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,26 @@
+"use client";
+import { useEffect, useState } from "react";
+import CashflowTile from "../components/CashflowTile";
+import DashboardPropertyCard, { DashboardProperty } from "../components/DashboardPropertyCard";
+import UpcomingReminders from "../components/UpcomingReminders";
+import QuickActionsBar from "../components/QuickActionsBar";
+
 export default function Page() {
-  return <div className="p-6">Welcome to PropTech Phase 2</div>;
+  const [properties, setProperties] = useState<DashboardProperty[]>([]);
+  useEffect(() => {
+    fetch('/api/properties').then(res => res.json()).then((data: DashboardProperty[]) => setProperties(data.slice(0, 3)));
+  }, []);
+
+  return (
+    <div className="p-6 space-y-6">
+      <CashflowTile />
+      <div className="grid gap-4 md:grid-cols-3">
+        {properties.map((p) => (
+          <DashboardPropertyCard key={p.id} property={p} />
+        ))}
+      </div>
+      <UpcomingReminders />
+      <QuickActionsBar />
+    </div>
+  );
 }

--- a/components/CashflowTile.tsx
+++ b/components/CashflowTile.tsx
@@ -1,0 +1,36 @@
+"use client";
+import { useEffect, useState } from "react";
+
+interface Property { monthlyRent?: number }
+interface Expense { amount?: number }
+
+export default function CashflowTile() {
+  const [rent, setRent] = useState(0);
+  const [expenses, setExpenses] = useState(0);
+
+  useEffect(() => {
+    fetch('/api/properties')
+      .then(res => res.json())
+      .then((data: Property[]) => {
+        const total = data.reduce((sum, p) => sum + (p.monthlyRent || 0), 0);
+        setRent(total);
+      });
+    fetch('/api/expenses')
+      .then(res => res.json())
+      .then((data: Expense[]) => {
+        const total = data.reduce((sum, e) => sum + (e.amount || 0), 0);
+        setExpenses(total);
+      });
+  }, []);
+
+  const net = rent - expenses;
+
+  return (
+    <div className="p-4 border rounded" data-testid="cashflow-tile">
+      <h2 className="text-lg font-bold mb-2">Monthly Cashflow</h2>
+      <p>Rent: ${rent}</p>
+      <p>Expenses: ${expenses}</p>
+      <p className="font-semibold">Net: ${net}</p>
+    </div>
+  );
+}

--- a/components/DashboardPropertyCard.tsx
+++ b/components/DashboardPropertyCard.tsx
@@ -1,0 +1,18 @@
+export interface DashboardProperty {
+  id: string;
+  address: string;
+  tenant: string;
+  rentStatus: string;
+  leaseExpiry: string;
+}
+
+export default function DashboardPropertyCard({ property }: { property: DashboardProperty }) {
+  return (
+    <div className="p-4 border rounded" data-testid="property-card">
+      <h3 className="font-semibold">{property.address}</h3>
+      <div className="text-sm">Tenant: {property.tenant}</div>
+      <div className="text-sm">Rent: {property.rentStatus}</div>
+      <div className="text-sm">Lease Expiry: {property.leaseExpiry}</div>
+    </div>
+  );
+}

--- a/components/QuickActionsBar.tsx
+++ b/components/QuickActionsBar.tsx
@@ -1,0 +1,88 @@
+"use client";
+import { useState } from "react";
+
+export default function QuickActionsBar() {
+  const [action, setAction] = useState<null | 'expense' | 'document' | 'message'>(null);
+
+  return (
+    <div className="space-y-2" data-testid="quick-actions">
+      <div className="flex gap-2">
+        <button className="px-2 py-1 border rounded" onClick={() => setAction('expense')}>
+          Log Expense
+        </button>
+        <button className="px-2 py-1 border rounded" onClick={() => setAction('document')}>
+          Upload Document
+        </button>
+        <button className="px-2 py-1 border rounded" onClick={() => setAction('message')}>
+          Message Tenant
+        </button>
+      </div>
+      {action === 'expense' && (
+        <form
+          onSubmit={async (e) => {
+            e.preventDefault();
+            const form = e.target as HTMLFormElement;
+            const amount = (form.elements.namedItem('amount') as HTMLInputElement).value;
+            await fetch('/api/expenses', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ amount: Number(amount) }),
+            });
+            setAction(null);
+          }}
+          className="border p-2 space-y-2"
+        >
+          <input name="amount" placeholder="Amount" className="border p-1" />
+          <button type="submit" className="px-2 py-1 border rounded">
+            Save
+          </button>
+        </form>
+      )}
+      {action === 'document' && (
+        <form
+          onSubmit={async (e) => {
+            e.preventDefault();
+            const form = e.target as HTMLFormElement;
+            const fileInput = form.elements.namedItem('file') as HTMLInputElement;
+            const formData = new FormData();
+            if (fileInput.files?.[0]) {
+              formData.append('file', fileInput.files[0]);
+            }
+            await fetch('/api/notifications', {
+              method: 'POST',
+              body: formData,
+            });
+            setAction(null);
+          }}
+          className="border p-2 space-y-2"
+        >
+          <input name="file" type="file" aria-label="Document" />
+          <button type="submit" className="px-2 py-1 border rounded">
+            Upload
+          </button>
+        </form>
+      )}
+      {action === 'message' && (
+        <form
+          onSubmit={async (e) => {
+            e.preventDefault();
+            const form = e.target as HTMLFormElement;
+            const message = (form.elements.namedItem('message') as HTMLTextAreaElement).value;
+            await fetch('/api/notifications', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ message }),
+            });
+            setAction(null);
+          }}
+          className="border p-2 space-y-2"
+        >
+          <textarea name="message" placeholder="Message to tenant" className="border p-1" />
+          <button type="submit" className="px-2 py-1 border rounded">
+            Send
+          </button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/components/UpcomingReminders.tsx
+++ b/components/UpcomingReminders.tsx
@@ -1,0 +1,21 @@
+"use client";
+import { useEffect, useState } from "react";
+
+interface Reminder { id: string; title: string; date: string }
+
+export default function UpcomingReminders() {
+  const [reminders, setReminders] = useState<Reminder[]>([]);
+  useEffect(() => {
+    fetch('/api/reminders').then(res => res.json()).then(setReminders);
+  }, []);
+  return (
+    <div className="p-4 border rounded" data-testid="reminders">
+      <h2 className="text-lg font-bold mb-2">Upcoming Reminders</h2>
+      <ul className="list-disc pl-5">
+        {reminders.map(r => (
+          <li key={r.id}>{r.title} - {r.date}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/tests/dashboard.spec.ts
+++ b/tests/dashboard.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+test('dashboard renders and quick actions work', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByTestId('cashflow-tile')).toBeVisible();
+  await expect(page.getByTestId('property-card').first()).toBeVisible();
+  await expect(page.getByTestId('reminders')).toBeVisible();
+  await expect(page.getByTestId('quick-actions')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Log Expense' }).click();
+  await expect(page.getByPlaceholder('Amount')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Upload Document' }).click();
+  await expect(page.getByLabel('Document')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Message Tenant' }).click();
+  await expect(page.getByPlaceholder('Message to tenant')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add dashboard components for cashflow, property cards, reminders, and quick actions
- mock API routes for properties, expenses, reminders, and notifications
- dashboard page layout and Playwright test

## Testing
- `npm test` *(fails: playwright not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tanstack%2freact-query)*

------
https://chatgpt.com/codex/tasks/task_e_68bade7fc0dc832c9ccbb15e3103488e