### PR TITLE
feat: add reminders timeline and API

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -4,6 +4,7 @@ import CashflowTile from "../../../components/CashflowTile";
 import DashboardPropertyCard from "../../../components/DashboardPropertyCard";
 import QuickActionsBar from "../../../components/QuickActionsBar";
 import Skeleton from "../../../components/Skeleton";
+import UpcomingReminders from "../../../components/UpcomingReminders";
 import { useToast } from "../../../components/ui/use-toast";
 import { z } from "zod";
 import type { PropertySummary } from "../../../types/summary";
@@ -47,6 +48,7 @@ export default function DashboardPage() {
           ))
         )}
       </div>
+      <UpcomingReminders />
       <QuickActionsBar />
     </div>
   );

--- a/app/api/reminders/route.ts
+++ b/app/api/reminders/route.ts
@@ -1,6 +1,5 @@
-import { prisma } from '../../../lib/prisma';
+import { reminders } from '../store';
 
 export async function GET() {
-  const rows = await prisma.mockData.findMany({ where: { type: 'reminder' } });
-  return Response.json(rows.map((r) => r.data));
+  return Response.json(reminders);
 }

--- a/app/api/store.ts
+++ b/app/api/store.ts
@@ -21,7 +21,21 @@ export type Document = {
   url: string;
   tag: DocumentTag;
 };
-export type Reminder = { id: string; propertyId: string; note: string; due: string };
+export type ReminderType =
+  | 'lease_expiry'
+  | 'rent_review'
+  | 'insurance_renewal'
+  | 'inspection_due'
+  | 'custom';
+export type ReminderSeverity = 'high' | 'medium' | 'low';
+export type Reminder = {
+  id: string;
+  propertyId: string;
+  type: ReminderType;
+  title: string;
+  dueDate: string;
+  severity: ReminderSeverity;
+};
 export type RentEntry = { id: string; propertyId: string; tenantId: string; amount: number; dueDate: string; status: 'paid' | 'late'; paidDate?: string };
 export type Notification = { id: string; [key: string]: any };
 
@@ -110,8 +124,38 @@ const initialDocuments: Document[] = [
 ];
 
 const initialReminders: Reminder[] = [
-  { id: 'rem1', propertyId: '1', note: 'Renew insurance', due: '2024-07-01' },
-  { id: 'rem2', propertyId: '2', note: 'Schedule inspection', due: '2024-06-15' },
+  {
+    id: 'rem1',
+    propertyId: '1',
+    type: 'lease_expiry',
+    title: 'Lease expires',
+    dueDate: '2025-08-01',
+    severity: 'high',
+  },
+  {
+    id: 'rem2',
+    propertyId: '2',
+    type: 'rent_review',
+    title: 'Rent review',
+    dueDate: '2025-09-20',
+    severity: 'medium',
+  },
+  {
+    id: 'rem3',
+    propertyId: '3',
+    type: 'insurance_renewal',
+    title: 'Insurance renewal',
+    dueDate: '2025-10-10',
+    severity: 'low',
+  },
+  {
+    id: 'rem4',
+    propertyId: '1',
+    type: 'inspection_due',
+    title: 'Inspection due',
+    dueDate: '2025-11-05',
+    severity: 'low',
+  },
 ];
 
 const initialRentLedger: RentEntry[] = [

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -53,8 +53,11 @@ export interface NotificationSettings {
 
 export interface Reminder {
   id: string;
-  propertyId?: string;
-  message: string;
+  propertyId: string;
+  type: 'lease_expiry' | 'rent_review' | 'insurance_renewal' | 'inspection_due' | 'custom';
+  title: string;
+  dueDate: string;
+  severity: 'high' | 'medium' | 'low';
 }
 
 export interface Notification {


### PR DESCRIPTION
## Summary
- implement reminders API using in-memory store
- add upcoming reminders kanban to dashboard
- define reminder model and seed sample data

## Testing
- `npm test` *(fails: playwright: not found)*
- `npm run test:unit` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd683a5d3c832cad0daf612aabceb2