### PR TITLE
Make task attachments viewable

### DIFF
--- a/components/tasks/TaskEditModal.tsx
+++ b/components/tasks/TaskEditModal.tsx
@@ -162,7 +162,16 @@ export default function TaskEditModal({
           {attachments?.length ? (
             <ul className="mt-1 list-inside list-disc text-xs">
               {attachments.map((a) => (
-                <li key={a.url}>{a.name}</li>
+                <li key={a.url}>
+                  <a
+                    href={a.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="underline hover:no-underline"
+                  >
+                    {a.name}
+                  </a>
+                </li>
               ))}
             </ul>
           ) : null}


### PR DESCRIPTION
## Summary
- Make task attachments clickable in the edit modal for easier viewing

## Testing
- `npm test` *(fails: playwright: not found)*
- `npx playwright install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68c013f79a50832cbe2f522bb0727845