### PR TITLE
Activate time-based dark mode

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -24,6 +24,10 @@ export default function Providers({ children }: { children: ReactNode }) {
     const stored = localStorage.getItem('theme') as Theme | null;
     if (stored) {
       setTheme(stored);
+    } else {
+      const hour = new Date().getHours();
+      const isDark = hour >= 18 || hour < 6;
+      setTheme(isDark ? 'dark' : 'light');
     }
   }, []);
 

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -6,6 +6,7 @@ test('Settings page has heading', async ({ page }) => {
 });
 
 test('can toggle dark mode', async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem('theme', 'light'));
   await page.goto('/settings');
   const html = page.locator('html');
   await expect(html).not.toHaveClass(/dark/);


### PR DESCRIPTION
## Summary
- switch theme to dark between 6pm–6am using system time
- seed light theme in tests before navigating to settings

## Testing
- `npm run test:unit` *(fails: vitest not found)*
- `npm ci` *(fails: 403 Forbidden from registry)*
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0179b9a88832c971e1fcdc877cbb4