### PR TITLE
feat: add AI doc scan for expense prefill

### DIFF
--- a/app/(app)/finance/scan/page.tsx
+++ b/app/(app)/finance/scan/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import AIDocScan from "../../../../components/AIDocScan";
+
+export default function ScanPage() {
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">Scan Receipt</h1>
+      <AIDocScan />
+    </div>
+  );
+}
+

--- a/app/api/ai/doc-scan/route.ts
+++ b/app/api/ai/doc-scan/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+
+function capitalize(s: string) {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+export async function POST(req: Request) {
+  const form = await req.formData();
+  const file = form.get('file');
+  const name = typeof file === 'object' && 'name' in file ? (file as File).name : '';
+  const base = name.replace(/\.[^/.]+$/, '');
+  const parts = base.split(/[-_]/).filter(Boolean);
+
+  let date = parts.find((p) => /^\d{4}-\d{2}-\d{2}$/.test(p) || /^\d{8}$/.test(p));
+  if (date && /^\d{8}$/.test(date)) {
+    date = `${date.slice(0,4)}-${date.slice(4,6)}-${date.slice(6)}`;
+  }
+  const amountStr = parts.find((p) => /^\d+(?:\.\d+)?$/.test(p));
+  const amount = amountStr ? parseFloat(amountStr) : 0;
+  const words = parts.filter((p) => isNaN(parseFloat(p)) && p !== date);
+  const vendor = words[0] ? capitalize(words[0]) : 'Vendor';
+  const category = words[1] ? capitalize(words[1]) : 'General';
+  const notes = base.replace(/[-_]/g, ' ');
+
+  return NextResponse.json({
+    date: date || '2024-01-01',
+    amount,
+    category,
+    vendor,
+    notes,
+  });
+}
+

--- a/components/AIDocScan.tsx
+++ b/components/AIDocScan.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import ExpenseForm from "./ExpenseForm";
+import { scanReceipt } from "../lib/api";
+
+interface Parsed {
+  date: string;
+  amount: number;
+  category: string;
+  vendor: string;
+  notes: string;
+}
+
+export default function AIDocScan() {
+  const [parsed, setParsed] = useState<Parsed | null>(null);
+  const [open, setOpen] = useState(false);
+
+  const handleFiles = async (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    const file = files[0];
+    const data = await scanReceipt(file);
+    setParsed(data);
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    handleFiles(e.dataTransfer.files);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div
+        onDrop={handleDrop}
+        onDragOver={(e) => e.preventDefault()}
+        className="border-2 border-dashed p-4 text-center"
+      >
+        Drag & drop receipt
+        <input
+          type="file"
+          className="block mx-auto mt-2"
+          onChange={(e) => handleFiles(e.target.files)}
+        />
+      </div>
+      {parsed && (
+        <div className="border p-4 space-y-1">
+          <div>Date: {parsed.date}</div>
+          <div>Amount: {parsed.amount}</div>
+          <div>Category: {parsed.category}</div>
+          <div>Vendor: {parsed.vendor}</div>
+          <div>Notes: {parsed.notes}</div>
+          <button
+            className="mt-2 px-2 py-1 bg-green-500 text-white"
+            onClick={() => setOpen(true)}
+          >
+            Apply to Expense
+          </button>
+        </div>
+      )}
+      <ExpenseForm
+        open={open}
+        onOpenChange={setOpen}
+        showTrigger={false}
+        defaults={parsed || undefined}
+        onCreated={() => {
+          setOpen(false);
+          setParsed(null);
+        }}
+      />
+    </div>
+  );
+}
+

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -290,6 +290,15 @@ export const uploadFile = (file: File) => {
   form.append('file', file);
   return api<{ url: string }>('/upload', { method: 'POST', body: form, headers: {} });
 };
+export const scanReceipt = (file: File) => {
+  const form = new FormData();
+  form.append("file", file);
+  return api<{ date: string; amount: number; category: string; vendor: string; notes: string }>("/ai/doc-scan", {
+    method: "POST",
+    body: form,
+    headers: {},
+  });
+};
 export const addVendorDocument = (id: string, url: string) =>
   api(`/vendors/${id}/documents`, { method: 'POST', body: JSON.stringify({ url }) });
 export const removeVendorDocument = (id: string, url: string) =>


### PR DESCRIPTION
## Summary
- add mock `/api/ai/doc-scan` endpoint parsing receipt filenames
- upload receipts with new `AIDocScan` component and prefill expense form
- extend `ExpenseForm` with default values support

## Testing
- `npm run test:unit` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden when fetching @tanstack/react-query)*
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd696d9e1c832cae32154f13c6426d