### PR TITLE
feat: interactive task list skeleton

### DIFF
--- a/app/(app)/tasks/page.tsx
+++ b/app/(app)/tasks/page.tsx
@@ -1,23 +1,12 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
-import { listTasks } from "../../../lib/api";
-import type { TaskDto } from "../../../types/tasks";
+import TaskList from "../../../components/tasks/TaskList";
 
 export default function TasksPage() {
-  const { data: tasks = [] } = useQuery<TaskDto[]>({
-    queryKey: ["tasks"],
-    queryFn: () => listTasks(),
-  });
-
   return (
     <div className="p-6 space-y-4">
       <h1 className="text-2xl font-semibold">Tasks</h1>
-      <ul className="list-disc pl-6">
-        {tasks.map((t) => (
-          <li key={t.id}>{t.title}</li>
-        ))}
-      </ul>
+      <TaskList />
     </div>
   );
 }

--- a/app/api/tasks/[id]/complete/route.ts
+++ b/app/api/tasks/[id]/complete/route.ts
@@ -1,9 +1,7 @@
-import { tasks } from '../../../store';
+import { completeTask } from '../../../store';
 
 export async function POST(_req: Request, { params }: { params: { id: string } }) {
-  const task = tasks.find((t) => t.id === params.id);
+  const task = completeTask(params.id);
   if (!task) return new Response('Not found', { status: 404 });
-  task.status = 'done';
-  task.updatedAt = new Date().toISOString();
   return Response.json(task);
 }

--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -1,26 +1,23 @@
-import { tasks } from '../../store';
+import { getTask, updateTask, deleteTask } from '../../store';
 import { zTask } from '../../../../lib/validation';
+import type { TaskDto } from '../../../../types/tasks';
 
 export async function GET(_req: Request, { params }: { params: { id: string } }) {
-  const task = tasks.find((t) => t.id === params.id);
+  const task = getTask(params.id);
   if (!task) return new Response('Not found', { status: 404 });
   return Response.json(task);
 }
 
 export async function PATCH(req: Request, { params }: { params: { id: string } }) {
-  const idx = tasks.findIndex((t) => t.id === params.id);
-  if (idx === -1) return new Response('Not found', { status: 404 });
   const body = await req.json();
   const parsed = zTask.partial().parse(body);
-  const task = tasks[idx];
-  Object.assign(task, parsed);
-  task.updatedAt = new Date().toISOString();
+  const task = updateTask(params.id, parsed as Partial<TaskDto>);
+  if (!task) return new Response('Not found', { status: 404 });
   return Response.json(task);
 }
 
 export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
-  const idx = tasks.findIndex((t) => t.id === params.id);
-  if (idx === -1) return new Response('Not found', { status: 404 });
-  tasks.splice(idx, 1);
+  const ok = deleteTask(params.id);
+  if (!ok) return new Response('Not found', { status: 404 });
   return new Response(null, { status: 204 });
 }

--- a/app/api/tasks/bulk/route.ts
+++ b/app/api/tasks/bulk/route.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+import { listTasks, completeTask, deleteTask, updateTask } from '../../store';
+import type { TaskDto } from '../../../../types/tasks';
+
+const bulkSchema = z.object({
+  ids: z.array(z.string()),
+  op: z.enum(['complete','delete','status','priority','assignProperties']),
+  status: z.enum(['todo','in_progress','blocked','done']).optional(),
+  priority: z.enum(['low','normal','high']).optional(),
+  properties: z
+    .array(z.object({ id: z.string(), address: z.string() }))
+    .optional(),
+});
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const parsed = bulkSchema.parse(body);
+  for (const id of parsed.ids) {
+    switch (parsed.op) {
+      case 'complete':
+        completeTask(id);
+        break;
+      case 'delete':
+        deleteTask(id);
+        break;
+      case 'status':
+        if (parsed.status) updateTask(id, { status: parsed.status });
+        break;
+      case 'priority':
+        if (parsed.priority) updateTask(id, { priority: parsed.priority });
+        break;
+      case 'assignProperties':
+        if (parsed.properties)
+          updateTask(id, { properties: parsed.properties as TaskDto['properties'] });
+        break;
+    }
+  }
+  return Response.json(listTasks());
+}

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -1,62 +1,24 @@
-import { tasks } from '../store';
+import { listTasks, createTask } from '../store';
 import { zTask } from '../../../lib/validation';
 import type { TaskDto } from '../../../types/tasks';
 
 export async function GET(req: Request) {
   const url = new URL(req.url);
-  let data = [...tasks];
-
-  const propertyId = url.searchParams.get('propertyId');
-  const cadence = url.searchParams.get('cadence');
-  const status = url.searchParams.get('status');
-  const from = url.searchParams.get('from');
-  const to = url.searchParams.get('to');
-  const search = url.searchParams.get('search');
-
-  if (propertyId) {
-    data = data.filter((t) => t.properties.some((p) => p.id === propertyId));
-  }
-  if (cadence) {
-    data = data.filter((t) => t.cadence === cadence);
-  }
-  if (status) {
-    data = data.filter((t) => t.status === status);
-  }
-  if (from || to) {
-    const fromTime = from ? Date.parse(from) : undefined;
-    const toTime = to ? Date.parse(to) : undefined;
-    data = data.filter((t) => {
-      const start = t.startDate || t.dueDate;
-      const end = t.endDate || t.dueDate;
-      const s = start ? Date.parse(start) : undefined;
-      const e = end ? Date.parse(end) : undefined;
-      if (fromTime && e && e < fromTime) return false;
-      if (toTime && s && s > toTime) return false;
-      return true;
-    });
-  }
-  if (search) {
-    const s = search.toLowerCase();
-    data = data.filter(
-      (t) =>
-        t.title.toLowerCase().includes(s) ||
-        (t.description ? t.description.toLowerCase().includes(s) : false)
-    );
-  }
-
+  const data = listTasks({
+    propertyId: url.searchParams.get('propertyId') || undefined,
+    status: url.searchParams.get('status') || undefined,
+    cadence: url.searchParams.get('cadence') || undefined,
+    q: url.searchParams.get('q') || undefined,
+    from: url.searchParams.get('from') || undefined,
+    to: url.searchParams.get('to') || undefined,
+    parentId: url.searchParams.get('parentId') || undefined,
+  });
   return Response.json(data);
 }
 
 export async function POST(req: Request) {
   const body = await req.json();
-  const parsed = zTask.parse(body);
-  const now = new Date().toISOString();
-  const task: TaskDto = {
-    ...parsed,
-    id: crypto.randomUUID(),
-    createdAt: now,
-    updatedAt: now,
-  };
-  tasks.push(task);
+  const parsed = zTask.parse(body) as TaskDto;
+  const task = createTask(parsed);
   return Response.json(task, { status: 201 });
 }

--- a/components/tasks/TaskList.tsx
+++ b/components/tasks/TaskList.tsx
@@ -1,0 +1,52 @@
+"use client";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { listTasks, createTask, updateTask, deleteTask, completeTask, listProperties } from "../../lib/api";
+import type { TaskDto } from "../../types/tasks";
+import TaskRow from "./TaskRow";
+import TaskQuickNew from "./TaskQuickNew";
+
+export default function TaskList() {
+  const qc = useQueryClient();
+  const { data: tasks = [] } = useQuery<TaskDto[]>({
+    queryKey: ["tasks"],
+    queryFn: () => listTasks(),
+  });
+  const { data: properties = [] } = useQuery({
+    queryKey: ["properties"],
+    queryFn: () => listProperties(),
+  });
+  const defaultProp = properties[0];
+
+  const createMut = useMutation({
+    mutationFn: (title: string) =>
+      createTask({ title, properties: defaultProp ? [{ id: defaultProp.id, address: defaultProp.address }] : [] }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["tasks"] }),
+  });
+  const updateMut = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: Partial<TaskDto> }) => updateTask(id, data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["tasks"] }),
+  });
+  const deleteMut = useMutation({
+    mutationFn: (id: string) => deleteTask(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["tasks"] }),
+  });
+  const completeMut = useMutation({
+    mutationFn: (id: string) => completeTask(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["tasks"] }),
+  });
+
+  return (
+    <div className="space-y-2">
+      <TaskQuickNew onCreate={(title) => createMut.mutate(title)} />
+      {tasks.map((t) => (
+        <TaskRow
+          key={t.id}
+          task={t}
+          onUpdate={(data) => updateMut.mutate({ id: t.id, data })}
+          onDelete={() => deleteMut.mutate(t.id)}
+          onToggle={() => completeMut.mutate(t.id)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/components/tasks/TaskPropertiesMenu.tsx
+++ b/components/tasks/TaskPropertiesMenu.tsx
@@ -1,0 +1,4 @@
+"use client";
+export default function TaskPropertiesMenu() {
+  return null;
+}

--- a/components/tasks/TaskQuickNew.tsx
+++ b/components/tasks/TaskQuickNew.tsx
@@ -1,0 +1,21 @@
+"use client";
+import { useState } from "react";
+
+export default function TaskQuickNew({ onCreate }: { onCreate: (title: string) => void }) {
+  const [title, setTitle] = useState("");
+  const handleKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && title.trim()) {
+      onCreate(title.trim());
+      setTitle("");
+    }
+  };
+  return (
+    <input
+      className="w-full border rounded p-2 mb-2"
+      placeholder="+ New task"
+      value={title}
+      onChange={(e) => setTitle(e.target.value)}
+      onKeyDown={handleKey}
+    />
+  );
+}

--- a/components/tasks/TaskRecurrencePopover.tsx
+++ b/components/tasks/TaskRecurrencePopover.tsx
@@ -1,0 +1,4 @@
+"use client";
+export default function TaskRecurrencePopover() {
+  return null;
+}

--- a/components/tasks/TaskRow.tsx
+++ b/components/tasks/TaskRow.tsx
@@ -1,0 +1,47 @@
+"use client";
+import { useState } from "react";
+import PropertyBadge from "../PropertyBadge";
+import type { TaskDto } from "../../types/tasks";
+
+export default function TaskRow({
+  task,
+  onUpdate,
+  onDelete,
+  onToggle,
+}: {
+  task: TaskDto;
+  onUpdate: (data: Partial<TaskDto>) => void;
+  onDelete: () => void;
+  onToggle: () => void;
+}) {
+  const [title, setTitle] = useState(task.title);
+  const handleBlur = () => {
+    if (title !== task.title) onUpdate({ title });
+  };
+  return (
+    <div className="flex items-start gap-2 p-2 border rounded">
+      <input
+        type="checkbox"
+        checked={task.status === "done"}
+        onChange={onToggle}
+        className="mt-1"
+      />
+      <div className="flex-1">
+        <input
+          className="w-full bg-transparent outline-none"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          onBlur={handleBlur}
+        />
+        <div className="flex flex-wrap gap-1 mt-1">
+          {task.properties.map((p) => (
+            <PropertyBadge key={p.id} address={p.address} />
+          ))}
+        </div>
+      </div>
+      <button onClick={onDelete} className="text-xs text-red-500">
+        ✕
+      </button>
+    </div>
+  );
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -378,7 +378,8 @@ export const listTasks = (params?: {
   status?: string;
   from?: string;
   to?: string;
-  search?: string;
+  q?: string;
+  parentId?: string;
 }) => {
   const query = params
     ? new URLSearchParams(
@@ -397,3 +398,5 @@ export const deleteTask = (id: string) =>
   api(`/tasks/${id}`, { method: 'DELETE' });
 export const completeTask = (id: string) =>
   api<TaskDto>(`/tasks/${id}/complete`, { method: 'POST' });
+export const bulkTasks = (payload: any) =>
+  api<TaskDto[]>('/tasks/bulk', { method: 'POST', body: JSON.stringify(payload) });

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -112,34 +112,35 @@ export const zReminder = z.object({
 
 export const zReminders = z.array(zReminder);
 
-export const zTaskCadence = z.enum(['Immediate','Weekly','Monthly','Yearly','Custom']);
-export const zTaskStatus = z.enum(['todo','in_progress','blocked','done']);
-export const zTaskPriority = z.enum(['low','normal','high']);
-
-export const zTaskRecurrence = z.object({
-  freq: z.enum(['WEEKLY','MONTHLY','YEARLY','CUSTOM']).nullable(),
-  interval: z.number().int().positive().optional(),
-  byDay: z.array(z.string()).optional(),
-  byMonthDay: z.array(z.number().int()).optional(),
-  rrule: z.string().optional(),
-}).nullable();
-
 export const zTask = z.object({
   id: z.string().optional(),
   title: z.string().min(1),
   description: z.string().optional(),
-  cadence: zTaskCadence,
-  dueDate: z.string().optional(),    // ISO
+  status: z.enum(['todo','in_progress','blocked','done']).default('todo'),
+  priority: z.enum(['low','normal','high']).default('normal'),
+  cadence: z.enum(['Immediate','Weekly','Monthly','Yearly','Custom']).default('Immediate'),
+  dueDate: z.string().optional(),
   startDate: z.string().optional(),
   endDate: z.string().optional(),
-  recurrence: zTaskRecurrence,
+  recurrence: z
+    .object({
+      freq: z.enum(['DAILY','WEEKLY','MONTHLY','YEARLY','CUSTOM']).nullable(),
+      interval: z.number().int().positive().optional(),
+      byDay: z.array(z.string()).optional(),
+      byMonthDay: z.array(z.number().int()).optional(),
+      rrule: z.string().optional(),
+      endsOn: z.string().nullable().optional(),
+    })
+    .nullable()
+    .optional(),
   properties: z.array(z.object({ id: z.string(), address: z.string() })).min(1),
-  status: zTaskStatus.default('todo'),
-  priority: zTaskPriority.default('normal'),
   tags: z.array(z.string()).optional(),
+  attachments: z
+    .array(z.object({ name: z.string(), url: z.string() }))
+    .optional(),
+  parentId: z.string().nullable().optional(),
   createdAt: z.string().optional(),
   updatedAt: z.string().optional(),
-  reminderId: z.string().nullable().optional(),
 });
 
 export const zTasks = z.array(zTask);

--- a/types/tasks.ts
+++ b/types/tasks.ts
@@ -1,29 +1,29 @@
 export type TaskCadence = 'Immediate'|'Weekly'|'Monthly'|'Yearly'|'Custom';
-export type TaskStatus = 'todo'|'in_progress'|'blocked'|'done';
+export type TaskStatus  = 'todo'|'in_progress'|'blocked'|'done';
 export type TaskPriority = 'low'|'normal'|'high';
+
 export type TaskDto = {
   id: string;
   title: string;
   description?: string;
-  cadence: TaskCadence;
-  // Single due date OR a date window for Gantt (start/end)
-  dueDate?: string;       // ISO
-  startDate?: string;     // ISO (optional, for Gantt)
-  endDate?: string;       // ISO (optional, for Gantt)
+  status: TaskStatus;            // checkbox maps todo/done
+  priority: TaskPriority;
+  cadence: TaskCadence;          // bucket for later Kanban
+  dueDate?: string;              // ISO
+  startDate?: string;            // for Gantt (optional)
+  endDate?: string;              // for Gantt (optional)
   recurrence?: {
-    // For Weekly/Monthly/Yearly or Custom RRULE-like
-    freq: 'WEEKLY'|'MONTHLY'|'YEARLY'|'CUSTOM'|null;
-    interval?: number; // e.g., every 2 weeks
-    byDay?: string[];  // ['MO','FR'] if weekly
-    byMonthDay?: number[]; // [1,15] if monthly
-    rrule?: string; // optional raw string if CUSTOM
+    freq: 'DAILY'|'WEEKLY'|'MONTHLY'|'YEARLY'|'CUSTOM'|null;
+    interval?: number;           // every N units
+    byDay?: string[];            // ['MO','FR'] etc
+    byMonthDay?: number[];       // [1,15]
+    rrule?: string;              // raw string if CUSTOM
+    endsOn?: string | null;      // ISO date limit
   } | null;
   properties: { id: string; address: string }[]; // 1..n properties
-  status: TaskStatus;
-  priority: TaskPriority;
-  tags?: string[];       // arbitrary labels
+  tags?: string[];
+  attachments?: { name: string; url: string }[];
+  parentId?: string | null;      // for subtasks
   createdAt: string;
   updatedAt: string;
-  // linkage to reminders (optional)
-  reminderId?: string | null;
 };


### PR DESCRIPTION
## Summary
- define richer `TaskDto` type and Zod schema
- add in-memory task operations and REST endpoints, including bulk actions
- replace Tasks page with interactive list and quick create

## Testing
- `npm run test:unit` *(fails: vitest not found)*
- `npm test` *(fails: playwright not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing type deps)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6560c0a4832c98882ae33e8ccfed