### PR TITLE
Make task attachments viewable and removable

### DIFF
--- a/components/tasks/TaskEditModal.tsx
+++ b/components/tasks/TaskEditModal.tsx
@@ -161,8 +161,28 @@ export default function TaskEditModal({
           />
           {attachments?.length ? (
             <ul className="mt-1 list-inside list-disc text-xs">
-              {attachments.map((a) => (
-                <li key={a.url}>{a.name}</li>
+              {attachments.map((a, i) => (
+                <li key={a.url} className="flex items-center justify-between">
+                  <a
+                    href={a.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="underline hover:no-underline"
+                  >
+                    {a.name}
+                  </a>
+                  <button
+                    className="ml-2 text-gray-400 hover:text-red-500"
+                    onClick={() =>
+                      setAttachments((att) =>
+                        (att ?? []).filter((_, idx) => idx !== i)
+                      )
+                    }
+                    aria-label={`Remove ${a.name}`}
+                  >
+                    &times;
+                  </button>
+                </li>
               ))}
             </ul>
           ) : null}


### PR DESCRIPTION
## Summary
- Make task attachments clickable in the edit modal for easier viewing
- Add a right-justified remove (×) button that turns red on hover

## Testing
- `npm test` *(fails: playwright: not found)*
- `npx playwright install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68c013f79a50832cbe2f522bb0727845