### PR TITLE
Replace browser prompt with modal for adding task lists

### DIFF
--- a/components/tasks/ColumnCreateModal.tsx
+++ b/components/tasks/ColumnCreateModal.tsx
@@ -1,0 +1,42 @@
+"use client";
+import { useState } from "react";
+
+export default function ColumnCreateModal({
+  onClose,
+  onSave,
+}: {
+  onClose: () => void;
+  onSave: (title: string) => void;
+}) {
+  const [title, setTitle] = useState("");
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
+      <div className="bg-white p-4 rounded w-80 space-y-2">
+        <h2 className="text-lg font-medium">New List</h2>
+        <input
+          className="w-full rounded border p-1"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+        <div className="flex justify-end gap-2 pt-2">
+          <button className="px-2 py-1 bg-gray-100" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            className="px-2 py-1 bg-blue-500 text-white"
+            onClick={() => {
+              if (!title.trim()) return;
+              onSave(title);
+              setTitle("");
+              onClose();
+            }}
+          >
+            Create
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/components/tasks/TasksKanban.tsx
+++ b/components/tasks/TasksKanban.tsx
@@ -21,6 +21,7 @@ import TaskQuickNew from "./TaskQuickNew";
 import TaskEditModal from "./TaskEditModal";
 import ColumnRenameModal from "./ColumnRenameModal";
 import ColumnDeleteModal from "./ColumnDeleteModal";
+import ColumnCreateModal from "./ColumnCreateModal";
 
 type Column = { id: string; title: string };
 
@@ -74,6 +75,7 @@ export default function TasksKanban() {
   const [menuColumn, setMenuColumn] = useState<string | null>(null);
   const [renaming, setRenaming] = useState<Column | null>(null);
   const [deleting, setDeleting] = useState<Column | null>(null);
+  const [creating, setCreating] = useState(false);
   const [columns, setColumns] = useState<Column[]>([]);
   useEffect(() => {
     const stored = localStorage.getItem(STORAGE_KEY);
@@ -95,9 +97,7 @@ export default function TasksKanban() {
     updateMut.mutate({ id: draggableId, data: { status: destination.droppableId } });
   };
 
-  const addColumn = () => {
-    const title = prompt("Column name");
-    if (!title) return;
+  const addColumn = (title: string) => {
     const id = title.toLowerCase().replace(/\s+/g, "_");
     setColumns([...columns, { id, title }]);
   };
@@ -197,7 +197,7 @@ export default function TasksKanban() {
       </DragDropContext>
       <div className="w-64 flex-shrink-0">
         <button
-          onClick={addColumn}
+          onClick={() => setCreating(true)}
           className="w-full border rounded p-2 text-sm"
         >
           + Add Column
@@ -232,6 +232,12 @@ export default function TasksKanban() {
           column={deleting}
           onClose={() => setDeleting(null)}
           onConfirm={() => deleteColumn(deleting.id)}
+        />
+      )}
+      {creating && (
+        <ColumnCreateModal
+          onClose={() => setCreating(false)}
+          onSave={(title) => addColumn(title)}
         />
       )}
     </>


### PR DESCRIPTION
## Summary
- Add `ColumnCreateModal` component for adding new task lists via an in-app popup
- Integrate modal into `TasksKanban` to replace browser prompt when creating columns

## Testing
- `npm test` *(fails: playwright: not found)*
- `npm run test:unit` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden for @hello-pangea/dnd)*

------
https://chatgpt.com/codex/tasks/task_e_68c013290380832c879606fe65aebf70