### PR TITLE
Ensure consistent spacing for new tasks in Kanban columns

### DIFF
--- a/components/tasks/TaskQuickNew.tsx
+++ b/components/tasks/TaskQuickNew.tsx
@@ -1,7 +1,13 @@
 "use client";
 import { useState } from "react";
 
-export default function TaskQuickNew({ onCreate }: { onCreate: (title: string) => void }) {
+export default function TaskQuickNew({
+  onCreate,
+  className = "",
+}: {
+  onCreate: (title: string) => void;
+  className?: string;
+}) {
   const [title, setTitle] = useState("");
   const handleKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter" && title.trim()) {
@@ -11,7 +17,7 @@ export default function TaskQuickNew({ onCreate }: { onCreate: (title: string) =
   };
   return (
     <input
-      className="w-full border rounded p-2 mb-2 bg-white dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+      className={`w-full border rounded p-2 bg-white dark:border-gray-600 dark:bg-gray-700 dark:text-white ${className}`}
       placeholder="+ New task"
       value={title}
       onChange={(e) => setTitle(e.target.value)}

--- a/components/tasks/TasksKanban.tsx
+++ b/components/tasks/TasksKanban.tsx
@@ -162,7 +162,7 @@ export default function TasksKanban() {
                 <div
                   ref={provided.innerRef}
                   {...provided.droppableProps}
-                  className="min-h-[100px] space-y-2"
+                  className="space-y-2"
                 >
                   {tasks
                     .filter((t) => t.status === col.id)
@@ -178,20 +178,20 @@ export default function TasksKanban() {
                             {...prov.draggableProps}
                             {...prov.dragHandleProps}
                           >
-                          <TaskCard task={task} onClick={() => setEditingTask(task)} />
+                            <TaskCard task={task} onClick={() => setEditingTask(task)} />
                           </div>
                         )}
                       </Draggable>
                     ))}
                   {provided.placeholder}
+                  <TaskQuickNew
+                    onCreate={(title) =>
+                      createMut.mutate({ title, status: col.id })
+                    }
+                  />
                 </div>
               )}
             </Droppable>
-            <TaskQuickNew
-              onCreate={(title) =>
-                createMut.mutate({ title, status: col.id })
-              }
-            />
           </div>
         ))}
       </DragDropContext>


### PR DESCRIPTION
## Summary
- Keep new task input snug to preceding content by embedding it within the droppable column
- Allow `TaskQuickNew` to accept optional className for flexible spacing

## Testing
- `npm test` *(fails: playwright: not found)*
- `npm run test:unit` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0176c1e8c832cb4f8a261b8d7b74d