### PR TITLE
Add finance P&L page with exports and API

### DIFF
--- a/app/(app)/finance/pnl/page.tsx
+++ b/app/(app)/finance/pnl/page.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import PnLChart from "../../../../components/PnLChart";
+import { useToast } from "../../../../components/ui/use-toast";
+import { exportPDF } from "../../../../lib/export";
+import { getPnL, type PnL } from "../../../../lib/api";
+
+const propertyId = "1";
+
+function formatDate(d: Date) {
+  return d.toISOString().slice(0, 10);
+}
+
+function periodRange(period: string) {
+  const now = new Date();
+  switch (period) {
+    case "quarter": {
+      const q = Math.floor(now.getMonth() / 3);
+      const start = new Date(now.getFullYear(), q * 3, 1);
+      const end = new Date(now.getFullYear(), q * 3 + 3, 0);
+      return { from: formatDate(start), to: formatDate(end) };
+    }
+    case "fy": {
+      const start = new Date(now.getFullYear(), 0, 1);
+      const end = new Date(now.getFullYear(), 11, 31);
+      return { from: formatDate(start), to: formatDate(end) };
+    }
+    default: {
+      const start = new Date(now.getFullYear(), now.getMonth(), 1);
+      const end = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+      return { from: formatDate(start), to: formatDate(end) };
+    }
+  }
+}
+
+export default function PnLPage() {
+  const [period, setPeriod] = useState("month");
+  const initial = periodRange("month");
+  const [from, setFrom] = useState(initial.from);
+  const [to, setTo] = useState(initial.to);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    if (period === "custom") return;
+    const range = periodRange(period);
+    setFrom(range.from);
+    setTo(range.to);
+  }, [period]);
+
+  const { data } = useQuery<PnL>({
+    queryKey: ["pnl", propertyId, from, to],
+    queryFn: () => getPnL({ propertyId, from, to }),
+  });
+
+  const params = () =>
+    new URLSearchParams({ propertyId, from, to }).toString();
+
+  const handleExportCSV = async () => {
+    const res = await fetch(`/api/pnl/export.csv?${params()}`);
+    const text = await res.text();
+    const blob = new Blob([text], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "pnl.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+    toast({ title: "P&L CSV downloaded" });
+  };
+
+  const handleExportPDF = async () => {
+    const res = await fetch(`/api/pnl/export.pdf?${params()}`);
+    const html = await res.text();
+    exportPDF("pnl.pdf", html);
+    toast({ title: "P&L PDF downloaded" });
+  };
+
+  const handleExportExpensesCSV = async () => {
+    const res = await fetch(`/api/expenses/export.csv?${params()}`);
+    const text = await res.text();
+    const blob = new Blob([text], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "expenses.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+    toast({ title: "Expenses CSV downloaded" });
+  };
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">Profit &amp; Loss</h1>
+      <div className="flex gap-2 items-center">
+        <select
+          className="border p-1"
+          value={period}
+          onChange={(e) => setPeriod(e.target.value)}
+        >
+          <option value="month">Month</option>
+          <option value="quarter">Quarter</option>
+          <option value="fy">FY</option>
+          <option value="custom">Custom</option>
+        </select>
+        <input
+          type="date"
+          className="border p-1"
+          value={from}
+          onChange={(e) => setFrom(e.target.value)}
+        />
+        <input
+          type="date"
+          className="border p-1"
+          value={to}
+          onChange={(e) => setTo(e.target.value)}
+        />
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="p-4 bg-white shadow">
+          <div className="text-sm text-gray-500">Income</div>
+          <div className="text-xl font-semibold">{data?.income ?? 0}</div>
+        </div>
+        <div className="p-4 bg-white shadow">
+          <div className="text-sm text-gray-500">Expenses</div>
+          <div className="text-xl font-semibold">{data?.expenses ?? 0}</div>
+        </div>
+        <div className="p-4 bg-white shadow">
+          <div className="text-sm text-gray-500">Net</div>
+          <div className="text-xl font-semibold">{data?.net ?? 0}</div>
+        </div>
+      </div>
+      <PnLChart data={data?.series ?? []} />
+      <div className="flex gap-2">
+        <button className="px-2 py-1 bg-gray-200" onClick={handleExportCSV}>
+          Export P&amp;L CSV
+        </button>
+        <button className="px-2 py-1 bg-gray-200" onClick={handleExportPDF}>
+          Export P&amp;L PDF
+        </button>
+        <button
+          className="px-2 py-1 bg-gray-200"
+          onClick={handleExportExpensesCSV}
+        >
+          Export Expenses CSV
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/api/expenses/export.csv/route.ts
+++ b/app/api/expenses/export.csv/route.ts
@@ -1,0 +1,33 @@
+import { expenses } from '../../store';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  let results = expenses;
+  const propertyId = searchParams.get('propertyId');
+  const from = searchParams.get('from');
+  const to = searchParams.get('to');
+
+  if (propertyId) {
+    results = results.filter((e) => e.propertyId === propertyId);
+  }
+  if (from) {
+    results = results.filter((e) => new Date(e.date) >= new Date(from));
+  }
+  if (to) {
+    results = results.filter((e) => new Date(e.date) <= new Date(to));
+  }
+
+  const rows = [
+    ['Date', 'Category', 'Vendor', 'Amount', 'GST', 'Notes'],
+    ...results.map((e) => [
+      e.date,
+      e.category,
+      e.vendor,
+      e.amount.toString(),
+      e.gst.toString(),
+      e.notes ?? '',
+    ]),
+  ];
+  const csv = rows.map((r) => r.join(',')).join('\n');
+  return new Response(csv, { headers: { 'Content-Type': 'text/csv' } });
+}

--- a/app/api/pnl/export.csv/route.ts
+++ b/app/api/pnl/export.csv/route.ts
@@ -1,0 +1,22 @@
+import { calculatePnL } from '../helpers';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const propertyId = searchParams.get('propertyId') || undefined;
+  const from = searchParams.get('from') || undefined;
+  const to = searchParams.get('to') || undefined;
+  const data = calculatePnL({ propertyId, from, to });
+  const rows = [
+    ['Month', 'Income', 'Expenses', 'Net'],
+    ...data.series.map((s) => [
+      s.month,
+      s.income.toString(),
+      s.expenses.toString(),
+      s.net.toString(),
+    ]),
+  ];
+  const csv = rows.map((r) => r.join(',')).join('\n');
+  return new Response(csv, {
+    headers: { 'Content-Type': 'text/csv' },
+  });
+}

--- a/app/api/pnl/export.pdf/route.ts
+++ b/app/api/pnl/export.pdf/route.ts
@@ -1,0 +1,17 @@
+import { calculatePnL } from '../helpers';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const propertyId = searchParams.get('propertyId') || undefined;
+  const from = searchParams.get('from') || undefined;
+  const to = searchParams.get('to') || undefined;
+  const data = calculatePnL({ propertyId, from, to });
+  const rows = data.series
+    .map(
+      (s) =>
+        `<tr><td>${s.month}</td><td>${s.income}</td><td>${s.expenses}</td><td>${s.net}</td></tr>`,
+    )
+    .join('');
+  const html = `<table border='1'><tr><th>Month</th><th>Income</th><th>Expenses</th><th>Net</th></tr>${rows}</table>`;
+  return new Response(html, { headers: { 'Content-Type': 'text/html' } });
+}

--- a/app/api/pnl/helpers.ts
+++ b/app/api/pnl/helpers.ts
@@ -1,0 +1,57 @@
+import { expenses, rentLedger } from '../store';
+
+interface Params {
+  from?: string;
+  to?: string;
+  propertyId?: string;
+}
+
+export function calculatePnL({ from, to, propertyId }: Params) {
+  const fromDate = from ? new Date(from) : new Date('1970-01-01');
+  const toDate = to ? new Date(to) : new Date('2100-01-01');
+
+  const incomeEntries = rentLedger.filter(
+    (e) =>
+      (!propertyId || e.propertyId === propertyId) &&
+      e.status === 'paid' &&
+      new Date(e.dueDate) >= fromDate &&
+      new Date(e.dueDate) <= toDate,
+  );
+
+  const expenseEntries = expenses.filter(
+    (e) =>
+      (!propertyId || e.propertyId === propertyId) &&
+      new Date(e.date) >= fromDate &&
+      new Date(e.date) <= toDate,
+  );
+
+  const income = incomeEntries.reduce((sum, e) => sum + e.amount, 0);
+  const expensesTotal = expenseEntries.reduce((sum, e) => sum + e.amount, 0);
+
+  const seriesMap = new Map<string, { income: number; expenses: number }>();
+
+  for (const entry of incomeEntries) {
+    const month = entry.dueDate.slice(0, 7);
+    const item = seriesMap.get(month) || { income: 0, expenses: 0 };
+    item.income += entry.amount;
+    seriesMap.set(month, item);
+  }
+
+  for (const entry of expenseEntries) {
+    const month = entry.date.slice(0, 7);
+    const item = seriesMap.get(month) || { income: 0, expenses: 0 };
+    item.expenses += entry.amount;
+    seriesMap.set(month, item);
+  }
+
+  const series = Array.from(seriesMap.entries())
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([month, v]) => ({
+      month,
+      income: v.income,
+      expenses: v.expenses,
+      net: v.income - v.expenses,
+    }));
+
+  return { income, expenses: expensesTotal, net: income - expensesTotal, series };
+}

--- a/app/api/pnl/route.ts
+++ b/app/api/pnl/route.ts
@@ -1,0 +1,10 @@
+import { calculatePnL } from './helpers';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const propertyId = searchParams.get('propertyId') || undefined;
+  const from = searchParams.get('from') || undefined;
+  const to = searchParams.get('to') || undefined;
+  const data = calculatePnL({ propertyId, from, to });
+  return Response.json(data);
+}

--- a/components/PnLChart.tsx
+++ b/components/PnLChart.tsx
@@ -11,6 +11,8 @@ import {
 
 interface MonthlyNet {
   month: string;
+  income?: number;
+  expenses?: number;
   net: number;
 }
 
@@ -28,6 +30,24 @@ export default function PnLChart({ data }: { data: MonthlyNet[] }) {
               color: "var(--tooltip-text, #000000)",
             }}
           />
+          {data.some((d) => d.income !== undefined) && (
+            <Line
+              type="monotone"
+              dataKey="income"
+              stroke="var(--color-income, rgb(34,197,94))"
+              strokeWidth={2}
+              dot={false}
+            />
+          )}
+          {data.some((d) => d.expenses !== undefined) && (
+            <Line
+              type="monotone"
+              dataKey="expenses"
+              stroke="var(--color-expenses, rgb(239,68,68))"
+              strokeWidth={2}
+              dot={false}
+            />
+          )}
           <Line
             type="monotone"
             dataKey="net"

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -238,6 +238,22 @@ export const uploadExpenseReceipt = (id: string, file: File) => {
 export const getPnLSummary = (propertyId: string) =>
   api<PnLSummary>(`/properties/${propertyId}/pnl`);
 
+export interface PnL {
+  income: number;
+  expenses: number;
+  net: number;
+  series: { month: string; income: number; expenses: number; net: number }[];
+}
+
+export const getPnL = (params: {
+  propertyId: string;
+  from: string;
+  to: string;
+}) => {
+  const query = new URLSearchParams(params).toString();
+  return api<PnL>(`/pnl?${query}`);
+};
+
 export const listIncome = (propertyId: string) =>
   api<IncomeRow[]>(`/properties/${propertyId}/income`);
 export const createIncome = (propertyId: string, payload: any) =>


### PR DESCRIPTION
## Summary
- add Profit & Loss page with period controls, KPI tiles and export actions
- support charting income, expenses and net across months
- provide API endpoints for PnL data and CSV/PDF exports

## Testing
- `npm run test:unit` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - @tanstack/react-query)*
- `npm test` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6d4a1f14832cbfbf75ad913a10d5