### PR TITLE
feat: add task edit modal

### DIFF
--- a/components/tasks/TaskCard.tsx
+++ b/components/tasks/TaskCard.tsx
@@ -2,9 +2,18 @@
 import React from "react";
 import type { TaskDto } from "../../types/tasks";
 
-export default function TaskCard({ task }: { task: TaskDto }) {
+export default function TaskCard({
+  task,
+  onClick,
+}: {
+  task: TaskDto;
+  onClick?: () => void;
+}) {
   return (
-    <div className="border rounded p-2">
+    <div
+      className={`border rounded p-2 ${onClick ? "cursor-pointer" : ""}`}
+      onClick={onClick}
+    >
       <div className="font-medium">{task.title}</div>
     </div>
   );

--- a/components/tasks/TaskEditModal.tsx
+++ b/components/tasks/TaskEditModal.tsx
@@ -1,0 +1,70 @@
+"use client";
+import { useState, useEffect } from "react";
+import type { TaskDto } from "../../types/tasks";
+
+export default function TaskEditModal({
+  task,
+  onClose,
+  onSave,
+}: {
+  task: TaskDto;
+  onClose: () => void;
+  onSave: (data: Partial<TaskDto>) => void;
+}) {
+  const [title, setTitle] = useState(task.title);
+  const [description, setDescription] = useState(task.description ?? "");
+  const [dueDate, setDueDate] = useState(task.dueDate ?? "");
+
+  useEffect(() => {
+    setTitle(task.title);
+    setDescription(task.description ?? "");
+    setDueDate(task.dueDate ?? "");
+  }, [task]);
+
+  const handleSave = () => {
+    onSave({
+      title,
+      description,
+      dueDate: dueDate || undefined,
+    });
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="w-80 rounded bg-white p-4 shadow dark:bg-gray-800 space-y-2">
+        <h2 className="text-lg font-semibold">Edit Task</h2>
+        <input
+          className="w-full rounded border p-1"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+        <textarea
+          className="w-full rounded border p-1"
+          placeholder="Notes"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+        <label className="block text-sm">
+          Due date
+          <input
+            type="date"
+            className="w-full rounded border p-1"
+            value={dueDate}
+            onChange={(e) => setDueDate(e.target.value)}
+          />
+        </label>
+        <div className="flex justify-end gap-2 pt-2">
+          <button onClick={onClose} className="px-2 py-1 text-gray-600">
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            className="rounded bg-blue-500 px-2 py-1 text-white"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/tasks/TasksKanban.tsx
+++ b/components/tasks/TasksKanban.tsx
@@ -17,6 +17,7 @@ import {
 import type { TaskDto } from "../../types/tasks";
 import TaskCard from "./TaskCard";
 import TaskQuickNew from "./TaskQuickNew";
+import TaskEditModal from "./TaskEditModal";
 
 type Column = { id: string; title: string };
 
@@ -61,6 +62,8 @@ export default function TasksKanban() {
     mutationFn: (id: string) => deleteTask(id),
     onSuccess: () => qc.invalidateQueries({ queryKey: ["tasks"] }),
   });
+  const [editingTask, setEditingTask] = useState<TaskDto | null>(null);
+
 
   const [columns, setColumns] = useState<Column[]>([]);
   useEffect(() => {
@@ -109,7 +112,7 @@ export default function TasksKanban() {
       );
   };
 
-  return (
+  return (<>
     <div className="flex gap-4 overflow-x-auto p-1">
       <DragDropContext onDragEnd={handleDragEnd}>
         {columns.map((col) => (
@@ -152,20 +155,10 @@ export default function TasksKanban() {
                             {...prov.draggableProps}
                             {...prov.dragHandleProps}
                           >
-                            <TaskCard task={task} />
+                             <TaskCard task={task} onClick={() => setEditingTask(task)} />
                             <div className="flex justify-end gap-1 text-xs mt-1">
                               <button
-                                onClick={() => {
-                                  const title = prompt(
-                                    "Edit task",
-                                    task.title
-                                  );
-                                  if (title)
-                                    updateMut.mutate({
-                                      id: task.id,
-                                      data: { title },
-                                    });
-                                }}
+                                onClick={() => setEditingTask(task)}
                                 className="text-blue-500"
                               >
                                 ✎
@@ -201,7 +194,18 @@ export default function TasksKanban() {
           + Add Column
         </button>
       </div>
-    </div>
+      </div>
+      {editingTask && (
+        <TaskEditModal
+          task={editingTask}
+          onClose={() => setEditingTask(null)}
+          onSave={(data) => {
+            updateMut.mutate({ id: editingTask.id, data });
+            setEditingTask(null);
+          }}
+        />
+      )}
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- add `TaskEditModal` for editing title, notes, and due dates
- allow `TaskCard` click to open editing modal
- replace prompt-based editing in Kanban with modal

## Testing
- `npm test` *(fails: playwright not found)*
- `npm run test:unit` *(fails: vitest not found)*
- `npm install` *(fails: E403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bffdd90ed8832c8d56b7980a4c38b6