### PR TITLE
Fix dashboard P&L chart linking and interactions

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { useEffect, useState } from "react";
-import Link from "next/link";
 import CashflowTile from "../../../components/CashflowTile";
 import DashboardPnlMiniChart from "../../../components/DashboardPnlMiniChart";
 import DashboardPropertyCard from "../../../components/DashboardPropertyCard";
@@ -38,14 +37,7 @@ export default function DashboardPage() {
   return (
     <div className="p-6 space-y-6">
       <div className="grid gap-4 md:grid-cols-3">
-        <div className="relative">
-          <DashboardPnlMiniChart />
-          <div className="absolute bottom-2 right-2 text-xs">
-            <Link href="/analytics" className="text-blue-600 underline">
-              View full analytics →
-            </Link>
-          </div>
-        </div>
+        <DashboardPnlMiniChart />
         <CashflowTile />
         {loading ? (
           <>

--- a/app/api/pnl/summary/route.ts
+++ b/app/api/pnl/summary/route.ts
@@ -1,7 +1,14 @@
-import { expenses, incomes, properties, isActiveProperty } from '../../store';
+import {
+  expenses,
+  incomes,
+  properties,
+  isActiveProperty,
+  seedIfEmpty,
+} from '../../store';
 import type { PnlSummary, PnlPoint } from '../../../../types/pnl';
 
 export async function GET(req: Request) {
+  seedIfEmpty();
   const { searchParams } = new URL(req.url);
   const period = searchParams.get('period') === 'last12m' ? 'last12m' : 'last6m';
   const propertyId = searchParams.get('propertyId') || undefined;

--- a/components/DashboardPnlMiniChart.tsx
+++ b/components/DashboardPnlMiniChart.tsx
@@ -7,9 +7,11 @@ import Skeleton from "./Skeleton";
 import EmptyState from "./EmptyState";
 import { zPnlSummary } from "../lib/validation";
 import type { PnlSummary } from "../types/pnl";
+import { useRouter } from "next/navigation";
 
 export default function DashboardPnlMiniChart() {
   const { toast } = useToast();
+  const router = useRouter();
   const { data, isLoading } = useQuery<PnlSummary>({
     queryKey: ["pnl-summary", "last6m"],
     queryFn: async () => {
@@ -36,7 +38,12 @@ export default function DashboardPnlMiniChart() {
   const { totals, series } = data;
 
   return (
-    <div className="p-4 border rounded" data-testid="pnl-mini">
+    <div
+      className="p-4 border rounded group cursor-pointer"
+      data-testid="pnl-mini"
+      onClick={() => router.push("/analytics")}
+      role="link"
+    >
       <h2 className="font-semibold mb-2">P&L Trend (Last 6 months)</h2>
       <div className="h-24">
         <ResponsiveContainer width="100%" height="100%">
@@ -59,7 +66,7 @@ export default function DashboardPnlMiniChart() {
           </AreaChart>
         </ResponsiveContainer>
       </div>
-      <div className="flex justify-between text-xs mt-2">
+      <div className="flex justify-between text-xs mt-2 opacity-0 group-hover:opacity-100 transition-opacity">
         <div>Income: {totals.income}</div>
         <div>Expenses: {totals.expenses}</div>
         <div>Net: {totals.net}</div>

--- a/tests/dashboard.analytics-link.spec.ts
+++ b/tests/dashboard.analytics-link.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('clicking P&L chart navigates to analytics', async ({ page }) => {
+  await page.goto('/dashboard');
+  await page.getByTestId('pnl-mini').click();
+  await expect(page).toHaveURL('/analytics');
+});


### PR DESCRIPTION
## Summary
- ensure P&L summary API seeds data so dashboard chart reflects real figures
- make dashboard P&L mini chart clickable and show totals only on hover
- remove redundant analytics link from dashboard and add test for chart navigation

## Testing
- `npm test` *(fails: playwright not found)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0069ebc34832ca4041a8d1d82b8a4