### PR TITLE
Expose secondary property workflows via contextual menu

### DIFF
--- a/app/(app)/properties/[id]/applications/page.tsx
+++ b/app/(app)/properties/[id]/applications/page.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import ApplicationsTable from "../../../../../components/ApplicationsTable";
+import { listApplications, createApplication, getProperty } from "../../../../../lib/api";
+import type { ApplicationRow } from "../../../../../types/application";
+
+export default function PropertyApplicationsPage() {
+  const { id } = useParams<{ id: string }>();
+  const queryClient = useQueryClient();
+
+  const { data: property } = useQuery({
+    queryKey: ["property", id],
+    queryFn: () => getProperty(id),
+  });
+
+  const { data: apps = [] } = useQuery<ApplicationRow[]>({
+    queryKey: ["applications", id],
+    queryFn: () => listApplications(id),
+  });
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      createApplication({
+        propertyId: id,
+        property: property?.address || "",
+        applicant: "New Applicant",
+        status: "New",
+      }),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["applications", id] }),
+  });
+
+  if (!property) return <div className="p-6">Loading...</div>;
+  if (property.tenant) return <div className="p-6">Property is occupied.</div>;
+
+  return (
+    <div className="p-6 space-y-4">
+      <div className="flex justify-between items-center">
+        <h1 className="text-xl font-semibold">Applications</h1>
+        <button
+          className="px-3 py-1 rounded bg-blue-600 text-white"
+          onClick={() => mutation.mutate()}
+        >
+          Add Application
+        </button>
+      </div>
+      <ApplicationsTable rows={apps} />
+    </div>
+  );
+}

--- a/app/(app)/properties/[id]/inspections/page.tsx
+++ b/app/(app)/properties/[id]/inspections/page.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { getInspections, createInspection, type Inspection } from "../../../../../lib/api";
+
+export default function PropertyInspectionsPage() {
+  const { id } = useParams<{ id: string }>();
+  const queryClient = useQueryClient();
+  const { data = [] } = useQuery<Inspection[]>({
+    queryKey: ["inspections", id],
+    queryFn: () => getInspections({ propertyId: id }),
+  });
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      createInspection({
+        propertyId: id,
+        type: "Routine",
+        status: "Scheduled",
+        date: new Date().toISOString(),
+      }),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["inspections", id] }),
+  });
+
+  return (
+    <div className="p-6 space-y-4">
+      <div className="flex justify-between items-center">
+        <h1 className="text-xl font-semibold">Inspections</h1>
+        <button
+          className="px-3 py-1 rounded bg-blue-600 text-white"
+          onClick={() => mutation.mutate()}
+        >
+          Start Inspection
+        </button>
+      </div>
+      <ul className="space-y-2">
+        {data.map((insp) => (
+          <li key={insp.id} className="p-4 bg-white border rounded">
+            <div className="flex justify-between">
+              <span>{insp.type}</span>
+              <span className="text-sm text-gray-500">{insp.status}</span>
+            </div>
+          </li>
+        ))}
+        {data.length === 0 && <li>No inspections</li>}
+      </ul>
+    </div>
+  );
+}

--- a/app/(app)/properties/[id]/listing/page.tsx
+++ b/app/(app)/properties/[id]/listing/page.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import ListingWizard from "../../../../../components/ListingWizard";
+import { getProperty } from "../../../../../lib/api";
+
+export default function PropertyListingPage() {
+  const { id } = useParams<{ id: string }>();
+  const { data: property } = useQuery({
+    queryKey: ["property", id],
+    queryFn: () => getProperty(id),
+  });
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-xl font-semibold">
+        Create Listing{property ? ` for ${property.address}` : ""}
+      </h1>
+      <ListingWizard />
+    </div>
+  );
+}

--- a/app/(app)/properties/[id]/page.tsx
+++ b/app/(app)/properties/[id]/page.tsx
@@ -11,11 +11,13 @@ import PropertyOverviewCard from "../../../../components/PropertyOverviewCard";
 import PropertyDetailTabs from "../../../../components/PropertyDetailTabs";
 import { getProperty } from "../../../../lib/api";
 import type { PropertySummary } from "../../../../types/property";
+import Link from "next/link";
 
 export default function PropertyPage() {
   const [expenseOpen, setExpenseOpen] = useState(false);
   const [docOpen, setDocOpen] = useState(false);
   const [messageOpen, setMessageOpen] = useState(false);
+  const [moreOpen, setMoreOpen] = useState(false);
   const { id } = useParams<{ id: string }>();
 
   const { data: property } = useQuery<PropertySummary>({
@@ -32,6 +34,44 @@ export default function PropertyPage() {
         onUploadDocument={() => setDocOpen(true)}
         onMessageTenant={() => setMessageOpen(true)}
       />
+      <div className="relative inline-block">
+        <button
+          className="px-2 py-1 border rounded"
+          onClick={() => setMoreOpen((o) => !o)}
+        >
+          More...
+        </button>
+        {moreOpen && (
+          <div className="absolute z-10 mt-2 bg-white border rounded shadow">
+            <Link
+              href={`/properties/${id}/inspections`}
+              className="block px-4 py-2 hover:bg-gray-100"
+            >
+              Inspections
+            </Link>
+            {property.tenant === "" && (
+              <Link
+                href={`/properties/${id}/applications`}
+                className="block px-4 py-2 hover:bg-gray-100"
+              >
+                Applications
+              </Link>
+            )}
+            <Link
+              href={`/properties/${id}/listing`}
+              className="block px-4 py-2 hover:bg-gray-100"
+            >
+              Create Listing
+            </Link>
+            <Link
+              href="/vendors"
+              className="block px-4 py-2 hover:bg-gray-100"
+            >
+              Vendors
+            </Link>
+          </div>
+        )}
+      </div>
       <ExpenseForm
         propertyId={id}
         open={expenseOpen}

--- a/app/api/applications/route.ts
+++ b/app/api/applications/route.ts
@@ -1,9 +1,13 @@
 import { randomUUID } from 'crypto';
 import { prisma } from '../../../lib/prisma';
 
-export async function GET() {
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const propertyId = searchParams.get('propertyId');
   const rows = await prisma.mockData.findMany({ where: { type: 'application' } });
-  return Response.json(rows.map((r) => r.data));
+  let data = rows.map((r) => r.data as any);
+  if (propertyId) data = data.filter((a) => a.propertyId === propertyId);
+  return Response.json(data);
 }
 
 export async function POST(req: Request) {

--- a/app/api/inspections/route.ts
+++ b/app/api/inspections/route.ts
@@ -1,9 +1,17 @@
 import { randomUUID } from 'crypto';
 import { prisma } from '../../../lib/prisma';
 
-export async function GET() {
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const propertyId = searchParams.get('propertyId');
+  const type = searchParams.get('type');
+  const status = searchParams.get('status');
   const rows = await prisma.mockData.findMany({ where: { type: 'inspection' } });
-  return Response.json(rows.map((r) => r.data));
+  let data = rows.map((r) => r.data as any);
+  if (propertyId) data = data.filter((i) => i.propertyId === propertyId);
+  if (type) data = data.filter((i) => i.type === type);
+  if (status) data = data.filter((i) => i.status === status);
+  return Response.json(data);
 }
 
 export async function POST(req: Request) {

--- a/app/api/store.ts
+++ b/app/api/store.ts
@@ -85,6 +85,14 @@ const initialProperties: Property[] = [
     leaseEnd: '2024-03-14',
     rent: 1100,
   },
+  {
+    id: '4',
+    address: '101 Vacant St',
+    tenant: '',
+    leaseStart: '',
+    leaseEnd: '',
+    rent: 0,
+  },
 ];
 
 const initialTenants: Tenant[] = [

--- a/components/ApplicationsTable.tsx
+++ b/components/ApplicationsTable.tsx
@@ -2,13 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import EmptyState from "./EmptyState";
-
-export interface ApplicationRow {
-  id: string;
-  applicant: string;
-  property: string;
-  status: string;
-}
+import type { ApplicationRow } from "../types/application";
 
 export default function ApplicationsTable({ rows }: { rows: ApplicationRow[] }) {
   const router = useRouter();

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -11,11 +11,7 @@ export default function Sidebar() {
   const links = [
     { href: "/", label: "Dashboard" },
     { href: "/properties", label: "Properties" },
-    { href: "/inspections", label: "Inspections" },
-    { href: "/applications", label: "Applications" },
-    { href: "/listings", label: "Listings" },
     { href: "/rent-review", label: "Rent Review" },
-    { href: "/vendors", label: "Vendors" },
     { href: "/settings", label: "Settings" }
   ];
 

--- a/components/UpcomingReminders.tsx
+++ b/components/UpcomingReminders.tsx
@@ -29,7 +29,11 @@ function ReminderColumn({
           {items.map((r) => (
             <li key={r.id}>
               <Link
-                href={`/properties/${r.propertyId}#key-dates`}
+                href={
+                  r.type === "inspection_due"
+                    ? `/properties/${r.propertyId}/inspections`
+                    : `/properties/${r.propertyId}#key-dates`
+                }
                 className={`block p-2 border-l-4 rounded hover:bg-gray-50 ${
                   r.severity === "high"
                     ? "border-red-500"

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,4 +1,4 @@
-import type { ApplicationRow } from '../components/ApplicationsTable';
+import type { ApplicationRow, Application } from '../types/application';
 import type { ExpenseRow } from '../types/expense';
 import type { Listing } from '../types/listing';
 import type { IncomeRow } from '../types/income';
@@ -27,13 +27,7 @@ export interface Vendor {
   documents?: string[];
 }
 
-export interface Application {
-  id: string;
-  applicant: string;
-  property: string;
-  status: string;
-  // include any other fields returned by `/applications/{id}`
-}
+// Application types moved to types/application.ts
 
 export interface PnLPoint {
   month: string;
@@ -156,8 +150,12 @@ export const shareInspectionReport = (id: string) =>
   api(`/inspections/${id}/share`, { method: 'POST' });
 
 // Applications
-export const listApplications = () =>
-  api<ApplicationRow[]>('/applications');
+export const listApplications = (propertyId?: string) =>
+  api<ApplicationRow[]>(
+    `/applications${propertyId ? `?propertyId=${propertyId}` : ''}`
+  );
+export const createApplication = (payload: any) =>
+  api('/applications', { method: 'POST', body: JSON.stringify(payload) });
 export const getApplication = (id: string) => api<Application>(`/applications/${id}`);
 export const updateApplication = (id: string, payload: any) => api(`/applications/${id}`, { method: 'PATCH', body: JSON.stringify(payload) });
 export const postScore = (id: string, payload: any) =>

--- a/types/application.ts
+++ b/types/application.ts
@@ -1,6 +1,9 @@
 export interface ApplicationRow {
   id: string;
+  propertyId: string;
   applicant: string;
   property: string;
   status: string;
 }
+
+export interface Application extends ApplicationRow {}


### PR DESCRIPTION
## Summary
- Seed a vacant property and remove sidebar links to secondary features
- Add property-level Inspections, Applications, and Listing pages with a contextual "More" menu
- Support property filtering for inspections and applications APIs and clients

## Testing
- `npm test` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6fd93378832c907de618dda8d18e