### PR TITLE
Add editable list menu for tasks board

### DIFF
--- a/components/tasks/ColumnDeleteModal.tsx
+++ b/components/tasks/ColumnDeleteModal.tsx
@@ -1,0 +1,57 @@
+"use client";
+import { useState, useEffect } from "react";
+
+type Column = { id: string; title: string };
+
+export default function ColumnDeleteModal({
+  column,
+  onClose,
+  onConfirm,
+}: {
+  column: Column;
+  onClose: () => void;
+  onConfirm: () => void;
+}) {
+  const [name, setName] = useState("");
+
+  useEffect(() => {
+    setName("");
+  }, [column]);
+
+  const canDelete = name === column.title;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
+      <div className="bg-white p-4 rounded w-80 space-y-2">
+        <h2 className="text-lg font-medium">Delete List</h2>
+        <p className="text-sm">
+          Type "{column.title}" to confirm deleting this list.
+        </p>
+        <input
+          className="w-full rounded border p-1"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <div className="flex justify-end gap-2 pt-2">
+          <button className="px-2 py-1 bg-gray-100" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            disabled={!canDelete}
+            className={`px-2 py-1 text-white ${
+              canDelete ? "bg-red-500" : "bg-red-300"
+            }`}
+            onClick={() => {
+              if (!canDelete) return;
+              onConfirm();
+              onClose();
+            }}
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/components/tasks/ColumnRenameModal.tsx
+++ b/components/tasks/ColumnRenameModal.tsx
@@ -1,0 +1,48 @@
+"use client";
+import { useState, useEffect } from "react";
+
+type Column = { id: string; title: string };
+
+export default function ColumnRenameModal({
+  column,
+  onClose,
+  onSave,
+}: {
+  column: Column;
+  onClose: () => void;
+  onSave: (title: string) => void;
+}) {
+  const [title, setTitle] = useState(column.title);
+
+  useEffect(() => {
+    setTitle(column.title);
+  }, [column]);
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
+      <div className="bg-white p-4 rounded w-80 space-y-2">
+        <h2 className="text-lg font-medium">Rename List</h2>
+        <input
+          className="w-full rounded border p-1"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+        <div className="flex justify-end gap-2 pt-2">
+          <button className="px-2 py-1 bg-gray-100" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            className="px-2 py-1 bg-blue-500 text-white"
+            onClick={() => {
+              onSave(title);
+              onClose();
+            }}
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Replace list edit/delete icons with a three-dot menu
- Support renaming lists via a modal
- Add delete confirmation modal requiring typing the list name

## Testing
- `npm test` *(fails: playwright: not found)*
- `npm run test:unit` *(fails: vitest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c00dd23528832cb4481f4d29aeb649