### PR TITLE
Add property CRUD

### DIFF
--- a/app/(app)/properties/[id]/edit/page.tsx
+++ b/app/(app)/properties/[id]/edit/page.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import PropertyForm from "../../../../../components/PropertyForm";
+import { getProperty } from "../../../../../lib/api";
+import type { PropertySummary } from "../../../../../types/property";
+
+export default function EditPropertyPage() {
+  const { id } = useParams<{ id: string }>();
+  const { data: property } = useQuery<PropertySummary>({
+    queryKey: ["property", id],
+    queryFn: () => getProperty(id),
+  });
+  if (!property) return <div className="p-6">Loading...</div>;
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">Edit Property</h1>
+      <PropertyForm property={property} />
+    </div>
+  );
+}
+

--- a/app/(app)/properties/[id]/page.tsx
+++ b/app/(app)/properties/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
+import Link from "next/link";
 import QuickActionsBar from "../../../../components/QuickActionsBar";
 import ExpenseForm from "../../../../components/ExpenseForm";
 import DocumentUploadModal from "../../../../components/DocumentUploadModal";
@@ -11,7 +12,6 @@ import PropertyOverviewCard from "../../../../components/PropertyOverviewCard";
 import PropertyDetailTabs from "../../../../components/PropertyDetailTabs";
 import { getProperty } from "../../../../lib/api";
 import type { PropertySummary } from "../../../../types/property";
-import Link from "next/link";
 
 export default function PropertyPage() {
   const [expenseOpen, setExpenseOpen] = useState(false);
@@ -34,6 +34,12 @@ export default function PropertyPage() {
         onUploadDocument={() => setDocOpen(true)}
         onMessageTenant={() => setMessageOpen(true)}
       />
+      <Link
+        href={`/properties/${id}/edit`}
+        className="inline-block px-2 py-1 border rounded"
+      >
+        Edit Property
+      </Link>
       <div className="relative inline-block">
         <button
           className="px-2 py-1 border rounded"

--- a/app/api/properties/[id]/route.ts
+++ b/app/api/properties/[id]/route.ts
@@ -1,4 +1,14 @@
-import { properties, reminders } from '../../store';
+import {
+  properties,
+  reminders,
+  tenants,
+  expenses,
+  incomes,
+  documents,
+  rentLedger,
+  notifications,
+  tenantNotes,
+} from '../../store';
 
 export async function GET(
   _req: Request,
@@ -12,4 +22,41 @@ export async function GET(
     .filter((r) => r.propertyId === params.id)
     .map((r) => ({ date: r.dueDate, title: r.title }));
   return Response.json({ ...property, events });
+}
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const property = properties.find((p) => p.id === params.id);
+  if (!property) return new Response('Not found', { status: 404 });
+  const body = await req.json();
+  if (body.address !== undefined) property.address = body.address;
+  if (body.imageUrl !== undefined) property.imageUrl = body.imageUrl;
+  if (body.tenant !== undefined) property.tenant = body.tenant;
+  if (body.leaseStart !== undefined) property.leaseStart = body.leaseStart;
+  if (body.leaseEnd !== undefined) property.leaseEnd = body.leaseEnd;
+  if (body.rent !== undefined)
+    property.rent = typeof body.rent === 'number' ? body.rent : Number(body.rent) || 0;
+  if (body.archived !== undefined) property.archived = body.archived;
+  const events = reminders
+    .filter((r) => r.propertyId === params.id)
+    .map((r) => ({ date: r.dueDate, title: r.title }));
+  return Response.json({ ...property, events });
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const idx = properties.findIndex((p) => p.id === params.id);
+  if (idx === -1) return new Response('Not found', { status: 404 });
+  properties.splice(idx, 1);
+  for (const arr of [tenants, expenses, incomes, documents, rentLedger, notifications, tenantNotes, reminders]) {
+    let i = arr.length;
+    while (i--) {
+      if ((arr[i] as any).propertyId === params.id) arr.splice(i, 1);
+    }
+  }
+  return new Response(null, { status: 204 });
 }

--- a/app/api/properties/route.ts
+++ b/app/api/properties/route.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { properties, reminders, isActiveProperty } from '../store';
 
 export async function GET(req: Request) {
@@ -17,4 +18,24 @@ export async function GET(req: Request) {
       .map((r) => ({ date: r.dueDate, title: r.title })),
   }));
   return Response.json(data);
+}
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const id = body.id || randomUUID();
+  const property = {
+    id,
+    address: body.address || '',
+    imageUrl: body.imageUrl,
+    tenant: body.tenant || '',
+    leaseStart: body.leaseStart || '',
+    leaseEnd: body.leaseEnd || '',
+    rent: typeof body.rent === 'number' ? body.rent : Number(body.rent) || 0,
+    archived: body.archived ?? false,
+  };
+  properties.push(property);
+  const events = reminders
+    .filter((r) => r.propertyId === id)
+    .map((r) => ({ date: r.dueDate, title: r.title }));
+  return Response.json({ ...property, events }, { status: 201 });
 }

--- a/app/properties/new/page.tsx
+++ b/app/properties/new/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import PropertyForm from "../../../components/PropertyForm";
+
+export default function NewPropertyPage() {
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">Add Property</h1>
+      <PropertyForm />
+    </div>
+  );
+}
+

--- a/app/properties/page.tsx
+++ b/app/properties/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
+import Link from 'next/link';
 import PropertyOverviewCard from '../../components/PropertyOverviewCard';
 import { listProperties } from '../../lib/api';
 import type { PropertySummary } from '../../types/property';
@@ -13,7 +14,15 @@ export default function PropertiesPage() {
 
   return (
     <div className="p-6 space-y-4">
-      <h1 className="text-2xl font-semibold">Properties</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Properties</h1>
+        <Link
+          href="/properties/new"
+          className="px-2 py-1 bg-blue-500 text-white"
+        >
+          Add Property
+        </Link>
+      </div>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {data.map((p) => (
           <PropertyOverviewCard key={p.id} property={p} />

--- a/components/PropertyForm.tsx
+++ b/components/PropertyForm.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createProperty, updateProperty, deleteProperty } from "../lib/api";
+import type { PropertySummary } from "../types/property";
+import { useToast } from "./ui/use-toast";
+
+interface Props {
+  property?: PropertySummary;
+}
+
+export default function PropertyForm({ property }: Props) {
+  const isEdit = !!property;
+  const [form, setForm] = useState({
+    address: property?.address ?? "",
+    imageUrl: property?.imageUrl ?? "",
+    tenant: property?.tenant ?? "",
+    leaseStart: property?.leaseStart ?? "",
+    leaseEnd: property?.leaseEnd ?? "",
+    rent: property ? String(property.rent) : "",
+  });
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  const saveMutation = useMutation({
+    mutationFn: (payload: any) =>
+      isEdit
+        ? updateProperty(property!.id, payload)
+        : createProperty(payload),
+    onSuccess: (p: any) => {
+      toast({ title: "Property saved" });
+      queryClient.invalidateQueries({ queryKey: ["properties"] });
+      if (isEdit) {
+        queryClient.invalidateQueries({ queryKey: ["property", property!.id] });
+        router.push(`/properties/${property!.id}`);
+      } else {
+        router.push(`/properties/${p.id}`);
+      }
+    },
+    onError: (e: any) =>
+      toast({ title: "Failed to save property", description: e.message }),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteProperty(property!.id),
+    onSuccess: () => {
+      toast({ title: "Property deleted" });
+      queryClient.invalidateQueries({ queryKey: ["properties"] });
+      queryClient.removeQueries({ queryKey: ["property", property!.id] });
+      router.push("/properties");
+    },
+    onError: (e: any) =>
+      toast({ title: "Failed to delete property", description: e.message }),
+  });
+
+  return (
+    <form
+      className="space-y-2"
+      onSubmit={(e) => {
+        e.preventDefault();
+        saveMutation.mutate({
+          address: form.address,
+          imageUrl: form.imageUrl,
+          tenant: form.tenant,
+          leaseStart: form.leaseStart,
+          leaseEnd: form.leaseEnd,
+          rent: parseFloat(form.rent),
+        });
+      }}
+    >
+      <label className="block">
+        Address
+        <input
+          className="border p-1 w-full"
+          value={form.address}
+          onChange={(e) => setForm({ ...form, address: e.target.value })}
+        />
+      </label>
+      <label className="block">
+        Image URL
+        <input
+          className="border p-1 w-full"
+          value={form.imageUrl}
+          onChange={(e) => setForm({ ...form, imageUrl: e.target.value })}
+        />
+      </label>
+      <label className="block">
+        Tenant
+        <input
+          className="border p-1 w-full"
+          value={form.tenant}
+          onChange={(e) => setForm({ ...form, tenant: e.target.value })}
+        />
+      </label>
+      <label className="block">
+        Lease Start
+        <input
+          type="date"
+          className="border p-1 w-full"
+          value={form.leaseStart}
+          onChange={(e) => setForm({ ...form, leaseStart: e.target.value })}
+        />
+      </label>
+      <label className="block">
+        Lease End
+        <input
+          type="date"
+          className="border p-1 w-full"
+          value={form.leaseEnd}
+          onChange={(e) => setForm({ ...form, leaseEnd: e.target.value })}
+        />
+      </label>
+      <label className="block">
+        Rent
+        <input
+          type="number"
+          className="border p-1 w-full"
+          value={form.rent}
+          onChange={(e) => setForm({ ...form, rent: e.target.value })}
+        />
+      </label>
+      <div className="space-x-2">
+        <button type="submit" className="px-2 py-1 bg-blue-500 text-white">
+          {isEdit ? "Save" : "Create"}
+        </button>
+        {isEdit && (
+          <button
+            type="button"
+            className="px-2 py-1 bg-red-500 text-white"
+            onClick={() => deleteMutation.mutate()}
+          >
+            Delete
+          </button>
+        )}
+      </div>
+    </form>
+  );
+}
+

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -95,6 +95,18 @@ export async function api<T>(path: string, init?: RequestInit): Promise<T> {
 
 export const listProperties = () => api<PropertySummary[]>('/properties');
 export const getProperty = (id: string) => api<PropertySummary>(`/properties/${id}`);
+export const createProperty = (payload: any) =>
+  api<PropertySummary>('/properties', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+export const updateProperty = (id: string, payload: any) =>
+  api<PropertySummary>(`/properties/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(payload),
+  });
+export const deleteProperty = (id: string) =>
+  api(`/properties/${id}`, { method: 'DELETE' });
 export const listLedger = (propertyId: string) =>
   api<LedgerEntry[]>(`/rent-ledger?propertyId=${propertyId}`);
 export const listTenantNotes = (propertyId: string) =>

--- a/tests/property-crud.spec.ts
+++ b/tests/property-crud.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+import { resetStore } from '../app/api/store';
+
+test.beforeEach(() => {
+  resetStore();
+});
+
+test('property can be created, updated and deleted', async ({ request }) => {
+  const createRes = await request.post('/api/properties', {
+    data: {
+      address: '789 Pine Rd',
+      tenant: 'New Tenant',
+      leaseStart: '2024-01-01',
+      leaseEnd: '2024-12-31',
+      rent: 1000,
+      imageUrl: 'http://example.com/img.jpg',
+    },
+  });
+  expect(createRes.ok()).toBeTruthy();
+  const created: any = await createRes.json();
+  expect(created.address).toBe('789 Pine Rd');
+
+  const updateRes = await request.patch(`/api/properties/${created.id}`, {
+    data: { address: '789 Updated Rd', rent: 1100 },
+  });
+  expect(updateRes.ok()).toBeTruthy();
+  const updated: any = await updateRes.json();
+  expect(updated.address).toBe('789 Updated Rd');
+  expect(updated.rent).toBe(1100);
+
+  const deleteRes = await request.delete(`/api/properties/${created.id}`);
+  expect(deleteRes.status()).toBe(204);
+
+  const listRes = await request.get('/api/properties');
+  const list: any[] = await listRes.json();
+  expect(list.find((p) => p.id === created.id)).toBeUndefined();
+});
+


### PR DESCRIPTION
## Summary
- allow creating properties via `/api/properties` and editing/deleting via `/api/properties/:id`
- add React form and pages to create, edit, and delete properties
- expose property CRUD helpers in client API and add regression tests

## Testing
- `npm test` *(fails: playwright: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tanstack%2freact-query)*
- `npm run test:unit` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68beb1b84ddc832ca818042910facd61