### PR TITLE
feat: add dashboard overview

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+import { useEffect, useState } from "react";
+import CashflowTile from "../../../components/CashflowTile";
+import DashboardPropertyCard from "../../../components/DashboardPropertyCard";
+import QuickActionsBar from "../../../components/QuickActionsBar";
+import Skeleton from "../../../components/Skeleton";
+import { useToast } from "../../../components/ui/use-toast";
+import { z } from "zod";
+import type { PropertySummary } from "../../../types/summary";
+
+const schema = z.array(
+  z.object({
+    id: z.string(),
+    address: z.string(),
+    tenantName: z.string(),
+    rentStatus: z.string(),
+    nextKeyDate: z.string(),
+  })
+);
+
+export default function DashboardPage() {
+  const [properties, setProperties] = useState<PropertySummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    fetch("/api/summary/properties")
+      .then((res) => res.json())
+      .then((json) => schema.parse(json))
+      .then(setProperties)
+      .catch(() => toast({ title: "Failed to load properties" }))
+      .finally(() => setLoading(false));
+  }, [toast]);
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="grid gap-4 md:grid-cols-3">
+        <CashflowTile />
+        {loading ? (
+          <>
+            <Skeleton className="h-24" />
+            <Skeleton className="h-24" />
+          </>
+        ) : (
+          properties.slice(0, 2).map((p) => (
+            <DashboardPropertyCard key={p.id} property={p} />
+          ))
+        )}
+      </div>
+      <QuickActionsBar />
+    </div>
+  );
+}

--- a/app/api/summary/cashflow/route.ts
+++ b/app/api/summary/cashflow/route.ts
@@ -1,0 +1,3 @@
+export async function GET() {
+  return Response.json({ monthIncome: 5000, monthExpenses: 2500, net: 2500 });
+}

--- a/app/api/summary/properties/route.ts
+++ b/app/api/summary/properties/route.ts
@@ -1,0 +1,25 @@
+export async function GET() {
+  return Response.json([
+    {
+      id: '1',
+      address: '123 Main St',
+      tenantName: 'Alice',
+      rentStatus: 'Paid',
+      nextKeyDate: '2024-07-01',
+    },
+    {
+      id: '2',
+      address: '456 Oak Ave',
+      tenantName: 'Bob',
+      rentStatus: 'Due',
+      nextKeyDate: '2024-06-15',
+    },
+    {
+      id: '3',
+      address: '789 Pine Rd',
+      tenantName: 'Carol',
+      rentStatus: 'Paid',
+      nextKeyDate: '2024-08-20',
+    },
+  ]);
+}

--- a/components/DashboardPropertyCard.tsx
+++ b/components/DashboardPropertyCard.tsx
@@ -1,18 +1,16 @@
-export interface DashboardProperty {
-  id: string;
-  address: string;
-  tenant: string;
-  rentStatus: string;
-  leaseExpiry: string;
-}
+import Link from "next/link";
+import type { PropertySummary } from "../types/summary";
 
-export default function DashboardPropertyCard({ property }: { property: DashboardProperty }) {
+export default function DashboardPropertyCard({ property }: { property: PropertySummary }) {
   return (
-    <div className="p-4 border rounded" data-testid="property-card">
+    <Link
+      href={`/properties/${property.id}`}
+      className="block p-4 border rounded hover:bg-gray-50"
+    >
       <h3 className="font-semibold">{property.address}</h3>
-      <div className="text-sm">Tenant: {property.tenant}</div>
+      <div className="text-sm">Tenant: {property.tenantName}</div>
       <div className="text-sm">Rent: {property.rentStatus}</div>
-      <div className="text-sm">Lease Expiry: {property.leaseExpiry}</div>
-    </div>
+      <div className="text-sm">Next: {property.nextKeyDate}</div>
+    </Link>
   );
 }

--- a/components/QuickActionsBar.tsx
+++ b/components/QuickActionsBar.tsx
@@ -1,36 +1,11 @@
 "use client";
 
-interface Props {
-  onLogExpense?: () => void;
-  onUploadDocument?: () => void;
-  onMessageTenant?: () => void;
-}
-
-export default function QuickActionsBar({
-  onLogExpense,
-  onUploadDocument,
-  onMessageTenant,
-}: Props) {
+export default function QuickActionsBar() {
   return (
     <div className="flex gap-2">
-      <button
-        className="px-2 py-1 bg-blue-500 text-white"
-        onClick={onLogExpense}
-      >
-        Log Expense
-      </button>
-      <button
-        className="px-2 py-1 bg-green-500 text-white"
-        onClick={onUploadDocument}
-      >
-        Upload Document
-      </button>
-      <button
-        className="px-2 py-1 bg-purple-500 text-white"
-        onClick={onMessageTenant}
-      >
-        Message Tenant
-      </button>
+      <button className="px-2 py-1 bg-blue-500 text-white rounded">+Expense</button>
+      <button className="px-2 py-1 bg-green-500 text-white rounded">+Upload Doc</button>
+      <button className="px-2 py-1 bg-purple-500 text-white rounded">+Tenant Note</button>
     </div>
   );
 }

--- a/types/summary.ts
+++ b/types/summary.ts
@@ -1,0 +1,13 @@
+export interface CashflowSummary {
+  monthIncome: number;
+  monthExpenses: number;
+  net: number;
+}
+
+export interface PropertySummary {
+  id: string;
+  address: string;
+  tenantName: string;
+  rentStatus: string;
+  nextKeyDate: string;
+}


### PR DESCRIPTION
## Summary
- implement dashboard page with cashflow, property cards, and quick actions
- mock summary APIs for cashflow and properties
- add summary types and zod-validated fetching with skeletons and toasts

## Testing
- `npm test` *(fails: playwright: not found)*
- `npm run test:unit` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5f9d115c832c945f63154ac4e5c8