### PR TITLE
feat: add dark mode styling for list modals

### DIFF
--- a/components/tasks/ColumnCreateModal.tsx
+++ b/components/tasks/ColumnCreateModal.tsx
@@ -12,19 +12,22 @@ export default function ColumnCreateModal({
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
-      <div className="bg-white p-4 rounded w-80 space-y-2">
+      <div className="w-80 space-y-2 rounded bg-white p-4 dark:bg-gray-800 dark:text-white">
         <h2 className="text-lg font-medium">New List</h2>
         <input
-          className="w-full rounded border p-1"
+          className="w-full rounded border p-1 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
         />
         <div className="flex justify-end gap-2 pt-2">
-          <button className="px-2 py-1 bg-gray-100" onClick={onClose}>
+          <button
+            className="px-2 py-1 bg-gray-100 dark:bg-gray-600 dark:text-white"
+            onClick={onClose}
+          >
             Cancel
           </button>
           <button
-            className="px-2 py-1 bg-blue-500 text-white"
+            className="px-2 py-1 bg-blue-500 text-white dark:bg-blue-600"
             onClick={() => {
               if (!title.trim()) return;
               onSave(title);

--- a/components/tasks/ColumnDeleteModal.tsx
+++ b/components/tasks/ColumnDeleteModal.tsx
@@ -22,24 +22,29 @@ export default function ColumnDeleteModal({
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
-      <div className="bg-white p-4 rounded w-80 space-y-2">
+      <div className="w-80 space-y-2 rounded bg-white p-4 dark:bg-gray-800 dark:text-white">
         <h2 className="text-lg font-medium">Delete List</h2>
-        <p className="text-sm">
+        <p className="text-sm dark:text-gray-300">
           Type "{column.title}" to confirm deleting this list.
         </p>
         <input
-          className="w-full rounded border p-1"
+          className="w-full rounded border p-1 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
         <div className="flex justify-end gap-2 pt-2">
-          <button className="px-2 py-1 bg-gray-100" onClick={onClose}>
+          <button
+            className="px-2 py-1 bg-gray-100 dark:bg-gray-600 dark:text-white"
+            onClick={onClose}
+          >
             Cancel
           </button>
           <button
             disabled={!canDelete}
             className={`px-2 py-1 text-white ${
-              canDelete ? "bg-red-500" : "bg-red-300"
+              canDelete
+                ? "bg-red-500 hover:bg-red-600 dark:bg-red-600 dark:hover:bg-red-700"
+                : "bg-red-300 dark:bg-red-300"
             }`}
             onClick={() => {
               if (!canDelete) return;

--- a/components/tasks/ColumnRenameModal.tsx
+++ b/components/tasks/ColumnRenameModal.tsx
@@ -20,19 +20,22 @@ export default function ColumnRenameModal({
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
-      <div className="bg-white p-4 rounded w-80 space-y-2">
+      <div className="w-80 space-y-2 rounded bg-white p-4 dark:bg-gray-800 dark:text-white">
         <h2 className="text-lg font-medium">Rename List</h2>
         <input
-          className="w-full rounded border p-1"
+          className="w-full rounded border p-1 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
         />
         <div className="flex justify-end gap-2 pt-2">
-          <button className="px-2 py-1 bg-gray-100" onClick={onClose}>
+          <button
+            className="px-2 py-1 bg-gray-100 dark:bg-gray-600 dark:text-white"
+            onClick={onClose}
+          >
             Cancel
           </button>
           <button
-            className="px-2 py-1 bg-blue-500 text-white"
+            className="px-2 py-1 bg-blue-500 text-white dark:bg-blue-600"
             onClick={() => {
               onSave(title);
               onClose();


### PR DESCRIPTION
## Summary
- add dark mode styles to create, rename, and delete list popups

## Testing
- `npm run test:unit` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@hello-pangea%2fdnd)*
- `npm test` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c01dddc7ec832cbf7ed3cbbadf3dae