### PR TITLE
Improve task editor layout and dark mode fields

### DIFF
--- a/components/tasks/TaskEditModal.tsx
+++ b/components/tasks/TaskEditModal.tsx
@@ -79,7 +79,7 @@ export default function TaskEditModal({
       onClick={handleClose}
     >
       <div
-        className="relative w-80 rounded bg-white p-4 shadow dark:bg-gray-800 space-y-2"
+        className="relative w-[32rem] rounded-xl bg-white p-6 shadow space-y-4 dark:bg-gray-800 dark:text-white"
         onClick={(e) => e.stopPropagation()}
       >
         <button
@@ -89,13 +89,13 @@ export default function TaskEditModal({
           ⋯
         </button>
         {menuOpen && (
-          <div className="absolute right-2 top-8 rounded border bg-white shadow">
+          <div className="absolute right-2 top-8 rounded-md border bg-white shadow dark:bg-gray-700">
             <button
               onClick={() => {
                 handleSave();
                 onArchive();
               }}
-              className="block px-4 py-2 text-left text-sm w-full hover:bg-gray-100"
+              className="block w-full px-4 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-600"
             >
               Archive
             </button>
@@ -103,29 +103,29 @@ export default function TaskEditModal({
         )}
         <h2 className="text-lg font-semibold">Task Details</h2>
         <input
-          className="w-full rounded border p-1"
+          className="w-full rounded-md border border-gray-300 p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
         />
         <textarea
-          className="w-full rounded border p-1"
+          className="w-full rounded-md border border-gray-300 p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
           placeholder="Notes"
           value={description}
           onChange={(e) => setDescription(e.target.value)}
         />
-        <label className="block text-sm">
+        <label className="block text-sm dark:text-gray-200">
           Due date
           <input
             type="date"
-            className="w-full rounded border p-1"
+            className="w-full rounded-md border border-gray-300 p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
             value={dueDate}
             onChange={(e) => setDueDate(e.target.value)}
           />
         </label>
         <div>
-          <label className="block text-sm mb-1">Property</label>
+          <label className="mb-1 block text-sm dark:text-gray-200">Property</label>
           <select
-            className="w-full rounded border p-1"
+            className="w-full rounded-md border border-gray-300 p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
             value={selectedProps[0] ?? ""}
             onChange={(e) => setSelectedProps(e.target.value ? [e.target.value] : [])}
           >
@@ -138,9 +138,9 @@ export default function TaskEditModal({
           </select>
         </div>
         <div>
-          <label className="block text-sm mb-1">Vendor</label>
+          <label className="mb-1 block text-sm dark:text-gray-200">Vendor</label>
           <select
-            className="w-full rounded border p-1"
+            className="w-full rounded-md border border-gray-300 p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
             value={vendorId}
             onChange={(e) => setVendorId(e.target.value)}
           >
@@ -153,10 +153,11 @@ export default function TaskEditModal({
           </select>
         </div>
         <div>
-          <label className="block text-sm mb-1">Attachments</label>
+          <label className="mb-1 block text-sm dark:text-gray-200">Attachments</label>
           <input
             type="file"
             multiple
+            className="text-sm text-gray-700 dark:text-gray-200"
             onChange={(e) => handleFiles(e.target.files)}
           />
           {attachments?.length ? (

--- a/components/tasks/TaskQuickNew.tsx
+++ b/components/tasks/TaskQuickNew.tsx
@@ -11,7 +11,7 @@ export default function TaskQuickNew({ onCreate }: { onCreate: (title: string) =
   };
   return (
     <input
-      className="w-full border rounded p-2 mb-2"
+      className="w-full border rounded p-2 mb-2 bg-white dark:border-gray-600 dark:bg-gray-700 dark:text-white"
       placeholder="+ New task"
       value={title}
       onChange={(e) => setTitle(e.target.value)}


### PR DESCRIPTION
## Summary
- widen and round task edit modal
- add dark mode styling to task inputs and quick new field

## Testing
- `npm test` *(fails: playwright not found)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c013a49e0c832cb3db47d400cb1bcd