### PR TITLE
Improve task editor layout and dark mode fields

### DIFF
--- a/components/tasks/TaskCard.tsx
+++ b/components/tasks/TaskCard.tsx
@@ -51,7 +51,9 @@ export default function TaskCard({
         ) : null}
         {task.dueDate && (
           <div className={dueSoon ? "text-red-600" : ""}>
-            {dueTomorrow ? `Due tomorrow!` : `Due ${task.dueDate}`}
+            {dueTomorrow
+              ? `Due tomorrow!`
+              : `Due ${task.dueDate}${task.dueTime ? ` ${task.dueTime}` : ""}`}
             {dueSoon && <span className="ml-1">⚠️</span>}
           </div>
         )}

--- a/components/tasks/TaskEditModal.tsx
+++ b/components/tasks/TaskEditModal.tsx
@@ -22,6 +22,7 @@ export default function TaskEditModal({
   const [title, setTitle] = useState(task.title);
   const [description, setDescription] = useState(task.description ?? "");
   const [dueDate, setDueDate] = useState(task.dueDate ?? "");
+  const [dueTime, setDueTime] = useState(task.dueTime ?? "");
   const [selectedProps, setSelectedProps] = useState<string[]>(
     task.properties.map((p) => p.id)
   );
@@ -34,6 +35,7 @@ export default function TaskEditModal({
     setTitle(task.title);
     setDescription(task.description ?? "");
     setDueDate(task.dueDate ?? "");
+    setDueTime(task.dueTime ?? "");
     setSelectedProps(task.properties.map((p) => p.id));
     setVendorId(task.vendor?.id ?? "");
     setAttachments(task.attachments ?? []);
@@ -60,6 +62,7 @@ export default function TaskEditModal({
       title,
       description,
       dueDate: dueDate || undefined,
+      dueTime: dueTime || undefined,
       properties: props,
       vendor: vendor ? { id: vendor.id!, name: vendor.name } : null,
       attachments,
@@ -79,7 +82,7 @@ export default function TaskEditModal({
       onClick={handleClose}
     >
       <div
-        className="relative w-80 rounded bg-white p-4 shadow dark:bg-gray-800 space-y-2"
+        className="relative w-[32rem] rounded-xl bg-white p-6 shadow space-y-4 dark:bg-gray-800 dark:text-white"
         onClick={(e) => e.stopPropagation()}
       >
         <button
@@ -89,13 +92,13 @@ export default function TaskEditModal({
           ⋯
         </button>
         {menuOpen && (
-          <div className="absolute right-2 top-8 rounded border bg-white shadow">
+          <div className="absolute right-2 top-8 rounded-md border bg-white shadow dark:bg-gray-700">
             <button
               onClick={() => {
                 handleSave();
                 onArchive();
               }}
-              className="block px-4 py-2 text-left text-sm w-full hover:bg-gray-100"
+              className="block w-full px-4 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-600"
             >
               Archive
             </button>
@@ -103,29 +106,40 @@ export default function TaskEditModal({
         )}
         <h2 className="text-lg font-semibold">Task Details</h2>
         <input
-          className="w-full rounded border p-1"
+          className="w-full rounded-md border border-gray-300 p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
         />
         <textarea
-          className="w-full rounded border p-1"
+          className="w-full rounded-md border border-gray-300 p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
           placeholder="Notes"
           value={description}
           onChange={(e) => setDescription(e.target.value)}
         />
-        <label className="block text-sm">
-          Due date
-          <input
-            type="date"
-            className="w-full rounded border p-1"
-            value={dueDate}
-            onChange={(e) => setDueDate(e.target.value)}
-          />
-        </label>
+        <div className="flex gap-2 text-sm">
+          <label className="flex flex-1 flex-col dark:text-gray-200">
+            Due date
+            <input
+              type="date"
+              className="w-full rounded-md border border-gray-300 p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+              value={dueDate}
+              onChange={(e) => setDueDate(e.target.value)}
+            />
+          </label>
+          <label className="flex flex-1 flex-col dark:text-gray-200">
+            Time
+            <input
+              type="time"
+              className="w-full rounded-md border border-gray-300 p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+              value={dueTime}
+              onChange={(e) => setDueTime(e.target.value)}
+            />
+          </label>
+        </div>
         <div>
-          <label className="block text-sm mb-1">Property</label>
+          <label className="mb-1 block text-sm dark:text-gray-200">Property</label>
           <select
-            className="w-full rounded border p-1"
+            className="w-full rounded-md border border-gray-300 p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
             value={selectedProps[0] ?? ""}
             onChange={(e) => setSelectedProps(e.target.value ? [e.target.value] : [])}
           >
@@ -138,9 +152,9 @@ export default function TaskEditModal({
           </select>
         </div>
         <div>
-          <label className="block text-sm mb-1">Vendor</label>
+          <label className="mb-1 block text-sm dark:text-gray-200">Vendor</label>
           <select
-            className="w-full rounded border p-1"
+            className="w-full rounded-md border border-gray-300 p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
             value={vendorId}
             onChange={(e) => setVendorId(e.target.value)}
           >
@@ -153,10 +167,11 @@ export default function TaskEditModal({
           </select>
         </div>
         <div>
-          <label className="block text-sm mb-1">Attachments</label>
+          <label className="mb-1 block text-sm dark:text-gray-200">Attachments</label>
           <input
             type="file"
             multiple
+            className="text-sm text-gray-700 dark:text-gray-200"
             onChange={(e) => handleFiles(e.target.files)}
           />
           {attachments?.length ? (

--- a/components/tasks/TaskQuickNew.tsx
+++ b/components/tasks/TaskQuickNew.tsx
@@ -11,7 +11,7 @@ export default function TaskQuickNew({ onCreate }: { onCreate: (title: string) =
   };
   return (
     <input
-      className="w-full border rounded p-2 mb-2"
+      className="w-full border rounded p-2 mb-2 bg-white dark:border-gray-600 dark:bg-gray-700 dark:text-white"
       placeholder="+ New task"
       value={title}
       onChange={(e) => setTitle(e.target.value)}

--- a/components/tasks/TaskRow.tsx
+++ b/components/tasks/TaskRow.tsx
@@ -21,6 +21,7 @@ export default function TaskRow({
   const [editing, setEditing] = useState(false);
   const [description, setDescription] = useState(task.description ?? "");
   const [dueDate, setDueDate] = useState(task.dueDate ?? "");
+  const [dueTime, setDueTime] = useState(task.dueTime ?? "");
   const [cadence, setCadence] = useState<TaskDto["cadence"]>(task.cadence);
   const [selectedProps, setSelectedProps] = useState<string[]>(
     task.properties.map((p) => p.id)
@@ -41,6 +42,7 @@ export default function TaskRow({
   const startEdit = () => {
     setDescription(task.description ?? "");
     setDueDate(task.dueDate ?? "");
+    setDueTime(task.dueTime ?? "");
     setCadence(task.cadence);
     setSelectedProps(task.properties.map((p) => p.id));
     setFreq(task.recurrence?.freq ?? null);
@@ -56,6 +58,7 @@ export default function TaskRow({
       title,
       description,
       dueDate: dueDate || undefined,
+      dueTime: dueTime || undefined,
       cadence,
       properties: props,
       recurrence: { freq },
@@ -111,7 +114,9 @@ export default function TaskRow({
                   dueSoon ? "text-red-600" : "text-gray-500"
                 }`}
               >
-                {dueTomorrow ? `Due tomorrow!` : `Due ${task.dueDate}`}
+                {dueTomorrow
+                  ? `Due tomorrow!`
+                  : `Due ${task.dueDate}${task.dueTime ? ` ${task.dueTime}` : ""}`}
                 {dueSoon && <span className="ml-1">⚠️</span>}
               </span>
             )}
@@ -145,6 +150,15 @@ export default function TaskRow({
                 className="border rounded p-1"
                 value={dueDate}
                 onChange={(e) => setDueDate(e.target.value)}
+              />
+            </label>
+            <label className="flex items-center gap-1">
+              Time
+              <input
+                type="time"
+                className="border rounded p-1"
+                value={dueTime}
+                onChange={(e) => setDueTime(e.target.value)}
               />
             </label>
             <label className="flex items-center gap-1">

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -121,6 +121,7 @@ export const zTask = z.object({
   priority: z.enum(['low','normal','high']).default('normal'),
   cadence: z.enum(['Immediate','Weekly','Monthly','Yearly','Custom']).default('Immediate'),
   dueDate: z.string().optional(),
+  dueTime: z.string().optional(),
   startDate: z.string().optional(),
   endDate: z.string().optional(),
   recurrence: z

--- a/types/tasks.ts
+++ b/types/tasks.ts
@@ -11,6 +11,7 @@ export type TaskDto = {
   priority: TaskPriority;
   cadence: TaskCadence;          // bucket for later Kanban
   dueDate?: string;              // ISO
+  dueTime?: string;              // HH:mm optional
   startDate?: string;            // for Gantt (optional)
   endDate?: string;              // for Gantt (optional)
   recurrence?: {


### PR DESCRIPTION
## Summary
- widen and round task edit modal
- add dark mode styling to task inputs and quick new field
- add optional due time field next to due date

## Testing
- `npm test` *(fails: playwright not found)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c013a49e0c832cb3db47d400cb1bcd