### PR TITLE
feat: enhance task management

### DIFF
--- a/.env.local.sample
+++ b/.env.local.sample
@@ -2,4 +2,5 @@ NEXT_PUBLIC_API_BASE=
 MOCK_MODE=true
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/propertylite
 MAX_UPLOAD_MB=8
+NEXT_PUBLIC_TASK_REMINDER_DAYS=1
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Copy `.env.local.sample` to `.env.local` and adjust as needed.
 * `MOCK_MODE` - Enables mocked API responses (defaults to `true`; set to `false` to use PostgreSQL).
 * `DATABASE_URL` - PostgreSQL connection string.
 * `MAX_UPLOAD_MB` - Maximum upload size in megabytes.
+* `NEXT_PUBLIC_TASK_REMINDER_DAYS` - Number of days before a task's due date to display a warning (default 1).
 
 ### Mock API setup
 

--- a/components/tasks/TaskCard.tsx
+++ b/components/tasks/TaskCard.tsx
@@ -9,12 +9,39 @@ export default function TaskCard({
   task: TaskDto;
   onClick?: () => void;
 }) {
+  const REMINDER_DAYS = Number(
+    process.env.NEXT_PUBLIC_TASK_REMINDER_DAYS ?? 1
+  );
+  const dueSoon = (() => {
+    if (!task.dueDate) return false;
+    const due = new Date(task.dueDate);
+    const now = new Date();
+    const diff = (due.getTime() - now.getTime()) / (1000 * 60 * 60 * 24);
+    return diff <= REMINDER_DAYS && diff >= 0;
+  })();
   return (
     <div
-      className={`border rounded p-2 ${onClick ? "cursor-pointer" : ""}`}
+      className={`border rounded p-2 ${
+        onClick ? "cursor-pointer" : ""
+      } ${dueSoon ? "border-yellow-500" : ""}`}
       onClick={onClick}
     >
       <div className="font-medium">{task.title}</div>
+      <div className="mt-1 space-y-1 text-xs">
+        {task.vendor && <div>Vendor: {task.vendor.name}</div>}
+        {task.properties.map((p) => (
+          <div key={p.id}>{p.address}</div>
+        ))}
+        {task.attachments?.length ? (
+          <div>📎 {task.attachments.length}</div>
+        ) : null}
+        {task.dueDate && (
+          <div className={dueSoon ? "text-red-600" : ""}>
+            Due {task.dueDate}
+            {dueSoon && <span className="ml-1">⚠️</span>}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/components/tasks/TaskEditModal.tsx
+++ b/components/tasks/TaskEditModal.tsx
@@ -1,31 +1,66 @@
 "use client";
 import { useState, useEffect } from "react";
 import type { TaskDto } from "../../types/tasks";
+import type { PropertySummary } from "../../types/property";
+import type { Vendor } from "../../lib/api";
 
 export default function TaskEditModal({
   task,
+  properties,
+  vendors,
   onClose,
   onSave,
 }: {
   task: TaskDto;
+  properties: PropertySummary[];
+  vendors: Vendor[];
   onClose: () => void;
   onSave: (data: Partial<TaskDto>) => void;
 }) {
   const [title, setTitle] = useState(task.title);
   const [description, setDescription] = useState(task.description ?? "");
   const [dueDate, setDueDate] = useState(task.dueDate ?? "");
+  const [selectedProps, setSelectedProps] = useState<string[]>(
+    task.properties.map((p) => p.id)
+  );
+  const [vendorId, setVendorId] = useState<string>(task.vendor?.id ?? "");
+  const [attachments, setAttachments] = useState<
+    TaskDto["attachments"]
+  >(task.attachments ?? []);
 
   useEffect(() => {
     setTitle(task.title);
     setDescription(task.description ?? "");
     setDueDate(task.dueDate ?? "");
+    setSelectedProps(task.properties.map((p) => p.id));
+    setVendorId(task.vendor?.id ?? "");
+    setAttachments(task.attachments ?? []);
   }, [task]);
 
+  const handleFiles = (files: FileList | null) => {
+    if (!files) return;
+    const arr = Array.from(files).map((f) => ({
+      name: f.name,
+      url: URL.createObjectURL(f),
+    }));
+    setAttachments((a) => [...(a ?? []), ...arr]);
+  };
+
   const handleSave = () => {
+    const props = selectedProps
+      .map((id) => properties.find((p) => p.id === id))
+      .filter(Boolean)
+      .map((p) => ({ id: p!.id, address: p!.address }));
+    const vendor = vendorId
+      ? vendors.find((v) => v.id === vendorId)
+      : undefined;
     onSave({
       title,
       description,
       dueDate: dueDate || undefined,
+      properties: props,
+      vendor: vendor ? { id: vendor.id!, name: vendor.name } : null,
+      attachments,
     });
   };
 
@@ -53,6 +88,51 @@ export default function TaskEditModal({
             onChange={(e) => setDueDate(e.target.value)}
           />
         </label>
+        <div>
+          <label className="block text-sm mb-1">Property</label>
+          <select
+            className="w-full rounded border p-1"
+            value={selectedProps[0] ?? ""}
+            onChange={(e) => setSelectedProps(e.target.value ? [e.target.value] : [])}
+          >
+            <option value="">Select property</option>
+            {properties.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.address}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Vendor</label>
+          <select
+            className="w-full rounded border p-1"
+            value={vendorId}
+            onChange={(e) => setVendorId(e.target.value)}
+          >
+            <option value="">None</option>
+            {vendors.map((v) => (
+              <option key={v.id} value={v.id}>
+                {v.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Attachments</label>
+          <input
+            type="file"
+            multiple
+            onChange={(e) => handleFiles(e.target.files)}
+          />
+          {attachments?.length ? (
+            <ul className="mt-1 list-inside list-disc text-xs">
+              {attachments.map((a) => (
+                <li key={a.url}>{a.name}</li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
         <div className="flex justify-end gap-2 pt-2">
           <button onClick={onClose} className="px-2 py-1 text-gray-600">
             Cancel

--- a/components/tasks/TasksKanban.tsx
+++ b/components/tasks/TasksKanban.tsx
@@ -13,6 +13,7 @@ import {
   updateTask,
   deleteTask,
   listProperties,
+  listVendors,
 } from "../../lib/api";
 import type { TaskDto } from "../../types/tasks";
 import TaskCard from "./TaskCard";
@@ -39,6 +40,10 @@ export default function TasksKanban() {
   const { data: properties = [] } = useQuery({
     queryKey: ["properties"],
     queryFn: () => listProperties(),
+  });
+  const { data: vendors = [] } = useQuery({
+    queryKey: ["vendors"],
+    queryFn: () => listVendors(),
   });
   const defaultProp = properties[0];
 
@@ -198,6 +203,8 @@ export default function TasksKanban() {
       {editingTask && (
         <TaskEditModal
           task={editingTask}
+          properties={properties}
+          vendors={vendors}
           onClose={() => setEditingTask(null)}
           onSave={(data) => {
             updateMut.mutate({ id: editingTask.id, data });

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -135,6 +135,7 @@ export const zTask = z.object({
     .nullable()
     .optional(),
   properties: z.array(z.object({ id: z.string(), address: z.string() })).min(1),
+  vendor: z.object({ id: z.string(), name: z.string() }).nullable().optional(),
   tags: z.array(z.string()).optional(),
   attachments: z
     .array(z.object({ name: z.string(), url: z.string() }))

--- a/types/tasks.ts
+++ b/types/tasks.ts
@@ -22,6 +22,7 @@ export type TaskDto = {
     endsOn?: string | null;      // ISO date limit
   } | null;
   properties: { id: string; address: string }[]; // 1..n properties
+  vendor?: { id: string; name: string } | null;
   tags?: string[];
   attachments?: { name: string; url: string }[];
   parentId?: string | null;      // for subtasks


### PR DESCRIPTION
## Summary
- add vendor, property assignment and attachments to task edit modal
- show vendor, attachments, properties and due date warnings on task cards
- make due date warning period configurable via NEXT_PUBLIC_TASK_REMINDER_DAYS

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0059d2b9c832c9732bd4591aa69e7