### PR TITLE
Remove Rent Review link from sidebar

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -58,26 +58,6 @@ export default function Sidebar() {
         { href: "/properties/456-oak-ave", label: "456 Oak Ave" },
       ],
     },
-    {
-      href: "/rent-review",
-      label: "Rent Review",
-      icon: (
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          className="h-6 w-6"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M9 2h6a2 2 0 012 2v16a2 2 0 01-2 2H9a2 2 0 01-2-2V4a2 2 0 012-2zm0 4h6m-6 4h6m-6 4h6"
-          />
-        </svg>
-      ),
-    },
   ];
 
   return (


### PR DESCRIPTION
## Summary
- remove redundant Rent Review link from the main sidebar

## Testing
- `npm test` *(fails: playwright not found)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be4a9b3828832ca195d0f422685569