### PR TITLE
Fix document uploads and keep sidebar static

### DIFF
--- a/app/(app)/properties/[id]/page.tsx
+++ b/app/(app)/properties/[id]/page.tsx
@@ -84,7 +84,11 @@ export default function PropertyPage() {
         onOpenChange={setExpenseOpen}
         showTrigger={false}
       />
-      <DocumentUploadModal open={docOpen} onClose={() => setDocOpen(false)} />
+      <DocumentUploadModal
+        propertyId={id}
+        open={docOpen}
+        onClose={() => setDocOpen(false)}
+      />
       <MessageTenantModal open={messageOpen} onClose={() => setMessageOpen(false)} />
       <h1 className="text-2xl font-semibold">Property Details</h1>
       <PropertyOverviewCard property={property} />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,9 +10,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <html lang="en">
       <body className="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-200">
         <Providers>
-          <div className="flex min-h-screen">
+          <div className="flex h-screen overflow-hidden">
             <Sidebar />
-            <main className="flex-1">{children}</main>
+            <main className="flex-1 overflow-y-auto">{children}</main>
           </div>
         </Providers>
       </body>

--- a/components/DocumentUploadModal.tsx
+++ b/components/DocumentUploadModal.tsx
@@ -1,15 +1,39 @@
 "use client";
 
 import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { uploadFile, createDocument } from "../lib/api";
+import { DocumentTag } from "../types/document";
 
 interface Props {
   open: boolean;
   onClose: () => void;
+  propertyId?: string;
 }
 
-export default function DocumentUploadModal({ open, onClose }: Props) {
+export default function DocumentUploadModal({ open, onClose, propertyId }: Props) {
   const [file, setFile] = useState<File | null>(null);
+  const queryClient = useQueryClient();
+
   if (!open) return null;
+
+  const handleUpload = async () => {
+    if (!file) return;
+    const { url } = await uploadFile(file);
+    await createDocument({
+      url,
+      title: file.name,
+      tag: DocumentTag.Other,
+      propertyId,
+    });
+    // Refresh any document queries for this property
+    if (propertyId) {
+      queryClient.invalidateQueries({ queryKey: ["documents", propertyId] });
+    }
+    onClose();
+    setFile(null);
+  };
+
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
       <div className="bg-white p-4 rounded space-y-2 w-80">
@@ -20,13 +44,13 @@ export default function DocumentUploadModal({ open, onClose }: Props) {
           onChange={(e) => setFile(e.target.files?.[0] || null)}
         />
         <div className="flex justify-end gap-2 pt-2">
-          <button className="px-2 py-1 bg-gray-100" onClick={onClose}>
+          <button className="px-2 py-1 bg-gray-100" onClick={() => { setFile(null); onClose(); }}>
             Cancel
           </button>
           <button
             className="px-2 py-1 bg-blue-600 text-white"
             disabled={!file}
-            onClick={onClose}
+            onClick={handleUpload}
           >
             Upload
           </button>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -314,6 +314,10 @@ export const createDocument = (payload: {
 export const searchDocuments = (search: string) =>
   listDocuments({ query: search });
 
+// Property documents
+export const listPropertyDocuments = (propertyId: string) =>
+  listDocuments({ propertyId });
+
 // Vendors
 export const listVendors = () => api<Vendor[]>('/vendors');
 export const createVendor = (payload: Vendor) =>


### PR DESCRIPTION
## Summary
- Save uploaded files to `public/uploads` and return their URLs
- Provide `listPropertyDocuments` API wrapper
- Allow uploading documents from property pages with `DocumentUploadModal`
- Keep sidebar fixed by limiting page scrolling to main content

## Testing
- `npm test` *(fails: playwright: not found)*
- `npm run test:unit` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68beb7af65b0832c82ed4f8a97eb22cc