### PR TITLE
Connect dashboard cashflow tile to data

### DIFF
--- a/app/api/summary/cashflow/route.ts
+++ b/app/api/summary/cashflow/route.ts
@@ -1,3 +1,33 @@
+import { rentLedger, expenses, seedIfEmpty } from '../../store';
+
 export async function GET() {
-  return Response.json({ monthIncome: 5000, monthExpenses: 2500, net: 2500 });
+  seedIfEmpty();
+
+  // Determine the most recent month that has either income or expense data
+  const dates = [
+    ...rentLedger
+      .filter((r) => r.status === 'paid')
+      .map((r) => r.paidDate || r.dueDate),
+    ...expenses.map((e) => e.date),
+  ].sort();
+  const latest = dates[dates.length - 1] || new Date().toISOString();
+  const month = latest.slice(0, 7); // YYYY-MM
+
+  const monthIncome = rentLedger
+    .filter(
+      (r) =>
+        r.status === 'paid' &&
+        (r.paidDate || r.dueDate).startsWith(month)
+    )
+    .reduce((sum, r) => sum + r.amount, 0);
+
+  const monthExpenses = expenses
+    .filter((e) => e.date.startsWith(month))
+    .reduce((sum, e) => sum + e.amount, 0);
+
+  return Response.json({
+    monthIncome,
+    monthExpenses,
+    net: monthIncome - monthExpenses,
+  });
 }


### PR DESCRIPTION
## Summary
- compute monthly cashflow from rent ledger and expenses
- expose latest month net totals via /api/summary/cashflow

## Testing
- `npm test` *(fails: playwright: not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c006c1b6f0832cbe42cfa93d341874