### PR TITLE
feat: add customizable Kanban board for tasks

### DIFF
--- a/app/(app)/tasks/page.tsx
+++ b/app/(app)/tasks/page.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import TaskList from "../../../components/tasks/TaskList";
+import TasksKanban from "../../../components/tasks/TasksKanban";
 
 export default function TasksPage() {
   return (
     <div className="p-6 space-y-4">
       <h1 className="text-2xl font-semibold">Tasks</h1>
-      <TaskList />
+      <TasksKanban />
     </div>
   );
 }

--- a/components/tasks/TasksKanban.tsx
+++ b/components/tasks/TasksKanban.tsx
@@ -1,14 +1,207 @@
 "use client";
-import React from "react";
+import { useState, useEffect } from "react";
+import {
+  DragDropContext,
+  Droppable,
+  Draggable,
+  type DropResult,
+} from "@hello-pangea/dnd";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  listTasks,
+  createTask,
+  updateTask,
+  deleteTask,
+  listProperties,
+} from "../../lib/api";
 import type { TaskDto } from "../../types/tasks";
 import TaskCard from "./TaskCard";
+import TaskQuickNew from "./TaskQuickNew";
 
-export default function TasksKanban({ tasks }: { tasks: TaskDto[] }) {
+type Column = { id: string; title: string };
+
+const DEFAULT_COLUMNS: Column[] = [
+  { id: "todo", title: "ASAP" },
+  { id: "in_progress", title: "Soon" },
+  { id: "blocked", title: "Later" },
+  { id: "done", title: "Done" },
+];
+
+const STORAGE_KEY = "task-columns";
+
+export default function TasksKanban() {
+  const qc = useQueryClient();
+  const { data: tasks = [] } = useQuery<TaskDto[]>({
+    queryKey: ["tasks"],
+    queryFn: () => listTasks(),
+  });
+  const { data: properties = [] } = useQuery({
+    queryKey: ["properties"],
+    queryFn: () => listProperties(),
+  });
+  const defaultProp = properties[0];
+
+  const createMut = useMutation({
+    mutationFn: ({ title, status }: { title: string; status: string }) =>
+      createTask({
+        title,
+        status,
+        properties: defaultProp
+          ? [{ id: defaultProp.id, address: defaultProp.address }]
+          : [],
+      }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["tasks"] }),
+  });
+  const updateMut = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: Partial<TaskDto> }) =>
+      updateTask(id, data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["tasks"] }),
+  });
+  const deleteMut = useMutation({
+    mutationFn: (id: string) => deleteTask(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["tasks"] }),
+  });
+
+  const [columns, setColumns] = useState<Column[]>([]);
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) setColumns(JSON.parse(stored));
+    else setColumns(DEFAULT_COLUMNS);
+  }, []);
+  useEffect(() => {
+    if (columns.length) localStorage.setItem(STORAGE_KEY, JSON.stringify(columns));
+  }, [columns]);
+
+  const handleDragEnd = (result: DropResult) => {
+    const { destination, source, draggableId } = result;
+    if (!destination) return;
+    if (
+      destination.droppableId === source.droppableId &&
+      destination.index === source.index
+    )
+      return;
+    updateMut.mutate({ id: draggableId, data: { status: destination.droppableId } });
+  };
+
+  const addColumn = () => {
+    const title = prompt("Column name");
+    if (!title) return;
+    const id = title.toLowerCase().replace(/\s+/g, "_");
+    setColumns([...columns, { id, title }]);
+  };
+
+  const renameColumn = (id: string) => {
+    const col = columns.find((c) => c.id === id);
+    if (!col) return;
+    const title = prompt("New name", col.title);
+    if (!title) return;
+    setColumns(columns.map((c) => (c.id === id ? { ...c, title } : c)));
+  };
+
+  const deleteColumn = (id: string) => {
+    if (!confirm("Delete column and move tasks to first column?")) return;
+    const fallback = columns[0]?.id || "todo";
+    setColumns(columns.filter((c) => c.id !== id));
+    tasks
+      .filter((t) => t.status === id)
+      .forEach((t) =>
+        updateMut.mutate({ id: t.id, data: { status: fallback } })
+      );
+  };
+
   return (
-    <div className="space-y-2">
-      {tasks.map((t) => (
-        <TaskCard key={t.id} task={t} />
-      ))}
+    <div className="flex gap-4 overflow-x-auto p-1">
+      <DragDropContext onDragEnd={handleDragEnd}>
+        {columns.map((col) => (
+          <div key={col.id} className="w-64 flex-shrink-0">
+            <div className="flex items-center justify-between mb-2">
+              <h2 className="font-semibold">{col.title}</h2>
+              <div className="space-x-1">
+                <button
+                  onClick={() => renameColumn(col.id)}
+                  className="text-xs text-blue-500"
+                >
+                  ✎
+                </button>
+                <button
+                  onClick={() => deleteColumn(col.id)}
+                  className="text-xs text-red-500"
+                >
+                  ✕
+                </button>
+              </div>
+            </div>
+            <Droppable droppableId={col.id}>
+              {(provided) => (
+                <div
+                  ref={provided.innerRef}
+                  {...provided.droppableProps}
+                  className="min-h-[100px] space-y-2"
+                >
+                  {tasks
+                    .filter((t) => t.status === col.id)
+                    .map((task, idx) => (
+                      <Draggable
+                        key={task.id}
+                        draggableId={task.id}
+                        index={idx}
+                      >
+                        {(prov) => (
+                          <div
+                            ref={prov.innerRef}
+                            {...prov.draggableProps}
+                            {...prov.dragHandleProps}
+                          >
+                            <TaskCard task={task} />
+                            <div className="flex justify-end gap-1 text-xs mt-1">
+                              <button
+                                onClick={() => {
+                                  const title = prompt(
+                                    "Edit task",
+                                    task.title
+                                  );
+                                  if (title)
+                                    updateMut.mutate({
+                                      id: task.id,
+                                      data: { title },
+                                    });
+                                }}
+                                className="text-blue-500"
+                              >
+                                ✎
+                              </button>
+                              <button
+                                onClick={() => deleteMut.mutate(task.id)}
+                                className="text-red-500"
+                              >
+                                🗑
+                              </button>
+                            </div>
+                          </div>
+                        )}
+                      </Draggable>
+                    ))}
+                  {provided.placeholder}
+                </div>
+              )}
+            </Droppable>
+            <TaskQuickNew
+              onCreate={(title) =>
+                createMut.mutate({ title, status: col.id })
+              }
+            />
+          </div>
+        ))}
+      </DragDropContext>
+      <div className="w-64 flex-shrink-0">
+        <button
+          onClick={addColumn}
+          className="w-full border rounded p-2 text-sm"
+        >
+          + Add Column
+        </button>
+      </div>
     </div>
   );
 }
+

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -116,7 +116,8 @@ export const zTask = z.object({
   id: z.string().optional(),
   title: z.string().min(1),
   description: z.string().optional(),
-  status: z.enum(['todo','in_progress','blocked','done']).default('todo'),
+  // Accept any string so additional columns can be created on the Kanban board
+  status: z.string().default('todo'),
   priority: z.enum(['low','normal','high']).default('normal'),
   cadence: z.enum(['Immediate','Weekly','Monthly','Yearly','Custom']).default('Immediate'),
   dueDate: z.string().optional(),

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "react-dom": "18.2.0",
     "@tanstack/react-query": "^5.0.0",
     "zod": "^3.23.0",
-    "recharts": "^2.8.0"
+    "recharts": "^2.8.0",
+    "@hello-pangea/dnd": "^15.2.0"
   },
   "devDependencies": {
     "prisma": "^5.13.0",

--- a/types/tasks.ts
+++ b/types/tasks.ts
@@ -1,5 +1,6 @@
 export type TaskCadence = 'Immediate'|'Weekly'|'Monthly'|'Yearly'|'Custom';
-export type TaskStatus  = 'todo'|'in_progress'|'blocked'|'done';
+// Allow arbitrary statuses so users can create custom columns in the Kanban board
+export type TaskStatus  = string;
 export type TaskPriority = 'low'|'normal'|'high';
 
 export type TaskDto = {


### PR DESCRIPTION
## Summary
- replace simple task list with a drag-and-drop Kanban board
- allow custom column names persisted in local storage
- support creating, editing, moving and deleting tasks across columns

## Testing
- `npm run test:unit` *(fails: vitest not found)*
- `npm test` *(fails: playwright not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bfb32a8bac832cbc6934940aa0fcb7