### PR TITLE
Add property pages and detail tabs

### DIFF
--- a/app/properties/[id]/page.tsx
+++ b/app/properties/[id]/page.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
+import { getProperty } from '../../../lib/api';
+import PropertyDetailTabs from '../../../components/PropertyDetailTabs';
+import type { PropertySummary } from '../../../types/property';
+
+export default function PropertyDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const { data } = useQuery<PropertySummary>({
+    queryKey: ['property', id],
+    queryFn: () => getProperty(id),
+  });
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">Property Details</h1>
+      {data && (
+        <PropertyDetailTabs propertyId={data.id} events={data.events} />
+      )}
+    </div>
+  );
+}
+

--- a/app/properties/page.tsx
+++ b/app/properties/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import PropertyOverviewCard from '../../components/PropertyOverviewCard';
+import { listProperties } from '../../lib/api';
+import type { PropertySummary } from '../../types/property';
+
+export default function PropertiesPage() {
+  const { data = [] } = useQuery<PropertySummary[]>({
+    queryKey: ['properties'],
+    queryFn: listProperties,
+  });
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">Properties</h1>
+      {data.map((p) => (
+        <PropertyOverviewCard key={p.id} property={p} />
+      ))}
+    </div>
+  );
+}
+

--- a/components/ExpensesTable.tsx
+++ b/components/ExpensesTable.tsx
@@ -7,7 +7,9 @@ import { listExpenses, deleteExpense } from "../lib/api";
 import type { ExpenseRow } from "../types/expense";
 
 export default function ExpensesTable() {
-  const { propertyId } = useParams<{ propertyId: string }>();
+  // Support routes using either `propertyId` or a generic `id` param
+  const params = useParams<{ propertyId?: string; id?: string }>();
+  const propertyId = params.propertyId ?? params.id ?? "";
   const queryClient = useQueryClient();
   const { data = [] } = useQuery<ExpenseRow[]>({
     queryKey: ["expenses", propertyId],

--- a/components/PropertyDetailTabs.tsx
+++ b/components/PropertyDetailTabs.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState } from "react";
+import ExpensesTable from "./ExpensesTable";
+import RentLedgerTable from "./RentLedgerTable";
+import PropertyDocumentsTable from "./PropertyDocumentsTable";
+
+interface Props {
+  propertyId: string;
+  events: { date: string; title: string }[];
+}
+
+const tabs = ["Rent Ledger", "Expenses", "Documents", "Key Dates"] as const;
+
+export default function PropertyDetailTabs({ propertyId, events }: Props) {
+  const [active, setActive] = useState<typeof tabs[number]>("Rent Ledger");
+
+  return (
+    <div>
+      <div className="flex space-x-4 border-b mb-4">
+        {tabs.map((t) => (
+          <button
+            key={t}
+            className={`pb-2 ${
+              active === t ? "border-b-2 border-blue-500 font-semibold" : ""
+            }`}
+            onClick={() => setActive(t)}
+            role="tab"
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+      {active === "Rent Ledger" && <RentLedgerTable propertyId={propertyId} />}
+      {active === "Expenses" && <ExpensesTable />}
+      {active === "Documents" && <PropertyDocumentsTable propertyId={propertyId} />}
+      {active === "Key Dates" && (
+        <ul className="space-y-1">
+          {events.map((e, i) => (
+            <li key={i} className="flex gap-2">
+              <span className="text-sm text-gray-600">{e.date}</span>
+              <span>{e.title}</span>
+            </li>
+          ))}
+          {events.length === 0 && <li>No upcoming dates</li>}
+        </ul>
+      )}
+    </div>
+  );
+}
+

--- a/components/PropertyDocumentsTable.tsx
+++ b/components/PropertyDocumentsTable.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import { listPropertyDocuments } from "../lib/api";
+import type { PropertyDocument } from "../types/property";
+
+export default function PropertyDocumentsTable({
+  propertyId: propId,
+}: {
+  propertyId?: string;
+}) {
+  const params = useParams<{ propertyId?: string; id?: string }>();
+  const propertyId = propId ?? params.propertyId ?? params.id ?? "";
+  const { data = [] } = useQuery<PropertyDocument[]>({
+    queryKey: ["documents", propertyId],
+    queryFn: () => listPropertyDocuments(propertyId),
+  });
+
+  return (
+    <table className="min-w-full border">
+      <thead className="bg-gray-100">
+        <tr>
+          <th className="p-2 text-left">Name</th>
+          <th className="p-2 text-left">Uploaded</th>
+          <th className="p-2 text-left">Link</th>
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((d) => (
+          <tr key={d.id} className="border-t">
+            <td className="p-2">{d.name}</td>
+            <td className="p-2">{d.uploaded}</td>
+            <td className="p-2">
+              <a
+                href={d.url}
+                target="_blank"
+                rel="noreferrer"
+                className="text-blue-600 underline"
+              >
+                View
+              </a>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+

--- a/components/PropertyOverviewCard.tsx
+++ b/components/PropertyOverviewCard.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import Link from "next/link";
+import type { PropertySummary } from "../types/property";
+
+interface Props {
+  property: PropertySummary;
+}
+
+export default function PropertyOverviewCard({ property }: Props) {
+  return (
+    <div className="border rounded p-4 space-y-2">
+      <div className="flex justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">
+            <Link
+              href={`/properties/${property.id}`}
+              className="text-blue-600 underline"
+            >
+              {property.address}
+            </Link>
+          </h2>
+          <p>Tenant: {property.tenant}</p>
+          <p>
+            Lease: {property.leaseStart} – {property.leaseEnd}
+          </p>
+        </div>
+        <div className="text-right">
+          <p className="text-lg font-semibold">${property.rent}/week</p>
+        </div>
+      </div>
+      <div>
+        <h3 className="font-semibold">Upcoming</h3>
+        <ul className="list-disc pl-5">
+          {property.events.map((e) => (
+            <li key={e.date + e.title}>
+              {e.date}: {e.title}
+            </li>
+          ))}
+          {property.events.length === 0 && <li>None</li>}
+        </ul>
+      </div>
+    </div>
+  );
+}
+

--- a/components/RentLedgerTable.tsx
+++ b/components/RentLedgerTable.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import { listLedger } from "../lib/api";
+import type { LedgerEntry } from "../types/property";
+
+export default function RentLedgerTable({
+  propertyId: propId,
+}: {
+  propertyId?: string;
+}) {
+  const params = useParams<{ propertyId?: string; id?: string }>();
+  const propertyId = propId ?? params.propertyId ?? params.id ?? "";
+  const { data = [] } = useQuery<LedgerEntry[]>({
+    queryKey: ["ledger", propertyId],
+    queryFn: () => listLedger(propertyId),
+  });
+
+  return (
+    <table className="min-w-full border">
+      <thead className="bg-gray-100">
+        <tr>
+          <th className="p-2 text-left">Date</th>
+          <th className="p-2 text-left">Description</th>
+          <th className="p-2 text-left">Amount</th>
+          <th className="p-2 text-left">Balance</th>
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((e) => (
+          <tr key={e.id} className="border-t">
+            <td className="p-2">{e.date}</td>
+            <td className="p-2">{e.description}</td>
+            <td className="p-2">{e.amount}</td>
+            <td className="p-2">{e.balance}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -12,6 +12,7 @@ export default function Sidebar() {
   const propertyId = match ? match[1] : "1";
   const links = [
     { href: "/", label: "Dashboard" },
+    { href: "/properties", label: "Properties" },
     { href: "/inspections", label: "Inspections" },
     { href: "/applications", label: "Applications" },
     { href: "/listings", label: "Listings" },

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -2,6 +2,11 @@ import type { ApplicationRow } from '../components/ApplicationsTable';
 import type { ExpenseRow } from '../components/ExpensesTable';
 import type { Listing } from '../types/listing';
 import type { IncomeRow } from '../types/income';
+import type {
+  PropertySummary,
+  LedgerEntry,
+  PropertyDocument,
+} from "../types/property";
 
 export interface Inspection {
   id: string;
@@ -245,3 +250,11 @@ export const updateNotificationSettings = (payload: NotificationSettings) =>
     method: 'PATCH',
     body: JSON.stringify(payload),
   });
+
+// Properties
+export const listProperties = () => api<PropertySummary[]>('/properties');
+export const getProperty = (id: string) => api<PropertySummary>(`/properties/${id}`);
+export const listLedger = (propertyId: string) =>
+  api<LedgerEntry[]>(`/properties/${propertyId}/ledger`);
+export const listPropertyDocuments = (propertyId: string) =>
+  api<PropertyDocument[]>(`/properties/${propertyId}/documents`);

--- a/tests/properties.spec.ts
+++ b/tests/properties.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+test('Properties page has heading', async ({ page }) => {
+  await page.goto('/properties');
+  await expect(page.getByRole('heading', { name: 'Properties' })).toBeVisible();
+});
+
+test('Property detail page shows tabs', async ({ page }) => {
+  await page.goto('/properties/1');
+  await expect(page.getByRole('heading', { name: 'Property Details' })).toBeVisible();
+});
+

--- a/types/property.ts
+++ b/types/property.ts
@@ -1,0 +1,30 @@
+export interface PropertyEvent {
+  date: string;
+  title: string;
+}
+
+export interface PropertySummary {
+  id: string;
+  address: string;
+  rent: number;
+  tenant: string;
+  leaseStart: string;
+  leaseEnd: string;
+  events: PropertyEvent[];
+}
+
+export interface LedgerEntry {
+  id: string;
+  date: string;
+  description: string;
+  amount: number;
+  balance: number;
+}
+
+export interface PropertyDocument {
+  id: string;
+  name: string;
+  url: string;
+  uploaded: string;
+}
+


### PR DESCRIPTION
## Summary
- Add property listing and detail pages
- Introduce overview card and detail tabs with ledger, expenses, documents, and key dates
- Link properties in navigation and add basic tests

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tanstack%2freact-query)*
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bade80884c832ca86b37d4b464b351