### PR TITLE
feat: add default property image

### DIFF
--- a/app/api/properties/route.ts
+++ b/app/api/properties/route.ts
@@ -7,6 +7,7 @@ export async function GET(req: Request) {
   const data = props.map((p) => ({
     id: p.id,
     address: p.address,
+    imageUrl: p.imageUrl,
     tenant: p.tenant,
     rent: p.rent,
     leaseStart: p.leaseStart,

--- a/app/api/store.ts
+++ b/app/api/store.ts
@@ -1,6 +1,7 @@
 export type Property = {
   id: string;
   address: string;
+  imageUrl?: string;
   tenant: string;
   leaseStart: string;
   leaseEnd: string;

--- a/components/PropertyOverviewCard.tsx
+++ b/components/PropertyOverviewCard.tsx
@@ -9,36 +9,45 @@ interface Props {
 
 export default function PropertyOverviewCard({ property }: Props) {
   return (
-    <div className="border rounded p-4 space-y-2">
-      <div className="flex justify-between">
-        <div>
-          <h2 className="text-xl font-semibold">
-            <Link
-              href={`/properties/${property.id}`}
-              className="text-blue-600 underline"
-            >
-              {property.address}
-            </Link>
-          </h2>
-          <p>Tenant: {property.tenant}</p>
-          <p>
-            Lease: {property.leaseStart} – {property.leaseEnd}
-          </p>
-        </div>
-        <div className="text-right">
-          <p className="text-lg font-semibold">${property.rent}/week</p>
-        </div>
+    <div className="border rounded overflow-hidden">
+      <div className="bg-gray-200">
+        <img
+          src={property.imageUrl || "/default-house.svg"}
+          alt="Property picture"
+          className="w-full h-48 object-cover"
+        />
       </div>
-      <div>
-        <h3 className="font-semibold">Upcoming</h3>
-        <ul className="list-disc pl-5">
-          {property.events.map((e) => (
-            <li key={e.date + e.title}>
-              {e.date}: {e.title}
-            </li>
-          ))}
-          {property.events.length === 0 && <li>None</li>}
-        </ul>
+      <div className="p-4 space-y-2">
+        <div className="flex justify-between">
+          <div>
+            <h2 className="text-xl font-semibold">
+              <Link
+                href={`/properties/${property.id}`}
+                className="text-blue-600 underline"
+              >
+                {property.address}
+              </Link>
+            </h2>
+            <p>Tenant: {property.tenant}</p>
+            <p>
+              Lease: {property.leaseStart} – {property.leaseEnd}
+            </p>
+          </div>
+          <div className="text-right">
+            <p className="text-lg font-semibold">${property.rent}/week</p>
+          </div>
+        </div>
+        <div>
+          <h3 className="font-semibold">Upcoming</h3>
+          <ul className="list-disc pl-5">
+            {property.events.map((e) => (
+              <li key={e.date + e.title}>
+                {e.date}: {e.title}
+              </li>
+            ))}
+            {property.events.length === 0 && <li>None</li>}
+          </ul>
+        </div>
       </div>
     </div>
   );

--- a/public/default-house.svg
+++ b/public/default-house.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <path d="M32 12L8 32h8v20h12V40h8v12h12V32h8L32 12z" fill="#cccccc" stroke="#888888" stroke-width="2"/>
+  <rect x="28" y="36" width="8" height="8" fill="#ffffff"/>
+</svg>

--- a/types/property.ts
+++ b/types/property.ts
@@ -6,6 +6,7 @@ export interface PropertyEvent {
 export interface PropertySummary {
   id: string;
   address: string;
+  imageUrl?: string;
   rent: number;
   tenant: string;
   leaseStart: string;


### PR DESCRIPTION
## Summary
- show property image above basic info and use default when none provided
- support optional property image URL in API and types

## Testing
- `npm test` *(fails: playwright not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bead339014832c96131423e5b62af6