### PR TITLE
feat: collapsible sidebar with settings icon

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,27 +1,36 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import { Button } from "./ui/button";
 
 export default function Sidebar() {
   const [open, setOpen] = useState(false);
 
+  useEffect(() => {
+    if (typeof window !== "undefined" && window.innerWidth >= 768) {
+      setOpen(true);
+    }
+  }, []);
+
   const links = [
     { href: "/", label: "Dashboard" },
     { href: "/properties", label: "Properties" },
-    { href: "/rent-review", label: "Rent Review" },
-    { href: "/settings", label: "Settings" }
+    { href: "/rent-review", label: "Rent Review" }
   ];
 
   return (
     <>
-      <Button className="m-2 md:hidden" onClick={() => setOpen(true)}>
-        Menu
+      <Button
+        className="m-2 fixed top-2 left-2 z-50"
+        onClick={() => setOpen(!open)}
+      >
+        {open ? "Collapse" : "Menu"}
       </Button>
-        <div
-          className={`fixed inset-y-0 left-0 z-40 w-64 bg-white dark:bg-gray-800 border-r dark:border-gray-700 transform transition-transform md:translate-x-0 ${open ? "translate-x-0" : "-translate-x-full md:translate-x-0"}`}
-        >
+      <div
+        className={`fixed inset-y-0 left-0 z-40 w-64 bg-white dark:bg-gray-800 border-r dark:border-gray-700 transform transition-transform ${open ? "translate-x-0" : "-translate-x-full"}`}
+      >
+        <div className="flex flex-col h-full justify-between">
           <div className="p-4 space-y-2">
             {links.map(link => (
               <Link
@@ -34,7 +43,37 @@ export default function Sidebar() {
               </Link>
             ))}
           </div>
+          <div className="p-4 border-t dark:border-gray-700">
+            <Link
+              href="/settings"
+              className="block px-4 py-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700 flex justify-center"
+              onClick={() => setOpen(false)}
+              aria-label="Settings"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-6 w-6"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.591 1.003 1.724 1.724 0 012.356.63 1.724 1.724 0 001.845 1.845 1.724 1.724 0 01.63 2.356 1.724 1.724 0 001.003 2.591c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.003 2.591 1.724 1.724 0 01-.63 2.356 1.724 1.724 0 00-2.356.63 1.724 1.724 0 01-2.591 1.003c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.591-1.003 1.724 1.724 0 01-2.356-.63 1.724 1.724 0 00-2.356-.63 1.724 1.724 0 01-1.003-2.591c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.003-2.591 1.724 1.724 0 01.63-2.356 1.724 1.724 0 00.63-2.356 1.724 1.724 0 011.003-2.591 1.724 1.724 0 012.591-1.003z"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                />
+              </svg>
+            </Link>
+          </div>
         </div>
+      </div>
       {open && (
         <div
           className="fixed inset-0 z-30 bg-black/50 md:hidden"


### PR DESCRIPTION
## Summary
- allow sidebar to collapse/expand across screen sizes
- move settings link to bottom and display as gear icon

## Testing
- `npm test` *(fails: playwright not found)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be41b73c9c832cbf5b5b41c4adb1d4