### PR TITLE
feat: add analytics section with endpoints and charts

### DIFF
--- a/app/(app)/analytics/page.tsx
+++ b/app/(app)/analytics/page.tsx
@@ -1,0 +1,160 @@
+"use client";
+import { useEffect, useState } from "react";
+import PnLChart from "../../../components/PnLChart";
+import Skeleton from "../../../components/Skeleton";
+import {
+  zPnlSeries,
+  zRentMetrics,
+  zExpenseBreakdown,
+  zOccupancy,
+} from "../../../lib/validation";
+import type {
+  PnLSeries,
+  RentMetrics,
+  ExpenseBreakdown,
+  Occupancy,
+} from "../../../types/analytics";
+import {
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+const COLORS = ["#0088FE", "#00C49F", "#FFBB28", "#FF8042", "#8884d8", "#82ca9d"];
+
+export default function AnalyticsPage() {
+  const [pnl, setPnl] = useState<PnLSeries | null>(null);
+  const [rent, setRent] = useState<RentMetrics | null>(null);
+  const [expenseData, setExpenseData] = useState<ExpenseBreakdown | null>(null);
+  const [occupancy, setOccupancy] = useState<Occupancy | null>(null);
+
+  useEffect(() => {
+    fetch("/api/analytics/pnl")
+      .then((res) => res.json())
+      .then((json) => setPnl(zPnlSeries.parse(json)))
+      .catch(() => {});
+    fetch("/api/analytics/rent")
+      .then((res) => res.json())
+      .then((json) => setRent(zRentMetrics.parse(json)))
+      .catch(() => {});
+    fetch("/api/analytics/expenses")
+      .then((res) => res.json())
+      .then((json) => setExpenseData(zExpenseBreakdown.parse(json)))
+      .catch(() => {});
+    fetch("/api/analytics/occupancy")
+      .then((res) => res.json())
+      .then((json) => setOccupancy(zOccupancy.parse(json)))
+      .catch(() => {});
+  }, []);
+
+  return (
+    <div className="p-6 space-y-6">
+      <h1 className="text-2xl font-semibold">Analytics</h1>
+
+      <div className="grid gap-4 md:grid-cols-4" data-testid="kpis">
+        <div className="p-4 border rounded" data-testid="kpi-net">
+          <div className="text-sm text-gray-500">Net</div>
+          <div className="text-xl font-bold">{pnl ? pnl.totals.net : '-'}</div>
+        </div>
+        <div className="p-4 border rounded" data-testid="kpi-collection">
+          <div className="text-sm text-gray-500">Collection rate</div>
+          <div className="text-xl font-bold">
+            {rent ? `${Math.round(rent.collectionRate * 100)}%` : '-'}
+          </div>
+        </div>
+        <div className="p-4 border rounded" data-testid="kpi-arrears">
+          <div className="text-sm text-gray-500">Arrears amount</div>
+          <div className="text-xl font-bold">{rent ? rent.arrearsAmount : '-'}</div>
+        </div>
+        <div className="p-4 border rounded" data-testid="kpi-occupancy">
+          <div className="text-sm text-gray-500">Occupancy rate</div>
+          <div className="text-xl font-bold">
+            {occupancy ? `${Math.round(occupancy.occupancyRate * 100)}%` : '-'}
+          </div>
+        </div>
+      </div>
+
+      <section>
+        <h2 className="font-semibold mb-2">P&L Trend</h2>
+        {pnl ? <PnLChart data={pnl.series} /> : <Skeleton className="h-64" />}
+        <a className="text-sm text-blue-600" href="/api/analytics/export/pnl.csv">
+          Export CSV
+        </a>
+      </section>
+
+      <section>
+        <h2 className="font-semibold mb-2">Expense Breakdown</h2>
+        {expenseData ? (
+          <>
+            <div className="h-64">
+              <ResponsiveContainer width="100%" height="100%">
+                <PieChart>
+                  <Pie
+                    dataKey="amount"
+                    nameKey="category"
+                    data={expenseData.slices}
+                    label
+                  >
+                    {expenseData.slices.map((_, i) => (
+                      <Cell key={i} fill={COLORS[i % COLORS.length]} />
+                    ))}
+                  </Pie>
+                  <Tooltip />
+                </PieChart>
+              </ResponsiveContainer>
+            </div>
+            <ul className="mt-2">
+              {expenseData.slices.map((s) => (
+                <li key={s.category} data-testid="expense-category">
+                  {s.category}: {s.amount}
+                </li>
+              ))}
+            </ul>
+          </>
+        ) : (
+          <Skeleton className="h-64" />
+        )}
+        <a className="text-sm text-blue-600" href="/api/analytics/export/expenses.csv">
+          Export CSV
+        </a>
+      </section>
+
+      <section>
+        <h2 className="font-semibold mb-2">Rent Collection</h2>
+        {rent ? (
+          <div className="h-64">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={[{ name: 'Rent', expected: rent.expected, received: rent.received }]}> 
+                <XAxis dataKey="name" stroke="currentColor" />
+                <YAxis stroke="currentColor" />
+                <Tooltip />
+                <Bar dataKey="expected" fill="#8884d8" />
+                <Bar dataKey="received" fill="#82ca9d" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        ) : (
+          <Skeleton className="h-64" />
+        )}
+        <a className="text-sm text-blue-600" href="/api/analytics/export/rent.csv">
+          Export CSV
+        </a>
+      </section>
+
+      <section>
+        <h2 className="font-semibold mb-2">Occupancy</h2>
+        {occupancy ? (
+          <div className="text-xl font-bold">{Math.round(occupancy.occupancyRate * 100)}%</div>
+        ) : (
+          <Skeleton className="h-8" />
+        )}
+      </section>
+    </div>
+  );
+}

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import CashflowTile from "../../../components/CashflowTile";
 import DashboardPnlMiniChart from "../../../components/DashboardPnlMiniChart";
 import DashboardPropertyCard from "../../../components/DashboardPropertyCard";
@@ -37,7 +38,14 @@ export default function DashboardPage() {
   return (
     <div className="p-6 space-y-6">
       <div className="grid gap-4 md:grid-cols-3">
-        <DashboardPnlMiniChart />
+        <div className="relative">
+          <DashboardPnlMiniChart />
+          <div className="absolute bottom-2 right-2 text-xs">
+            <Link href="/analytics" className="text-blue-600 underline">
+              View full analytics →
+            </Link>
+          </div>
+        </div>
         <CashflowTile />
         {loading ? (
           <>

--- a/app/api/analytics/expenses/route.ts
+++ b/app/api/analytics/expenses/route.ts
@@ -1,0 +1,56 @@
+import { expenses, properties, isActiveProperty } from '../../store';
+import { seedIfEmpty } from '../../store';
+import type { ExpenseBreakdown } from '../../../../types/analytics';
+
+function getRange(search: URLSearchParams) {
+  const from = search.get('from');
+  const to = search.get('to');
+  if (from && to) return { from: new Date(from), to: new Date(to) };
+  const dates = expenses.map((e) => e.date).sort();
+  const latest = dates[dates.length - 1];
+  const toDate = latest ? new Date(latest) : new Date();
+  const fromDate = new Date(toDate);
+  fromDate.setMonth(fromDate.getMonth() - 5);
+  fromDate.setDate(1);
+  return { from: fromDate, to: toDate };
+}
+
+export function computeExpenseBreakdown(params: {
+  from?: Date;
+  to?: Date;
+  propertyId?: string;
+}): ExpenseBreakdown {
+  const { from, to, propertyId } = params;
+  const fromDate = from || new Date('1970-01-01');
+  const toDate = to || new Date('2100-01-01');
+  const allowed = propertyId
+    ? [propertyId]
+    : properties.filter(isActiveProperty).map((p) => p.id);
+
+  const filtered = expenses.filter(
+    (e) =>
+      allowed.includes(e.propertyId) &&
+      new Date(e.date) >= fromDate &&
+      new Date(e.date) <= toDate,
+  );
+
+  const map = new Map<string, number>();
+  for (const e of filtered) {
+    map.set(e.category, (map.get(e.category) || 0) + e.amount);
+  }
+  const slices = Array.from(map.entries()).map(([category, amount]) => ({
+    category,
+    amount,
+  }));
+  const total = slices.reduce((s, x) => s + x.amount, 0);
+  return { slices, total };
+}
+
+export async function GET(req: Request) {
+  seedIfEmpty();
+  const { searchParams } = new URL(req.url);
+  const { from, to } = getRange(searchParams);
+  const propertyId = searchParams.get('propertyId') || undefined;
+  const data = computeExpenseBreakdown({ from, to, propertyId });
+  return Response.json(data);
+}

--- a/app/api/analytics/export/expenses/route.ts
+++ b/app/api/analytics/export/expenses/route.ts
@@ -1,0 +1,20 @@
+import { computeExpenseBreakdown } from '../../expenses/route';
+import { toCSV } from '../../../../../lib/export';
+import { seedIfEmpty } from '../../../store';
+
+export async function GET(req: Request) {
+  seedIfEmpty();
+  const url = new URL(req.url);
+  const data = computeExpenseBreakdown({
+    from: url.searchParams.get('from') ? new Date(url.searchParams.get('from')!) : undefined,
+    to: url.searchParams.get('to') ? new Date(url.searchParams.get('to')!) : undefined,
+    propertyId: url.searchParams.get('propertyId') || undefined,
+  });
+  const rows = [
+    ['Category', 'Amount'],
+    ...data.slices.map((s) => [s.category, s.amount.toString()]),
+    ['Total', data.total.toString()],
+  ];
+  const csv = toCSV(rows);
+  return new Response(csv, { headers: { 'Content-Type': 'text/csv' } });
+}

--- a/app/api/analytics/export/pnl/route.ts
+++ b/app/api/analytics/export/pnl/route.ts
@@ -1,0 +1,22 @@
+import { computePnL } from '../../pnl/route';
+import { toCSV } from '../../../../../lib/export';
+import { seedIfEmpty } from '../../../store';
+
+export async function GET(req: Request) {
+  seedIfEmpty();
+  const url = new URL(req.url);
+  const data = computePnL({
+    from: url.searchParams.get('from') ? new Date(url.searchParams.get('from')!) : undefined,
+    to: url.searchParams.get('to') ? new Date(url.searchParams.get('to')!) : undefined,
+    propertyId: url.searchParams.get('propertyId') || undefined,
+  });
+  const rows = [
+    ['Month', 'Income', 'Expenses', 'Net'],
+    ...data.series.map((p) => [p.month, p.income.toString(), p.expenses.toString(), p.net.toString()]),
+    ['Totals', data.totals.income.toString(), data.totals.expenses.toString(), data.totals.net.toString()],
+  ];
+  const csv = toCSV(rows);
+  return new Response(csv, {
+    headers: { 'Content-Type': 'text/csv' },
+  });
+}

--- a/app/api/analytics/export/rent/route.ts
+++ b/app/api/analytics/export/rent/route.ts
@@ -1,0 +1,25 @@
+import { computeRentMetrics } from '../../rent/route';
+import { toCSV } from '../../../../../lib/export';
+import { seedIfEmpty } from '../../../store';
+
+export async function GET(req: Request) {
+  seedIfEmpty();
+  const url = new URL(req.url);
+  const data = computeRentMetrics({
+    from: url.searchParams.get('from') ? new Date(url.searchParams.get('from')!) : undefined,
+    to: url.searchParams.get('to') ? new Date(url.searchParams.get('to')!) : undefined,
+    propertyId: url.searchParams.get('propertyId') || undefined,
+  });
+  const rows = [
+    ['Expected', 'Received', 'CollectionRate', 'ArrearsCount', 'ArrearsAmount'],
+    [
+      data.expected.toString(),
+      data.received.toString(),
+      data.collectionRate.toString(),
+      data.arrearsCount.toString(),
+      data.arrearsAmount.toString(),
+    ],
+  ];
+  const csv = toCSV(rows);
+  return new Response(csv, { headers: { 'Content-Type': 'text/csv' } });
+}

--- a/app/api/analytics/occupancy/route.ts
+++ b/app/api/analytics/occupancy/route.ts
@@ -1,0 +1,59 @@
+import { properties, isActiveProperty } from '../../store';
+import { seedIfEmpty } from '../../store';
+import type { Occupancy } from '../../../../types/analytics';
+
+function getRange(search: URLSearchParams) {
+  const from = search.get('from');
+  const to = search.get('to');
+  if (from && to) return { from: new Date(from), to: new Date(to) };
+  const dates = properties.map((p) => p.leaseEnd).filter(Boolean).sort();
+  const latest = dates[dates.length - 1];
+  const toDate = latest ? new Date(latest) : new Date();
+  const fromDate = new Date(toDate);
+  fromDate.setMonth(fromDate.getMonth() - 5);
+  fromDate.setDate(1);
+  return { from: fromDate, to: toDate };
+}
+
+function daysBetween(a: Date, b: Date) {
+  return Math.max(0, Math.ceil((b.getTime() - a.getTime()) / (1000 * 60 * 60 * 24)) + 1);
+}
+
+export function computeOccupancy(params: {
+  from?: Date;
+  to?: Date;
+  propertyId?: string;
+}): Occupancy {
+  const { from, to, propertyId } = params;
+  const fromDate = from || new Date('1970-01-01');
+  const toDate = to || new Date('2100-01-01');
+  const allowed = propertyId
+    ? [propertyId]
+    : properties.filter(isActiveProperty).map((p) => p.id);
+
+  const periodDays = daysBetween(fromDate, toDate) * allowed.length;
+  let occupiedDays = 0;
+
+  for (const p of properties) {
+    if (!allowed.includes(p.id) || !p.leaseStart || !p.leaseEnd) continue;
+    const leaseStart = new Date(p.leaseStart);
+    const leaseEnd = new Date(p.leaseEnd);
+    const start = leaseStart > fromDate ? leaseStart : fromDate;
+    const end = leaseEnd < toDate ? leaseEnd : toDate;
+    if (start <= end) {
+      occupiedDays += daysBetween(start, end);
+    }
+  }
+  const vacantDays = periodDays - occupiedDays;
+  const occupancyRate = periodDays ? occupiedDays / periodDays : 0;
+  return { occupiedDays, vacantDays, occupancyRate };
+}
+
+export async function GET(req: Request) {
+  seedIfEmpty();
+  const { searchParams } = new URL(req.url);
+  const { from, to } = getRange(searchParams);
+  const propertyId = searchParams.get('propertyId') || undefined;
+  const data = computeOccupancy({ from, to, propertyId });
+  return Response.json(data);
+}

--- a/app/api/analytics/pnl/route.ts
+++ b/app/api/analytics/pnl/route.ts
@@ -1,0 +1,91 @@
+import { rentLedger, expenses, properties, isActiveProperty } from '../../store';
+import { seedIfEmpty } from '../../store';
+import type { PnLSeries } from '../../../../types/analytics';
+
+function getRange(search: URLSearchParams) {
+  const from = search.get('from');
+  const to = search.get('to');
+  if (from && to) return { from: new Date(from), to: new Date(to) };
+  const dates = [
+    ...rentLedger.map((r) => r.paidDate || r.dueDate),
+    ...expenses.map((e) => e.date),
+  ].sort();
+  const latest = dates[dates.length - 1];
+  const toDate = latest ? new Date(latest) : new Date();
+  const fromDate = new Date(toDate);
+  fromDate.setMonth(fromDate.getMonth() - 5);
+  fromDate.setDate(1);
+  return { from: fromDate, to: toDate };
+}
+
+export function computePnL(params: {
+  from?: Date;
+  to?: Date;
+  propertyId?: string;
+}): PnLSeries {
+  const { from, to, propertyId } = params;
+  const fromDate = from || new Date('1970-01-01');
+  const toDate = to || new Date('2100-01-01');
+  const allowed = propertyId
+    ? [propertyId]
+    : properties.filter(isActiveProperty).map((p) => p.id);
+
+  const incomeEntries = rentLedger.filter(
+    (e) =>
+      e.status === 'paid' &&
+      allowed.includes(e.propertyId) &&
+      new Date(e.paidDate || e.dueDate) >= fromDate &&
+      new Date(e.paidDate || e.dueDate) <= toDate,
+  );
+  const expenseEntries = expenses.filter(
+    (e) =>
+      allowed.includes(e.propertyId) &&
+      new Date(e.date) >= fromDate &&
+      new Date(e.date) <= toDate,
+  );
+
+  const seriesMap = new Map<string, { income: number; expenses: number }>();
+
+  for (const entry of incomeEntries) {
+    const month = (entry.paidDate || entry.dueDate).slice(0, 7);
+    const item = seriesMap.get(month) || { income: 0, expenses: 0 };
+    item.income += entry.amount;
+    seriesMap.set(month, item);
+  }
+  for (const entry of expenseEntries) {
+    const month = entry.date.slice(0, 7);
+    const item = seriesMap.get(month) || { income: 0, expenses: 0 };
+    item.expenses += entry.amount;
+    seriesMap.set(month, item);
+  }
+
+  const series = Array.from(seriesMap.entries())
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([month, v]) => ({
+      month,
+      income: v.income,
+      expenses: v.expenses,
+      net: v.income - v.expenses,
+    }));
+
+  const totals = series.reduce(
+    (acc, p) => {
+      acc.income += p.income;
+      acc.expenses += p.expenses;
+      acc.net += p.net;
+      return acc;
+    },
+    { income: 0, expenses: 0, net: 0 },
+  );
+
+  return { series, totals };
+}
+
+export async function GET(req: Request) {
+  seedIfEmpty();
+  const { searchParams } = new URL(req.url);
+  const { from, to } = getRange(searchParams);
+  const propertyId = searchParams.get('propertyId') || undefined;
+  const data = computePnL({ from, to, propertyId });
+  return Response.json(data);
+}

--- a/app/api/analytics/rent/route.ts
+++ b/app/api/analytics/rent/route.ts
@@ -1,0 +1,55 @@
+import { rentLedger, properties, isActiveProperty } from '../../store';
+import { seedIfEmpty } from '../../store';
+import type { RentMetrics } from '../../../../types/analytics';
+
+function getRange(search: URLSearchParams) {
+  const from = search.get('from');
+  const to = search.get('to');
+  if (from && to) return { from: new Date(from), to: new Date(to) };
+  const dates = rentLedger.map((r) => r.dueDate).sort();
+  const latest = dates[dates.length - 1];
+  const toDate = latest ? new Date(latest) : new Date();
+  const fromDate = new Date(toDate);
+  fromDate.setMonth(fromDate.getMonth() - 5);
+  fromDate.setDate(1);
+  return { from: fromDate, to: toDate };
+}
+
+export function computeRentMetrics(params: {
+  from?: Date;
+  to?: Date;
+  propertyId?: string;
+}): RentMetrics {
+  const { from, to, propertyId } = params;
+  const fromDate = from || new Date('1970-01-01');
+  const toDate = to || new Date('2100-01-01');
+  const allowed = propertyId
+    ? [propertyId]
+    : properties.filter(isActiveProperty).map((p) => p.id);
+
+  const entries = rentLedger.filter(
+    (e) =>
+      allowed.includes(e.propertyId) &&
+      new Date(e.dueDate) >= fromDate &&
+      new Date(e.dueDate) <= toDate,
+  );
+
+  const expected = entries.reduce((sum, e) => sum + e.amount, 0);
+  const received = entries
+    .filter((e) => e.status === 'paid' && new Date(e.paidDate || e.dueDate) >= fromDate && new Date(e.paidDate || e.dueDate) <= toDate)
+    .reduce((sum, e) => sum + e.amount, 0);
+  const arrearsEntries = entries.filter((e) => e.status !== 'paid');
+  const arrearsAmount = arrearsEntries.reduce((s, e) => s + e.amount, 0);
+  const arrearsCount = arrearsEntries.length;
+  const collectionRate = expected ? received / expected : 0;
+  return { expected, received, collectionRate, arrearsAmount, arrearsCount };
+}
+
+export async function GET(req: Request) {
+  seedIfEmpty();
+  const { searchParams } = new URL(req.url);
+  const { from, to } = getRange(searchParams);
+  const propertyId = searchParams.get('propertyId') || undefined;
+  const data = computeRentMetrics({ from, to, propertyId });
+  return Response.json(data);
+}

--- a/app/api/store.ts
+++ b/app/api/store.ts
@@ -135,6 +135,33 @@ const initialExpenses: Expense[] = [
     gst: 20,
   },
   {
+    id: 'exp6',
+    propertyId: '1',
+    date: '2024-04-12',
+    category: 'Gardening & landscaping',
+    vendor: 'GreenThumb',
+    amount: 180,
+    gst: 25,
+  },
+  {
+    id: 'exp7',
+    propertyId: '1',
+    date: '2024-05-18',
+    category: 'Electrical',
+    vendor: 'Sparky Ltd',
+    amount: 220,
+    gst: 30,
+  },
+  {
+    id: 'exp8',
+    propertyId: '1',
+    date: '2024-06-05',
+    category: 'General repairs',
+    vendor: 'Handyman Co',
+    amount: 160,
+    gst: 24,
+  },
+  {
     id: 'exp4',
     propertyId: '2',
     date: '2024-04-01',
@@ -151,6 +178,42 @@ const initialExpenses: Expense[] = [
     vendor: 'Cleaners Ltd',
     amount: 300,
     gst: 45,
+  },
+  {
+    id: 'exp9',
+    propertyId: '2',
+    date: '2024-01-20',
+    category: 'Council rates',
+    vendor: 'City Council',
+    amount: 800,
+    gst: 0,
+  },
+  {
+    id: 'exp10',
+    propertyId: '2',
+    date: '2024-02-14',
+    category: 'Plumbing',
+    vendor: 'Plumber Co',
+    amount: 120,
+    gst: 18,
+  },
+  {
+    id: 'exp11',
+    propertyId: '2',
+    date: '2024-03-22',
+    category: 'Landlord insurance',
+    vendor: 'Insurance Co',
+    amount: 400,
+    gst: 0,
+  },
+  {
+    id: 'exp12',
+    propertyId: '2',
+    date: '2024-06-10',
+    category: 'Miscellaneous',
+    vendor: 'Misc Vendor',
+    amount: 100,
+    gst: 15,
   },
 ];
 
@@ -240,8 +303,18 @@ const initialReminders: Reminder[] = [
 ];
 
 const initialRentLedger: RentEntry[] = [
-  { id: 'rent1', propertyId: '1', tenantId: 'tenant1', amount: 1200, dueDate: '2024-05-01', status: 'paid', paidDate: '2024-05-01' },
-  { id: 'rent2', propertyId: '1', tenantId: 'tenant1', amount: 1200, dueDate: '2024-06-01', status: 'late' },
+  { id: 'rent1-jan', propertyId: '1', tenantId: 'tenant1', amount: 1200, dueDate: '2024-01-01', status: 'paid', paidDate: '2024-01-01' },
+  { id: 'rent1-feb', propertyId: '1', tenantId: 'tenant1', amount: 1200, dueDate: '2024-02-01', status: 'paid', paidDate: '2024-02-01' },
+  { id: 'rent1-mar', propertyId: '1', tenantId: 'tenant1', amount: 1200, dueDate: '2024-03-01', status: 'paid', paidDate: '2024-03-01' },
+  { id: 'rent1-apr', propertyId: '1', tenantId: 'tenant1', amount: 1200, dueDate: '2024-04-01', status: 'paid', paidDate: '2024-04-01' },
+  { id: 'rent1-may', propertyId: '1', tenantId: 'tenant1', amount: 1200, dueDate: '2024-05-01', status: 'paid', paidDate: '2024-05-01' },
+  { id: 'rent1-jun', propertyId: '1', tenantId: 'tenant1', amount: 1200, dueDate: '2024-06-01', status: 'paid', paidDate: '2024-06-01' },
+  { id: 'rent2-jan', propertyId: '2', tenantId: 'tenant2', amount: 950, dueDate: '2024-01-01', status: 'paid', paidDate: '2024-01-01' },
+  { id: 'rent2-feb', propertyId: '2', tenantId: 'tenant2', amount: 950, dueDate: '2024-02-01', status: 'paid', paidDate: '2024-02-01' },
+  { id: 'rent2-mar', propertyId: '2', tenantId: 'tenant2', amount: 950, dueDate: '2024-03-01', status: 'paid', paidDate: '2024-03-01' },
+  { id: 'rent2-apr', propertyId: '2', tenantId: 'tenant2', amount: 950, dueDate: '2024-04-01', status: 'paid', paidDate: '2024-04-01' },
+  { id: 'rent2-may', propertyId: '2', tenantId: 'tenant2', amount: 950, dueDate: '2024-05-01', status: 'paid', paidDate: '2024-05-01' },
+  { id: 'rent2-jun', propertyId: '2', tenantId: 'tenant2', amount: 950, dueDate: '2024-06-01', status: 'late' },
 ];
 
 const initialTenantNotes: TenantNote[] = [
@@ -319,6 +392,14 @@ export const resetStore = () => {
   (Object.keys(store) as (keyof Store)[]).forEach((key) => {
     // mutate arrays in place so imported references stay valid
     store[key].length = 0;
+    store[key].push(...fresh[key]);
+  });
+};
+
+export const seedIfEmpty = () => {
+  if (properties.length > 0) return;
+  const fresh = initStore();
+  (Object.keys(store) as (keyof Store)[]).forEach((key) => {
     store[key].push(...fresh[key]);
   });
 };

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -35,6 +35,21 @@ export default function Sidebar() {
       ),
     },
     {
+      href: "/analytics",
+      label: "Analytics",
+      icon: (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="h-6 w-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 3v18M6 8v13M16 13v8" />
+        </svg>
+      ),
+    },
+    {
       href: "/properties",
       label: "Properties",
       icon: (

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -61,6 +61,39 @@ export const zPnlSummary = z.object({
   }),
 });
 
+export const zPnlSeries = z.object({
+  series: z.array(zPnlPoint),
+  totals: z.object({
+    income: z.number(),
+    expenses: z.number(),
+    net: z.number(),
+  }),
+});
+
+export const zRentMetrics = z.object({
+  expected: z.number(),
+  received: z.number(),
+  collectionRate: z.number(),
+  arrearsCount: z.number(),
+  arrearsAmount: z.number(),
+});
+
+export const zExpenseSlice = z.object({
+  category: z.string(),
+  amount: z.number(),
+});
+
+export const zExpenseBreakdown = z.object({
+  slices: z.array(zExpenseSlice),
+  total: z.number(),
+});
+
+export const zOccupancy = z.object({
+  occupiedDays: z.number(),
+  vacantDays: z.number(),
+  occupancyRate: z.number(),
+});
+
 export const zReminder = z.object({
   id: z.string(),
   propertyId: z.string(),

--- a/tests/analytics.spec.ts
+++ b/tests/analytics.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+
+test('analytics page loads and KPIs render', async ({ page }) => {
+  await page.goto('/analytics');
+  await expect(page.getByTestId('kpi-net')).toBeVisible();
+  await expect(page.getByTestId('kpi-collection')).toBeVisible();
+});
+
+test('pnl series provides multiple points', async ({ request }) => {
+  const res = await request.get('/api/analytics/pnl');
+  const data = await res.json();
+  expect(data.series.length).toBeGreaterThan(3);
+});
+
+test('expense breakdown has categories', async ({ request }) => {
+  const res = await request.get('/api/analytics/expenses');
+  const data = await res.json();
+  expect(data.slices.length).toBeGreaterThanOrEqual(3);
+});
+
+test('export csv endpoints respond', async ({ request }) => {
+  for (const path of ['/api/analytics/export/pnl.csv', '/api/analytics/export/expenses.csv', '/api/analytics/export/rent.csv']) {
+    const res = await request.get(path);
+    expect(res.status()).toBe(200);
+    const text = await res.text();
+    expect(text.length).toBeGreaterThan(10);
+  }
+});

--- a/types/analytics.ts
+++ b/types/analytics.ts
@@ -1,0 +1,6 @@
+export type PnLPoint = { month: string; income: number; expenses: number; net: number };
+export type PnLSeries = { series: PnLPoint[]; totals: { income: number; expenses: number; net: number } };
+export type RentMetrics = { expected: number; received: number; collectionRate: number; arrearsCount: number; arrearsAmount: number };
+export type ExpenseSlice = { category: string; amount: number };
+export type ExpenseBreakdown = { slices: ExpenseSlice[]; total: number };
+export type Occupancy = { occupiedDays: number; vacantDays: number; occupancyRate: number };


### PR DESCRIPTION
## Summary
- add analytics API endpoints for P&L, rent collection, occupancy and expenses with CSV export
- introduce analytics UI with KPI tiles, charts and CSV downloads
- seed store with richer expenses and rent ledger data and link analytics in sidebar/dashboard

## Testing
- `npm test tests/analytics.spec.ts` *(fails: playwright: not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bec275fd90832cacd3828b2e6c1ae9