### PR TITLE
Add property archive and unarchive endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,12 @@ and restart the dev server.
 
 From the finance pages (`/finance/[propertyId]/pnl` or `/finance/[propertyId]/expenses`) use the **Export** buttons to download CSV or PDF reports.
 
+### Property archive endpoints
+
+Mock API routes are available to hide or restore properties:
+
+- `POST /api/properties/:id/archive` marks a property as archived.
+- `POST /api/properties/:id/unarchive` restores an archived property.
+
+Archived properties are excluded from listings unless `includeArchived=true` is specified.
+

--- a/app/api/properties/[id]/archive/route.ts
+++ b/app/api/properties/[id]/archive/route.ts
@@ -1,0 +1,13 @@
+import { properties } from '../../store';
+
+export async function POST(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const property = properties.find((p) => p.id === params.id);
+  if (!property) {
+    return new Response('Not found', { status: 404 });
+  }
+  property.archived = true;
+  return new Response(null, { status: 204 });
+}

--- a/app/api/properties/[id]/unarchive/route.ts
+++ b/app/api/properties/[id]/unarchive/route.ts
@@ -1,0 +1,13 @@
+import { properties } from '../../store';
+
+export async function POST(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const property = properties.find((p) => p.id === params.id);
+  if (!property) {
+    return new Response('Not found', { status: 404 });
+  }
+  property.archived = false;
+  return new Response(null, { status: 204 });
+}

--- a/tests/property-archive.spec.ts
+++ b/tests/property-archive.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+import { resetStore } from '../app/api/store';
+
+test.beforeEach(() => {
+  resetStore();
+});
+
+test('property can be archived and unarchived', async ({ request }) => {
+  let res = await request.post('/api/properties/2/archive');
+  expect(res.status()).toBe(204);
+
+  const list = await request.get('/api/properties');
+  const data: any[] = await list.json();
+  expect(data.find((p) => p.id === '2')).toBeUndefined();
+
+  res = await request.post('/api/properties/2/unarchive');
+  expect(res.status()).toBe(204);
+  const list2 = await request.get('/api/properties');
+  const data2: any[] = await list2.json();
+  expect(data2.find((p) => p.id === '2')).toBeTruthy();
+});


### PR DESCRIPTION
## Summary
- add POST /api/properties/:id/archive and /unarchive to toggle archived flag
- document new endpoints in README
- add test covering archive/unarchive behavior

## Testing
- `npx playwright test tests/property-archive.spec.ts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tanstack%2freact-query)*

------
https://chatgpt.com/codex/tasks/task_e_68be53fb3548832c942d22228eddde5b