### PR TITLE
Fix sidebar property links to use property IDs

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -48,8 +48,13 @@ export default function Sidebar() {
         </svg>
       ),
       children: [
-        { href: "/properties/123-main-st", label: "123 Main St" },
-        { href: "/properties/456-oak-ave", label: "456 Oak Ave" },
+        // Use property IDs to link directly to the property pages.
+        // The previous slug-based links (e.g. "/properties/123-main-st")
+        // didn't match the API routes which expect numeric IDs, causing
+        // the property page to get stuck in a loading state when accessed
+        // from the sidebar.
+        { href: "/properties/1", label: "123 Main St" },
+        { href: "/properties/2", label: "456 Oak Ave" },
       ],
     },
   ];


### PR DESCRIPTION
## Summary
- use property IDs in the sidebar links so they align with API routes

## Testing
- `npm test` *(fails: playwright not found)*
- `npm run test:unit` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68beac22d778832c96ce2315214386fb