### PR TITLE
Integrate reminders into dashboard and property pages

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -52,7 +52,7 @@ export default function DashboardPage() {
         )}
       </div>
       <AlertsPanel />
-      <UpcomingReminders />
+      <UpcomingReminders showViewAll />
       <QuickActionsBar />
     </div>
   );

--- a/app/(app)/properties/[id]/page.tsx
+++ b/app/(app)/properties/[id]/page.tsx
@@ -82,7 +82,7 @@ export default function PropertyPage() {
       <MessageTenantModal open={messageOpen} onClose={() => setMessageOpen(false)} />
       <h1 className="text-2xl font-semibold">Property Details</h1>
       <PropertyOverviewCard property={property} />
-      <PropertyDetailTabs propertyId={id} events={property.events} />
+      <PropertyDetailTabs propertyId={id} />
     </div>
   );
 }

--- a/app/(app)/reminders/page.tsx
+++ b/app/(app)/reminders/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import UpcomingReminders from "../../../components/UpcomingReminders";
+
+export default function RemindersPage() {
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">Reminders</h1>
+      <UpcomingReminders />
+    </div>
+  );
+}
+

--- a/app/api/reminders/route.ts
+++ b/app/api/reminders/route.ts
@@ -3,18 +3,21 @@ import { reminders, properties, isActiveProperty } from '../store';
 export async function GET(req: Request) {
   const url = new URL(req.url);
   const includeArchived = url.searchParams.get('includeArchived') === 'true';
+  const propertyId = url.searchParams.get('propertyId');
 
   const activeProps = includeArchived
     ? properties
     : properties.filter(isActiveProperty);
   const map = new Map(activeProps.map((p) => [p.id, p.address]));
 
-  const data = reminders
-    .filter((r) => map.has(r.propertyId))
-    .map((r) => ({
-      ...r,
-      propertyAddress: map.get(r.propertyId)!,
-    }));
+  let data = reminders.filter((r) => map.has(r.propertyId));
+  if (propertyId) {
+    data = data.filter((r) => r.propertyId === propertyId);
+  }
+  data = data.map((r) => ({
+    ...r,
+    propertyAddress: map.get(r.propertyId)!,
+  }));
 
   return Response.json(data);
 }

--- a/app/api/store.ts
+++ b/app/api/store.ts
@@ -35,7 +35,7 @@ export type ReminderType =
   | 'insurance_renewal'
   | 'inspection_due'
   | 'custom';
-export type ReminderSeverity = 'high' | 'medium' | 'low';
+export type ReminderSeverity = 'high' | 'med' | 'low';
 export type Reminder = {
   id: string;
   propertyId: string;
@@ -80,11 +80,12 @@ const initialProperties: Property[] = [
   },
   {
     id: '3',
-    address: '101 Vacant St',
+    address: '10 Rose St',
     tenant: '',
     leaseStart: '',
     leaseEnd: '',
     rent: 0,
+    archived: true,
   },
 ];
 
@@ -188,7 +189,7 @@ const initialReminders: Reminder[] = [
     type: 'rent_review',
     title: 'Rent review',
     dueDate: '2025-09-20',
-    severity: 'medium',
+    severity: 'med',
   },
   {
     id: 'rem3',

--- a/components/PropertyDetailTabs.tsx
+++ b/components/PropertyDetailTabs.tsx
@@ -5,10 +5,10 @@ import ExpensesTable from "./ExpensesTable";
 import RentLedgerTable from "./RentLedgerTable";
 import PropertyDocumentsTable from "./PropertyDocumentsTable";
 import TenantCRM from "./TenantCRM";
+import UpcomingReminders from "./UpcomingReminders";
 
 interface Props {
   propertyId: string;
-  events: { date: string; title: string }[];
 }
 
 const tabs = [
@@ -19,7 +19,7 @@ const tabs = [
   { id: "tenant-crm", label: "Tenant CRM" },
 ] as const;
 
-export default function PropertyDetailTabs({ propertyId, events }: Props) {
+export default function PropertyDetailTabs({ propertyId }: Props) {
   const [active, setActive] = useState<string>(tabs[0].id);
 
   useEffect(() => {
@@ -54,17 +54,7 @@ export default function PropertyDetailTabs({ propertyId, events }: Props) {
       {active === "rent-ledger" && <RentLedgerTable propertyId={propertyId} />}
       {active === "expenses" && <ExpensesTable propertyId={propertyId} />}
       {active === "documents" && <PropertyDocumentsTable propertyId={propertyId} />}
-      {active === "key-dates" && (
-        <ul className="space-y-1">
-          {events.map((e, i) => (
-            <li key={i} className="flex gap-2">
-              <span className="text-sm text-gray-600">{e.date}</span>
-              <span>{e.title}</span>
-            </li>
-          ))}
-          {events.length === 0 && <li>No upcoming dates</li>}
-        </ul>
-      )}
+      {active === "key-dates" && <UpcomingReminders propertyId={propertyId} />}
       {active === "tenant-crm" && <TenantCRM propertyId={propertyId} />}
     </div>
   );

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -6,7 +6,6 @@ import { Button } from "./ui/button";
 
 export default function Sidebar() {
   const [open, setOpen] = useState(false);
-  const [showActions, setShowActions] = useState(false);
 
   const links = [
     { href: "/", label: "Dashboard" },
@@ -34,26 +33,6 @@ export default function Sidebar() {
               {link.label}
             </Link>
           ))}
-          <button
-            className="block w-full text-left px-4 py-2 rounded hover:bg-gray-100"
-            onClick={() => setShowActions(a => !a)}
-          >
-            Actions
-          </button>
-          {showActions && (
-            <div className="ml-4 space-y-2">
-              {actions.map(link => (
-                <Link
-                  key={link.href}
-                  href={link.href}
-                  className="block px-4 py-2 rounded hover:bg-gray-100"
-                  onClick={() => setOpen(false)}
-                >
-                  {link.label}
-                </Link>
-              ))}
-            </div>
-          )}
         </div>
       </div>
       {open && (

--- a/components/UpcomingReminders.tsx
+++ b/components/UpcomingReminders.tsx
@@ -38,7 +38,7 @@ function ReminderColumn({
                 className={`block p-2 border-l-4 rounded hover:bg-gray-50 ${
                   r.severity === "high"
                     ? "border-red-500"
-                    : r.severity === "medium"
+                    : r.severity === "med"
                     ? "border-yellow-500"
                     : "border-gray-300"
                 }`}
@@ -59,30 +59,50 @@ function ReminderColumn({
   );
 }
 
-export default function UpcomingReminders() {
+interface Props {
+  propertyId?: string;
+  showViewAll?: boolean;
+}
+
+export default function UpcomingReminders({
+  propertyId,
+  showViewAll,
+}: Props) {
   const { data, isLoading } = useQuery<Reminder[]>({
-    queryKey: ["reminders"],
-    queryFn: listReminders,
+    queryKey: ["reminders", propertyId],
+    queryFn: () => listReminders(propertyId ? { propertyId } : undefined),
   });
 
   const reminders = data ?? [];
   const { overdue, thisMonth, later } = bucketReminders(reminders);
+  const gridCols = propertyId ? "" : "md:grid-cols-3";
 
   return (
     <div className="space-y-4" data-testid="reminders">
-      <h2 className="text-xl font-semibold">Upcoming Reminders</h2>
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold">Upcoming Reminders</h2>
+        {showViewAll && (
+          <Link href="/reminders" className="text-sm text-blue-600">
+            View all
+          </Link>
+        )}
+      </div>
       {isLoading ? (
-        <div className="grid gap-4 md:grid-cols-3">
+        <div className={`grid gap-4 ${gridCols}`}>
           <Skeleton className="h-24" />
-          <Skeleton className="h-24" />
-          <Skeleton className="h-24" />
+          {!propertyId && (
+            <>
+              <Skeleton className="h-24" />
+              <Skeleton className="h-24" />
+            </>
+          )}
         </div>
       ) : reminders.length === 0 ? (
         <div className="p-4 text-center text-gray-500">
-          No upcoming reminders
+          Nothing urgent 🎉
         </div>
       ) : (
-        <div className="grid gap-4 md:grid-cols-3">
+        <div className={`grid gap-4 ${gridCols}`}>
           <ReminderColumn title="Overdue" items={overdue} />
           <ReminderColumn title="This Month" items={thisMonth} />
           <ReminderColumn title="Later" items={later} />

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -45,7 +45,7 @@ export interface Reminder {
   type: 'lease_expiry' | 'rent_review' | 'insurance_renewal' | 'inspection_due' | 'custom';
   title: string;
   dueDate: string;
-  severity: 'high' | 'medium' | 'low';
+  severity: 'high' | 'med' | 'low';
 }
 
 export interface TenantNote {
@@ -339,7 +339,10 @@ export const updateNotificationSettings = (payload: NotificationSettings) =>
   });
 
 // Reminders & notifications
-export const listReminders = () => api<Reminder[]>('/reminders');
+export const listReminders = (params?: { propertyId?: string }) => {
+  const query = params?.propertyId ? `?propertyId=${params.propertyId}` : '';
+  return api<Reminder[]>(`/reminders${query}`);
+};
 export const listNotifications = () => api<Notification[]>('/notifications');
 export const getPnlSummary = (
   period: 'last6m' | 'last12m',

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -60,8 +60,10 @@ export const zReminder = z.object({
   ]),
   title: z.string(),
   dueDate: z.string(),
-  severity: z.enum(['low', 'medium', 'high']),
+  severity: z.enum(['low', 'med', 'high']),
 });
+
+export const zReminders = z.array(zReminder);
 
 export type InspectionInput = z.infer<typeof inspectionSchema>;
 export type ExpenseInput = z.infer<typeof expenseSchema>;

--- a/tests/dashboard.reminders.spec.ts
+++ b/tests/dashboard.reminders.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+test('Dashboard shows reminders with property badges and view all link', async ({ page }) => {
+  await page.goto('/dashboard');
+  const container = page.getByTestId('reminders');
+  await expect(container).toBeVisible();
+  await expect(container.getByText('123 Main St')).toBeVisible();
+  await expect(container.getByText('10 Rose St')).toHaveCount(0);
+  await page.getByRole('link', { name: 'View all' }).click();
+  await expect(page).toHaveURL('/reminders');
+});
+

--- a/tests/property.keydates.spec.ts
+++ b/tests/property.keydates.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test';
+
+test('Property detail key dates tab shows only that property reminders', async ({ page }) => {
+  await page.goto('/properties/1');
+  await page.getByRole('tab', { name: 'Key Dates' }).click();
+  const container = page.getByTestId('reminders');
+  await expect(container.getByText('123 Main St')).toBeVisible();
+  await expect(container.getByText('456 Oak Ave')).toHaveCount(0);
+});
+

--- a/types/reminders.ts
+++ b/types/reminders.ts
@@ -1,0 +1,19 @@
+export type ReminderType =
+  | 'lease_expiry'
+  | 'rent_review'
+  | 'insurance_renewal'
+  | 'inspection_due'
+  | 'custom';
+
+export type ReminderSeverity = 'low' | 'med' | 'high';
+
+export type ReminderDto = {
+  id: string;
+  propertyId: string;
+  propertyAddress: string;
+  type: ReminderType;
+  title: string;
+  dueDate: string; // ISO date
+  severity: ReminderSeverity;
+};
+


### PR DESCRIPTION
## Summary
- expand reminders API with property filters and inlined addresses
- show upcoming reminders on dashboard and property pages with property badges and view-all link; remove Actions from sidebar
- add basic full reminders page and playwight smoke tests

## Testing
- `npm test` *(fails: playwright not found)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd85c75f94832c8633a407446d2016