### PR TITLE
Activate time-based dark mode

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -24,16 +24,23 @@ export default function Providers({ children }: { children: ReactNode }) {
     const stored = localStorage.getItem('theme') as Theme | null;
     if (stored) {
       setTheme(stored);
+    } else {
+      const hour = new Date().getHours();
+      const isDark = hour >= 18 || hour < 6;
+      setTheme(isDark ? 'dark' : 'light');
     }
   }, []);
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
-    localStorage.setItem('theme', theme);
   }, [theme]);
 
   const toggleTheme = () =>
-    setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'));
+    setTheme((prev) => {
+      const next = prev === 'dark' ? 'light' : 'dark';
+      localStorage.setItem('theme', next);
+      return next;
+    });
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -6,6 +6,7 @@ test('Settings page has heading', async ({ page }) => {
 });
 
 test('can toggle dark mode', async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem('theme', 'light'));
   await page.goto('/settings');
   const html = page.locator('html');
   await expect(html).not.toHaveClass(/dark/);


### PR DESCRIPTION
## Summary
- switch theme to dark between 6pm–6am using system time unless user preference stored
- persist theme only when toggled by user
- seed light theme in tests before navigating to settings

## Testing
- `npm run test:unit` *(fails: vitest not found)*
- `npm test` *(fails: playwright not found)*
- `npm ci` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c0179b9a88832c971e1fcdc877cbb4