### PR TITLE
Archive tasks via modal and streamline task UI

### DIFF
--- a/app/api/store.ts
+++ b/app/api/store.ts
@@ -495,6 +495,7 @@ type TaskFilters = {
   from?: string;
   to?: string;
   parentId?: string;
+  archived?: boolean;
 };
 
 export const listTasks = (filters: TaskFilters = {}): TaskDto[] => {
@@ -505,6 +506,12 @@ export const listTasks = (filters: TaskFilters = {}): TaskDto[] => {
       properties: t.properties.filter((p) => activeIds.has(p.id)),
     }))
     .filter((t) => t.properties.length > 0);
+
+  if (filters.archived !== undefined) {
+    data = data.filter((t) => !!t.archived === filters.archived);
+  } else {
+    data = data.filter((t) => !t.archived);
+  }
 
   if (filters.propertyId) {
     data = data.filter((t) => t.properties.some((p) => p.id === filters.propertyId));
@@ -553,6 +560,7 @@ export const createTask = (
     id: data.id ?? crypto.randomUUID(),
     createdAt: data.createdAt ?? now,
     updatedAt: data.updatedAt ?? now,
+    archived: data.archived ?? false,
   } as TaskDto;
   tasks.push(task);
   return task;
@@ -564,6 +572,20 @@ export const updateTask = (id: string, data: Partial<TaskDto>): TaskDto | null =
   const updated = { ...tasks[idx], ...data, updatedAt: new Date().toISOString() } as TaskDto;
   tasks[idx] = updated;
   return updated;
+};
+
+export const archiveTask = (id: string): boolean => {
+  const task = tasks.find((t) => t.id === id);
+  if (!task) return false;
+  task.archived = true;
+  return true;
+};
+
+export const unarchiveTask = (id: string): boolean => {
+  const task = tasks.find((t) => t.id === id);
+  if (!task) return false;
+  task.archived = false;
+  return true;
 };
 
 export const deleteTask = (id: string): boolean => {

--- a/app/api/tasks/[id]/archive/route.ts
+++ b/app/api/tasks/[id]/archive/route.ts
@@ -1,0 +1,13 @@
+import { archiveTask } from '../../../store';
+
+export async function POST(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const ok = archiveTask(params.id);
+  if (!ok) {
+    return new Response('Not found', { status: 404 });
+  }
+  return new Response(null, { status: 204 });
+}
+

--- a/app/api/tasks/[id]/unarchive/route.ts
+++ b/app/api/tasks/[id]/unarchive/route.ts
@@ -1,0 +1,13 @@
+import { unarchiveTask } from '../../../store';
+
+export async function POST(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const ok = unarchiveTask(params.id);
+  if (!ok) {
+    return new Response('Not found', { status: 404 });
+  }
+  return new Response(null, { status: 204 });
+}
+

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -12,6 +12,12 @@ export async function GET(req: Request) {
     from: url.searchParams.get('from') || undefined,
     to: url.searchParams.get('to') || undefined,
     parentId: url.searchParams.get('parentId') || undefined,
+    archived:
+      url.searchParams.get('archived') === 'true'
+        ? true
+        : url.searchParams.get('archived') === 'false'
+        ? false
+        : undefined,
   });
   return Response.json(data);
 }

--- a/components/tasks/TaskEditModal.tsx
+++ b/components/tasks/TaskEditModal.tsx
@@ -10,12 +10,14 @@ export default function TaskEditModal({
   vendors,
   onClose,
   onSave,
+  onArchive,
 }: {
   task: TaskDto;
   properties: PropertySummary[];
   vendors: Vendor[];
   onClose: () => void;
   onSave: (data: Partial<TaskDto>) => void;
+  onArchive: () => void;
 }) {
   const [title, setTitle] = useState(task.title);
   const [description, setDescription] = useState(task.description ?? "");
@@ -64,10 +66,42 @@ export default function TaskEditModal({
     });
   };
 
+  const handleClose = () => {
+    handleSave();
+    onClose();
+  };
+
+  const [menuOpen, setMenuOpen] = useState(false);
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="w-80 rounded bg-white p-4 shadow dark:bg-gray-800 space-y-2">
-        <h2 className="text-lg font-semibold">Edit Task</h2>
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={handleClose}
+    >
+      <div
+        className="relative w-80 rounded bg-white p-4 shadow dark:bg-gray-800 space-y-2"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          className="absolute right-2 top-2 text-xl"
+          onClick={() => setMenuOpen((o) => !o)}
+        >
+          ⋯
+        </button>
+        {menuOpen && (
+          <div className="absolute right-2 top-8 rounded border bg-white shadow">
+            <button
+              onClick={() => {
+                handleSave();
+                onArchive();
+              }}
+              className="block px-4 py-2 text-left text-sm w-full hover:bg-gray-100"
+            >
+              Archive
+            </button>
+          </div>
+        )}
+        <h2 className="text-lg font-semibold">Task Details</h2>
         <input
           className="w-full rounded border p-1"
           value={title}
@@ -132,17 +166,6 @@ export default function TaskEditModal({
               ))}
             </ul>
           ) : null}
-        </div>
-        <div className="flex justify-end gap-2 pt-2">
-          <button onClick={onClose} className="px-2 py-1 text-gray-600">
-            Cancel
-          </button>
-          <button
-            onClick={handleSave}
-            className="rounded bg-blue-500 px-2 py-1 text-white"
-          >
-            Save
-          </button>
         </div>
       </div>
     </div>

--- a/components/tasks/TasksKanban.tsx
+++ b/components/tasks/TasksKanban.tsx
@@ -11,7 +11,7 @@ import {
   listTasks,
   createTask,
   updateTask,
-  deleteTask,
+  archiveTask,
   listProperties,
   listVendors,
 } from "../../lib/api";
@@ -63,8 +63,8 @@ export default function TasksKanban() {
       updateTask(id, data),
     onSuccess: () => qc.invalidateQueries({ queryKey: ["tasks"] }),
   });
-  const deleteMut = useMutation({
-    mutationFn: (id: string) => deleteTask(id),
+  const archiveMut = useMutation({
+    mutationFn: (id: string) => archiveTask(id),
     onSuccess: () => qc.invalidateQueries({ queryKey: ["tasks"] }),
   });
   const [editingTask, setEditingTask] = useState<TaskDto | null>(null);
@@ -160,21 +160,7 @@ export default function TasksKanban() {
                             {...prov.draggableProps}
                             {...prov.dragHandleProps}
                           >
-                             <TaskCard task={task} onClick={() => setEditingTask(task)} />
-                            <div className="flex justify-end gap-1 text-xs mt-1">
-                              <button
-                                onClick={() => setEditingTask(task)}
-                                className="text-blue-500"
-                              >
-                                ✎
-                              </button>
-                              <button
-                                onClick={() => deleteMut.mutate(task.id)}
-                                className="text-red-500"
-                              >
-                                🗑
-                              </button>
-                            </div>
+                          <TaskCard task={task} onClick={() => setEditingTask(task)} />
                           </div>
                         )}
                       </Draggable>
@@ -208,6 +194,10 @@ export default function TasksKanban() {
           onClose={() => setEditingTask(null)}
           onSave={(data) => {
             updateMut.mutate({ id: editingTask.id, data });
+            setEditingTask(null);
+          }}
+          onArchive={() => {
+            archiveMut.mutate(editingTask.id);
             setEditingTask(null);
           }}
         />

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -380,10 +380,13 @@ export const listTasks = (params?: {
   to?: string;
   q?: string;
   parentId?: string;
+  archived?: boolean;
 }) => {
   const query = params
     ? new URLSearchParams(
-        Object.entries(params).filter(([, v]) => v) as [string, string][]
+        Object.entries(params)
+          .filter(([, v]) => v !== undefined && v !== null)
+          .map(([k, v]) => [k, String(v)])
       ).toString()
     : '';
   const path = `/tasks${query ? `?${query}` : ''}`;
@@ -396,6 +399,10 @@ export const updateTask = (id: string, payload: any) =>
   api<TaskDto>(`/tasks/${id}`, { method: 'PATCH', body: JSON.stringify(payload) });
 export const deleteTask = (id: string) =>
   api(`/tasks/${id}`, { method: 'DELETE' });
+export const archiveTask = (id: string) =>
+  api(`/tasks/${id}/archive`, { method: 'POST' });
+export const unarchiveTask = (id: string) =>
+  api(`/tasks/${id}/unarchive`, { method: 'POST' });
 export const completeTask = (id: string) =>
   api<TaskDto>(`/tasks/${id}/complete`, { method: 'POST' });
 export const bulkTasks = (payload: any) =>

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -141,6 +141,7 @@ export const zTask = z.object({
     .array(z.object({ name: z.string(), url: z.string() }))
     .optional(),
   parentId: z.string().nullable().optional(),
+  archived: z.boolean().optional(),
   createdAt: z.string().optional(),
   updatedAt: z.string().optional(),
 });

--- a/types/tasks.ts
+++ b/types/tasks.ts
@@ -26,6 +26,7 @@ export type TaskDto = {
   tags?: string[];
   attachments?: { name: string; url: string }[];
   parentId?: string | null;      // for subtasks
+  archived?: boolean;
   createdAt: string;
   updatedAt: string;
 };


### PR DESCRIPTION
## Summary
- Remove inline edit/delete controls on tasks board and open details by clicking the card
- Add archive option in task details modal and save changes when closing
- Support task archiving in API and data store

## Testing
- `npm run test:unit` *(fails: vitest not found)*
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0088d1618832c9b1d4a94129edfb7