### PR TITLE
fix: prevent cashflow fetch loop

### DIFF
--- a/components/CashflowTile.tsx
+++ b/components/CashflowTile.tsx
@@ -23,7 +23,7 @@ export default function CashflowTile() {
       .then(setData)
       .catch(() => toast({ title: "Failed to load cashflow" }))
       .finally(() => setLoading(false));
-  }, [toast]);
+  }, []);
 
   if (loading) {
     return (


### PR DESCRIPTION
## Summary
- avoid infinite re-fetching of cashflow summary by running effect only once

## Testing
- `npm test` *(fails: playwright: not found)*
- `npm install` *(fails: 403 Forbidden)*
- `npm run test:unit` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd83db94cc832cbbfc414d78a9a047