### PR TITLE
feat: move rent review into property tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ PropTechTest is a lightweight, dashboard-first property management prototype for
 - **Vendors** management and invitations.
 - **Listings & Applications** with generated listing copy and applicant scoring.
 - **Inspections** with room checklists and shareable reports.
-- **Rent review** calculator and notice generation.
+- **Rent review** calculator and notice generation within each property.
 - **Settings** for notification preferences.
 
 ## Navigation
@@ -20,7 +20,6 @@ A collapsible sidebar links to:
 - Inspections
 - Applications
 - Listings
-- Rent Review
 - Finance (Expenses & P&L)
 - Vendors
 - Settings

--- a/components/PropertyDetailTabs.tsx
+++ b/components/PropertyDetailTabs.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import ExpensesTable from "./ExpensesTable";
 import RentLedgerTable from "./RentLedgerTable";
 import PropertyDocumentsTable from "./PropertyDocumentsTable";
+import PropertyRentReview from "./PropertyRentReview";
 import TenantCRM from "./TenantCRM";
 import UpcomingReminders from "./UpcomingReminders";
 
@@ -15,6 +16,7 @@ const tabs = [
   { id: "rent-ledger", label: "Rent Ledger" },
   { id: "expenses", label: "Expenses" },
   { id: "documents", label: "Documents" },
+  { id: "rent-review", label: "Rent Review" },
   { id: "key-dates", label: "Key Dates" },
   { id: "tenant-crm", label: "Tenant CRM" },
 ] as const;
@@ -54,6 +56,7 @@ export default function PropertyDetailTabs({ propertyId }: Props) {
       {active === "rent-ledger" && <RentLedgerTable propertyId={propertyId} />}
       {active === "expenses" && <ExpensesTable propertyId={propertyId} />}
       {active === "documents" && <PropertyDocumentsTable propertyId={propertyId} />}
+      {active === "rent-review" && <PropertyRentReview propertyId={propertyId} />}
       {active === "key-dates" && <UpcomingReminders propertyId={propertyId} />}
       {active === "tenant-crm" && <TenantCRM propertyId={propertyId} />}
     </div>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -10,7 +10,6 @@ export default function Sidebar() {
   const links = [
     { href: "/", label: "Dashboard" },
     { href: "/properties", label: "Properties" },
-    { href: "/rent-review", label: "Rent Review" },
     { href: "/settings", label: "Settings" }
   ];
 

--- a/tests/rent-review.spec.ts
+++ b/tests/rent-review.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 
-test('Rent Review page has heading', async ({ page }) => {
-  await page.goto('/rent-review');
-  await expect(page.getByRole('heading', { name: 'Rent Reviews' })).toBeVisible();
+test('Rent Review tab is available on property page', async ({ page }) => {
+  await page.goto('/properties/1');
+  await page.getByRole('button', { name: 'Rent Review' }).click();
+  await expect(page.getByRole('heading', { name: 'Rent Review' })).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- remove sidebar link to rent reviews
- add rent review tab to property details
- document new location for rent reviews

## Testing
- `npm install` *(fails: 403 Forbidden accessing registry)*
- `npm test` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be40be6e54832c9b20a4258eaf569a