### PR TITLE
feat: add prisma persistence toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ make seed
 make reset
 ```
 
+### Persistence mode
+
+To use Prisma with PostgreSQL instead of the in-memory mock store, set `MOCK_MODE=false` and ensure `DATABASE_URL` points to a running database. Apply migrations and seed demo data with:
+
+```bash
+npm run db:migrate
+npm run db:seed
+```
+
+Setting `MOCK_MODE=true` switches back to the in-memory store.
+
 ### Seeding demo data
 
 Populate the database with demo data:

--- a/app/api/expenses/route.ts
+++ b/app/api/expenses/route.ts
@@ -1,32 +1,47 @@
 import { NextResponse } from 'next/server';
 import { expenses } from '../store';
 import { expenseSchema } from '../../../lib/validation';
+import { prisma } from '../../../lib/prisma';
+import { randomUUID } from 'crypto';
 
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
-  let results = expenses;
   const propertyId = searchParams.get('propertyId');
   const from = searchParams.get('from');
   const to = searchParams.get('to');
   const category = searchParams.get('category');
   const vendor = searchParams.get('vendor');
 
+  let results;
+  if (process.env.MOCK_MODE === 'true') {
+    results = expenses;
+  } else {
+    const records = await (prisma as any).mockData.findMany({
+      where: { type: 'expense' },
+    });
+    results = records.map((r: any) => r.data);
+  }
+
   if (propertyId) {
-    results = results.filter((e) => e.propertyId === propertyId);
+    results = results.filter((e: any) => e.propertyId === propertyId);
   }
   if (from) {
-    results = results.filter((e) => new Date(e.date) >= new Date(from));
+    results = results.filter(
+      (e: any) => new Date(e.date) >= new Date(from)
+    );
   }
   if (to) {
-    results = results.filter((e) => new Date(e.date) <= new Date(to));
+    results = results.filter(
+      (e: any) => new Date(e.date) <= new Date(to)
+    );
   }
   if (category) {
-    results = results.filter((e) =>
+    results = results.filter((e: any) =>
       e.category.toLowerCase().includes(category.toLowerCase())
     );
   }
   if (vendor) {
-    results = results.filter((e) =>
+    results = results.filter((e: any) =>
       e.vendor.toLowerCase().includes(vendor.toLowerCase())
     );
   }
@@ -37,8 +52,14 @@ export async function POST(req: Request) {
   try {
     const body = await req.json();
     const parsed = expenseSchema.parse(body);
-    const newExpense = { id: `exp${expenses.length + 1}`, ...parsed };
-    expenses.push(newExpense);
+    const newExpense = { id: randomUUID(), ...parsed };
+    if (process.env.MOCK_MODE === 'true') {
+      expenses.push(newExpense);
+    } else {
+      await (prisma as any).mockData.create({
+        data: { id: newExpense.id, type: 'expense', data: newExpense },
+      });
+    }
     return NextResponse.json(newExpense, { status: 201 });
   } catch (err: any) {
     return new NextResponse(err.message, { status: 400 });

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "prisma": "prisma",
     "seed": "node --loader ts-node/esm prisma/seed.ts",
+    "db:migrate": "prisma migrate deploy",
+    "db:seed": "prisma db seed",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",


### PR DESCRIPTION
## Summary
- support Prisma/Postgres in expenses and documents routes when MOCK_MODE=false
- add migrate/seed scripts and document persistence toggle

## Testing
- `npm run db:migrate` *(fails: prisma: not found)*
- `npm run db:seed` *(fails: prisma: not found)*
- `npm run test:unit` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7892d344832c907f47b020794820