### PR TITLE
Display running clock and show due tomorrow label

### DIFF
--- a/app/(app)/tasks/page.tsx
+++ b/app/(app)/tasks/page.tsx
@@ -1,11 +1,15 @@
 "use client";
 
 import TasksKanban from "../../../components/tasks/TasksKanban";
+import Clock from "../../../components/Clock";
 
 export default function TasksPage() {
   return (
-    <div className="p-6 space-y-4">
+    <div className="p-6 space-y-4 relative">
       <h1 className="text-2xl font-semibold">Tasks</h1>
+      <div className="absolute top-6 right-6">
+        <Clock />
+      </div>
       <TasksKanban />
     </div>
   );

--- a/components/Clock.tsx
+++ b/components/Clock.tsx
@@ -1,0 +1,43 @@
+"use client";
+import { useEffect, useState } from "react";
+
+function pad(n: number) {
+  return n.toString().padStart(2, "0");
+}
+
+const weekdays = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
+const months = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+export default function Clock() {
+  const [now, setNow] = useState(new Date());
+  useEffect(() => {
+    const timer = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+  const day = weekdays[now.getDay()];
+  const date = `${now.getDate()} ${months[now.getMonth()]} ${now.getFullYear()}`;
+  const time = `${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`;
+  return <span>{`${day} ${date} – ${time}`}</span>;
+}
+

--- a/components/tasks/TaskCard.tsx
+++ b/components/tasks/TaskCard.tsx
@@ -19,6 +19,20 @@ export default function TaskCard({
     const diff = (due.getTime() - now.getTime()) / (1000 * 60 * 60 * 24);
     return diff <= REMINDER_DAYS && diff >= 0;
   })();
+  const dueTomorrow = (() => {
+    if (!task.dueDate) return false;
+    const due = new Date(task.dueDate);
+    const now = new Date();
+    const startOfToday = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate()
+    );
+    const startOfDue = new Date(due.getFullYear(), due.getMonth(), due.getDate());
+    const diff =
+      (startOfDue.getTime() - startOfToday.getTime()) / (1000 * 60 * 60 * 24);
+    return diff === 1;
+  })();
   return (
     <div
       className={`border rounded p-2 ${
@@ -37,7 +51,7 @@ export default function TaskCard({
         ) : null}
         {task.dueDate && (
           <div className={dueSoon ? "text-red-600" : ""}>
-            Due {task.dueDate}
+            {dueTomorrow ? `Due tomorrow!` : `Due ${task.dueDate}`}
             {dueSoon && <span className="ml-1">⚠️</span>}
           </div>
         )}

--- a/components/tasks/TaskRow.tsx
+++ b/components/tasks/TaskRow.tsx
@@ -63,6 +63,28 @@ export default function TaskRow({
     setEditing(false);
   };
 
+  const dueSoon = (() => {
+    if (!task.dueDate) return false;
+    const due = new Date(task.dueDate);
+    const now = new Date();
+    const diff = (due.getTime() - now.getTime()) / (1000 * 60 * 60 * 24);
+    return diff <= 1 && diff >= 0;
+  })();
+  const dueTomorrow = (() => {
+    if (!task.dueDate) return false;
+    const due = new Date(task.dueDate);
+    const now = new Date();
+    const startOfToday = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate()
+    );
+    const startOfDue = new Date(due.getFullYear(), due.getMonth(), due.getDate());
+    const diff =
+      (startOfDue.getTime() - startOfToday.getTime()) / (1000 * 60 * 60 * 24);
+    return diff === 1;
+  })();
+
   return (
     <div className="flex flex-col gap-2 p-2 border rounded">
       <div className="flex items-start gap-2">
@@ -84,7 +106,14 @@ export default function TaskRow({
               <PropertyBadge key={p.id} address={p.address} />
             ))}
             {task.dueDate && (
-              <span className="text-xs text-gray-500">Due {task.dueDate}</span>
+              <span
+                className={`text-xs ${
+                  dueSoon ? "text-red-600" : "text-gray-500"
+                }`}
+              >
+                {dueTomorrow ? `Due tomorrow!` : `Due ${task.dueDate}`}
+                {dueSoon && <span className="ml-1">⚠️</span>}
+              </span>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Display live clock with current date/time in the Tasks page
- Show "Due tomorrow!" when task due date is the next day

## Testing
- `npm run test:unit` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden fetching @hello-pangea/dnd)*
- `npm test` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c00b9ef030832c927d74da842618bf