### PR TITLE
feat: add notification preferences and alerts

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -5,6 +5,7 @@ import DashboardPropertyCard from "../../../components/DashboardPropertyCard";
 import QuickActionsBar from "../../../components/QuickActionsBar";
 import Skeleton from "../../../components/Skeleton";
 import UpcomingReminders from "../../../components/UpcomingReminders";
+import AlertsPanel from "../../../components/AlertsPanel";
 import { useToast } from "../../../components/ui/use-toast";
 import { z } from "zod";
 import type { PropertySummary } from "../../../types/summary";
@@ -48,6 +49,7 @@ export default function DashboardPage() {
           ))
         )}
       </div>
+      <AlertsPanel />
       <UpcomingReminders />
       <QuickActionsBar />
     </div>

--- a/app/(app)/settings/notifications/page.tsx
+++ b/app/(app)/settings/notifications/page.tsx
@@ -1,4 +1,4 @@
-import NotificationPrefsForm from '../../../components/NotificationPrefsForm';
+import NotificationPrefsForm from '../../../../components/NotificationPrefsForm';
 
 export default function NotificationSettingsPage() {
   return (

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import PageHeader from "../../components/PageHeader";
+import PageHeader from "../../../components/PageHeader";
 
 export default function SettingsPage() {
   return (

--- a/app/api/me/notification-settings/route.ts
+++ b/app/api/me/notification-settings/route.ts
@@ -1,16 +1,24 @@
 import { prisma } from '../../../../lib/prisma';
 
+const defaults = {
+  arrears: { email: false, sms: false, inApp: false },
+  maintenance: { email: false, sms: false, inApp: false },
+  compliance: { email: false, sms: false, inApp: false },
+  quietHoursStart: '',
+  quietHoursEnd: '',
+};
+
 export async function GET() {
   const row = await prisma.mockData.findUnique({
     where: { id: 'notificationSettings' },
   });
-  return Response.json(row?.data ?? {});
+  return Response.json(row?.data ?? defaults);
 }
 
 export async function PATCH(req: Request) {
   const body = await req.json();
   const row = await prisma.mockData.findUnique({ where: { id: 'notificationSettings' } });
-  const data = { ...(row?.data as any), ...body };
+  const data = { ...defaults, ...(row?.data as any), ...body };
   await prisma.mockData.upsert({
     where: { id: 'notificationSettings' },
     create: { id: 'notificationSettings', type: 'notification', data },

--- a/app/api/store.ts
+++ b/app/api/store.ts
@@ -223,7 +223,14 @@ const initialTenantNotes: TenantNote[] = [
 ];
 
 const initialNotifications: Notification[] = [
-  { id: 'notificationSettings', email: true, sms: false, push: true },
+  {
+    id: 'notificationSettings',
+    arrears: { email: false, sms: false, inApp: false },
+    maintenance: { email: false, sms: false, inApp: false },
+    compliance: { email: false, sms: false, inApp: false },
+    quietHoursStart: '',
+    quietHoursEnd: '',
+  },
   { id: 'note1', message: 'Welcome to PropTech' },
   { id: 'note2', message: 'Rent due reminder' },
 ];

--- a/components/AlertsPanel.tsx
+++ b/components/AlertsPanel.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { listNotifications, Notification } from "../lib/api";
+import Skeleton from "./Skeleton";
+
+export default function AlertsPanel() {
+  const { data, isLoading } = useQuery<Notification[]>({
+    queryKey: ["notifications"],
+    queryFn: listNotifications,
+  });
+
+  const alerts = data ?? [];
+
+  return (
+    <div className="space-y-2" data-testid="alerts">
+      <h2 className="text-xl font-semibold">Alerts</h2>
+      {isLoading ? (
+        <Skeleton className="h-24" />
+      ) : alerts.length === 0 ? (
+        <div className="p-4 text-center text-gray-500">No alerts</div>
+      ) : (
+        <ul className="space-y-2">
+          {alerts.map((n) => (
+            <li key={n.id} className="p-2 border rounded">
+              {n.message}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -36,13 +36,11 @@ export interface PnLPoint {
 }
 
 export interface NotificationSettings {
-  email: boolean;
-  sms: boolean;
-  inApp: boolean;
+  arrears: { email: boolean; sms: boolean; inApp: boolean };
+  maintenance: { email: boolean; sms: boolean; inApp: boolean };
+  compliance: { email: boolean; sms: boolean; inApp: boolean };
   quietHoursStart?: string;
   quietHoursEnd?: string;
-  critical: boolean;
-  normal: boolean;
 }
 
 export interface Reminder {


### PR DESCRIPTION
## Summary
- move settings under app route group and wire new notification preferences form
- allow matrix-based notification settings with quiet hours and preview suppression
- add alerts panel on dashboard sourcing in-app notifications

## Testing
- `npm run test:unit` *(fails: vitest not found)*
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd73db9828832c996a2aee481cbc84