### PR TITLE
feat: add property pnl summary endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,11 @@ Mock API routes are available to hide or restore properties:
 
 Archived properties are excluded from listings unless `includeArchived=true` is specified.
 
+### Property P&L summary endpoint
+
+Retrieve profit and loss figures for a single property over a specific date range using the mock API:
+
+- `GET /api/properties/:id/summary/pnl?from=YYYY-MM-DD&to=YYYY-MM-DD`
+
+The response contains total `income`, `expenses`, `net` amount and a `buckets` array of monthly breakdowns.
+

--- a/app/api/properties/[id]/summary/pnl/route.ts
+++ b/app/api/properties/[id]/summary/pnl/route.ts
@@ -1,0 +1,44 @@
+import { prisma } from '../../../../../../lib/prisma';
+
+export async function GET(req: Request, { params }: { params: { id: string } }) {
+  const url = new URL(req.url);
+  const from = url.searchParams.get('from');
+  const to = url.searchParams.get('to');
+
+  const incomeRows = await prisma.mockData.findMany({ where: { type: 'income' } });
+  const expenseRows = await prisma.mockData.findMany({ where: { type: 'expense' } });
+
+  let incomes = incomeRows.map((r: any) => r.data).filter((i: any) => i.propertyId === params.id);
+  let expenses = expenseRows.map((r: any) => r.data).filter((e: any) => e.propertyId === params.id);
+
+  if (from) {
+    incomes = incomes.filter((i: any) => i.date >= from);
+    expenses = expenses.filter((e: any) => e.date >= from);
+  }
+  if (to) {
+    incomes = incomes.filter((i: any) => i.date <= to);
+    expenses = expenses.filter((e: any) => e.date <= to);
+  }
+
+  const income = incomes.reduce((sum: number, i: any) => sum + (i.amount || 0), 0);
+  const expensesTotal = expenses.reduce((sum: number, e: any) => sum + (e.amount || 0), 0);
+  const net = income - expensesTotal;
+
+  const monthlyMap: Record<string, { income: number; expenses: number }> = {};
+  for (const i of incomes) {
+    const month = i.date.slice(0, 7);
+    monthlyMap[month] = monthlyMap[month] || { income: 0, expenses: 0 };
+    monthlyMap[month].income += i.amount || 0;
+  }
+  for (const e of expenses) {
+    const month = e.date.slice(0, 7);
+    monthlyMap[month] = monthlyMap[month] || { income: 0, expenses: 0 };
+    monthlyMap[month].expenses += e.amount || 0;
+  }
+
+  const buckets = Object.entries(monthlyMap)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([month, m]) => ({ month, income: m.income, expenses: m.expenses, net: m.income - m.expenses }));
+
+  return Response.json({ income, expenses: expensesTotal, net, buckets });
+}

--- a/tests/property-pnl-summary.spec.ts
+++ b/tests/property-pnl-summary.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+
+test('property pnl summary endpoint supports date range', async ({ request }) => {
+  const res = await request.get('/api/properties/1/summary/pnl?from=2024-01-01&to=2024-03-31');
+  expect(res.ok()).toBeTruthy();
+  const json = await res.json();
+  expect(json.income).toBe(1250);
+  expect(json.expenses).toBe(1650);
+  expect(json.net).toBe(-400);
+  expect(json.buckets).toEqual([
+    { month: '2024-01', income: 1250, expenses: 1000, net: 250 },
+    { month: '2024-02', income: 0, expenses: 500, net: -500 },
+    { month: '2024-03', income: 0, expenses: 150, net: -150 },
+  ]);
+});


### PR DESCRIPTION
## Summary
- add date-filtered per-property P&L summary API
- document new P&L endpoint
- cover endpoint with Playwright test

## Testing
- `npm test` *(fails: playwright: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tanstack%2freact-query)*
- `npx playwright install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68bea5c16124832c94d4267d8f16ed70