### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -1,15 +1,20 @@
 import Link from "next/link";
 import PageHeader from "../../../components/PageHeader";
+import DarkModeToggle from "../../../components/DarkModeToggle";
 
 export default function SettingsPage() {
   return (
-    <div className="p-6 space-y-4">
-      <PageHeader title="Settings" />
-      <ul className="list-disc pl-6 space-y-1">
-        <li>
-          <Link href="/settings/notifications">Notification Preferences</Link>
-        </li>
-      </ul>
-    </div>
+      <div className="p-6 space-y-4">
+        <PageHeader title="Settings" />
+        <label className="flex items-center justify-between">
+          <span>Dark Mode</span>
+          <DarkModeToggle />
+        </label>
+        <ul className="list-disc pl-6 space-y-1">
+          <li>
+            <Link href="/settings/notifications">Notification Preferences</Link>
+          </li>
+        </ul>
+      </div>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,7 +8,7 @@ export const metadata = { title: 'PropTech' };
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body className="min-h-screen bg-gray-50">
+      <body className="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
         <Providers>
           <Sidebar />
           <main className="md:ml-64">{children}</main>

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,9 +1,45 @@
 'use client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactNode } from 'react';
+import { ReactNode, createContext, useState, useEffect } from 'react';
 
 const queryClient = new QueryClient();
 
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+export const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'light',
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  toggleTheme: () => {},
+});
+
 export default function Providers({ children }: { children: ReactNode }) {
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  const [theme, setTheme] = useState<Theme>('light');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme') as Theme | null;
+    if (stored) {
+      setTheme(stored);
+    }
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () =>
+    setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'));
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ThemeContext.Provider value={{ theme, toggleTheme }}>
+        {children}
+      </ThemeContext.Provider>
+    </QueryClientProvider>
+  );
 }

--- a/components/DarkModeToggle.tsx
+++ b/components/DarkModeToggle.tsx
@@ -1,0 +1,9 @@
+'use client';
+import { useContext } from 'react';
+import { ThemeContext } from '../app/providers';
+import { Switch } from './ui/switch';
+
+export default function DarkModeToggle() {
+  const { theme, toggleTheme } = useContext(ThemeContext);
+  return <Switch checked={theme === 'dark'} onCheckedChange={toggleTheme} />;
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -19,22 +19,22 @@ export default function Sidebar() {
       <Button className="m-2 md:hidden" onClick={() => setOpen(true)}>
         Menu
       </Button>
-      <div
-        className={`fixed inset-y-0 left-0 z-40 w-64 bg-white border-r transform transition-transform md:translate-x-0 ${open ? "translate-x-0" : "-translate-x-full md:translate-x-0"}`}
-      >
-        <div className="p-4 space-y-2">
-          {links.map(link => (
-            <Link
-              key={link.href}
-              href={link.href}
-              className="block px-4 py-2 rounded hover:bg-gray-100"
-              onClick={() => setOpen(false)}
-            >
-              {link.label}
-            </Link>
-          ))}
+        <div
+          className={`fixed inset-y-0 left-0 z-40 w-64 bg-white dark:bg-gray-800 border-r dark:border-gray-700 transform transition-transform md:translate-x-0 ${open ? "translate-x-0" : "-translate-x-full md:translate-x-0"}`}
+        >
+          <div className="p-4 space-y-2">
+            {links.map(link => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="block px-4 py-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
+                onClick={() => setOpen(false)}
+              >
+                {link.label}
+              </Link>
+            ))}
+          </div>
         </div>
-      </div>
       {open && (
         <div
           className="fixed inset-0 z-30 bg-black/50 md:hidden"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from 'tailwindcss';
 
 const config: Config = {
+  darkMode: 'class',
   content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
   theme: {
     extend: {},

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -4,3 +4,11 @@ test('Settings page has heading', async ({ page }) => {
   await page.goto('/settings');
   await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
 });
+
+test('can toggle dark mode', async ({ page }) => {
+  await page.goto('/settings');
+  const html = page.locator('html');
+  await expect(html).not.toHaveClass(/dark/);
+  await page.getByLabel('Dark Mode').check();
+  await expect(html).toHaveClass(/dark/);
+});


### PR DESCRIPTION
## Summary
- enable class-based dark mode in Tailwind
- add theme context and toggle component with setting
- style sidebar and layout for dark mode

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tanstack%2freact-query)*
- `npm test` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd909bf240832cbdc0cd7457bc1a2b