### PR TITLE
feat: scaffold analytics dashboard

### DIFF
--- a/app/(app)/analytics/components/AppliedFiltersPanel.tsx
+++ b/app/(app)/analytics/components/AppliedFiltersPanel.tsx
@@ -1,0 +1,26 @@
+import type { AnalyticsStateType } from '../../../lib/schemas';
+
+interface Props {
+  state: AnalyticsStateType;
+  onRemove: (key: string, value: string) => void;
+}
+
+export default function AppliedFiltersPanel({ state }: Props) {
+  const chips: string[] = [];
+  Object.entries(state.filters).forEach(([k, arr]) => {
+    (arr as string[]).forEach(v => chips.push(`${k}:${v}`));
+  });
+  return (
+    <div data-testid="applied-filters" className="p-4 border rounded-2xl shadow-sm space-y-2">
+      <div className="font-semibold">Currently Applied</div>
+      <div className="flex flex-wrap gap-2">
+        {chips.map((c) => (
+          <span key={c} className="px-2 py-1 text-sm bg-gray-200 rounded-full">
+            {c}
+          </span>
+        ))}
+        {chips.length === 0 && <div className="text-sm text-gray-500">None</div>}
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/analytics/components/CustomGraphBuilder.tsx
+++ b/app/(app)/analytics/components/CustomGraphBuilder.tsx
@@ -1,0 +1,13 @@
+interface Props {
+  onRun: () => void;
+}
+
+export default function CustomGraphBuilder({ onRun }: Props) {
+  return (
+    <div>
+      <button className="px-4 py-2 bg-blue-600 text-white rounded" onClick={onRun} data-testid="custom-builder-run">
+        Run Custom Graph
+      </button>
+    </div>
+  );
+}

--- a/app/(app)/analytics/components/DateRangeFilter.tsx
+++ b/app/(app)/analytics/components/DateRangeFilter.tsx
@@ -1,0 +1,15 @@
+import type { AnalyticsStateType } from '../../../lib/schemas';
+
+interface Props {
+  state: AnalyticsStateType;
+  onChange: (s: Partial<AnalyticsStateType>) => void;
+}
+
+export default function DateRangeFilter({ state }: Props) {
+  return (
+    <div data-testid="date-range-filter" className="p-4 border rounded-2xl shadow-sm">
+      <div className="font-semibold mb-2">Date Range</div>
+      <div className="text-sm">{state.from} → {state.to}</div>
+    </div>
+  );
+}

--- a/app/(app)/analytics/components/ExportButtons.tsx
+++ b/app/(app)/analytics/components/ExportButtons.tsx
@@ -1,0 +1,28 @@
+import { downloadCsv, downloadPng } from '../../../lib/download';
+import { useRef } from 'react';
+
+interface Props {
+  csvData: string;
+}
+
+export default function ExportButtons({ csvData }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  return (
+    <div className="flex gap-2" data-testid="export-buttons" ref={ref}>
+      <button
+        className="px-3 py-1 text-sm bg-gray-200 rounded"
+        onClick={() => downloadCsv(csvData, 'analytics.csv')}
+      >
+        CSV
+      </button>
+      <button
+        className="px-3 py-1 text-sm bg-gray-200 rounded"
+        onClick={() => {
+          if (ref.current) downloadPng(ref.current, 'chart.png');
+        }}
+      >
+        PNG
+      </button>
+    </div>
+  );
+}

--- a/app/(app)/analytics/components/PresetMenu.tsx
+++ b/app/(app)/analytics/components/PresetMenu.tsx
@@ -1,0 +1,16 @@
+import { usePresets } from '../../../hooks/useAnalytics';
+
+export default function PresetMenu() {
+  const { data } = usePresets();
+  return (
+    <div data-testid="preset-menu" className="p-4 border rounded-2xl shadow-sm">
+      <div className="font-semibold mb-2">Presets</div>
+      <ul className="list-disc pl-4 text-sm">
+        {(data || []).map((p: any) => (
+          <li key={p.id}>{p.name}</li>
+        ))}
+        {!data && <li className="list-none text-gray-500">None</li>}
+      </ul>
+    </div>
+  );
+}

--- a/app/(app)/analytics/components/SearchExpensesPanel.tsx
+++ b/app/(app)/analytics/components/SearchExpensesPanel.tsx
@@ -1,0 +1,8 @@
+export default function SearchExpensesPanel() {
+  return (
+    <div data-testid="search-expenses" className="p-4 border rounded-2xl shadow-sm">
+      <div className="font-semibold mb-2">Search Expenses</div>
+      <div className="text-sm text-gray-500">Typeahead coming soon</div>
+    </div>
+  );
+}

--- a/app/(app)/analytics/components/SearchIncomePanel.tsx
+++ b/app/(app)/analytics/components/SearchIncomePanel.tsx
@@ -1,0 +1,8 @@
+export default function SearchIncomePanel() {
+  return (
+    <div data-testid="search-income" className="p-4 border rounded-2xl shadow-sm">
+      <div className="font-semibold mb-2">Search Income</div>
+      <div className="text-sm text-gray-500">Typeahead coming soon</div>
+    </div>
+  );
+}

--- a/app/(app)/analytics/components/VizLine.tsx
+++ b/app/(app)/analytics/components/VizLine.tsx
@@ -1,0 +1,20 @@
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
+
+interface Props {
+  data: { label: string; value: number }[];
+}
+
+export default function VizLine({ data }: Props) {
+  return (
+    <div data-testid="viz-line" className="h-64">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={data}>
+          <XAxis dataKey="label" />
+          <YAxis />
+          <Tooltip />
+          <Line type="monotone" dataKey="value" stroke="#8884d8" />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/app/(app)/analytics/components/VizPie.tsx
+++ b/app/(app)/analytics/components/VizPie.tsx
@@ -1,0 +1,24 @@
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts';
+
+interface Props {
+  data: { label: string; value: number }[];
+}
+
+const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042'];
+
+export default function VizPie({ data }: Props) {
+  return (
+    <div data-testid="viz-pie" className="h-64">
+      <ResponsiveContainer width="100%" height="100%">
+        <PieChart>
+          <Pie data={data} dataKey="value" nameKey="label" label>
+            {data.map((_, i) => (
+              <Cell key={i} fill={COLORS[i % COLORS.length]} />
+            ))}
+          </Pie>
+          <Tooltip />
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/app/(app)/analytics/page.tsx
+++ b/app/(app)/analytics/page.tsx
@@ -1,160 +1,49 @@
-"use client";
-import { useEffect, useState } from "react";
-import PnLChart from "../../../components/PnLChart";
-import Skeleton from "../../../components/Skeleton";
-import {
-  zPnlSeries,
-  zRentMetrics,
-  zExpenseBreakdown,
-  zOccupancy,
-} from "../../../lib/validation";
-import type {
-  PnLSeries,
-  RentMetrics,
-  ExpenseBreakdown,
-  Occupancy,
-} from "../../../types/analytics";
-import {
-  PieChart,
-  Pie,
-  Cell,
-  Tooltip,
-  ResponsiveContainer,
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-} from "recharts";
+'use client';
+import { useState } from 'react';
+import DateRangeFilter from './components/DateRangeFilter';
+import AppliedFiltersPanel from './components/AppliedFiltersPanel';
+import SearchIncomePanel from './components/SearchIncomePanel';
+import SearchExpensesPanel from './components/SearchExpensesPanel';
+import VizLine from './components/VizLine';
+import VizPie from './components/VizPie';
+import CustomGraphBuilder from './components/CustomGraphBuilder';
+import ExportButtons from './components/ExportButtons';
+import PresetMenu from './components/PresetMenu';
+import { AnalyticsState, AnalyticsStateType } from '../../../lib/schemas';
+import { useUrlState } from '../../../lib/urlState';
+import { useSeries } from '../../../hooks/useAnalytics';
 
-const COLORS = ["#0088FE", "#00C49F", "#FFBB28", "#FF8042", "#8884d8", "#82ca9d"];
+const now = new Date();
+const defaultState = AnalyticsState.parse({
+  from: new Date(now.getFullYear(), now.getMonth() - 1, now.getDate()).toISOString(),
+  to: now.toISOString(),
+});
 
 export default function AnalyticsPage() {
-  const [pnl, setPnl] = useState<PnLSeries | null>(null);
-  const [rent, setRent] = useState<RentMetrics | null>(null);
-  const [expenseData, setExpenseData] = useState<ExpenseBreakdown | null>(null);
-  const [occupancy, setOccupancy] = useState<Occupancy | null>(null);
+  const [state, setState] = useState<AnalyticsStateType>(defaultState);
+  useUrlState(state, setState);
+  const { data } = useSeries(state);
 
-  useEffect(() => {
-    fetch("/api/analytics/pnl")
-      .then((res) => res.json())
-      .then((json) => setPnl(zPnlSeries.parse(json)))
-      .catch(() => {});
-    fetch("/api/analytics/rent")
-      .then((res) => res.json())
-      .then((json) => setRent(zRentMetrics.parse(json)))
-      .catch(() => {});
-    fetch("/api/analytics/expenses")
-      .then((res) => res.json())
-      .then((json) => setExpenseData(zExpenseBreakdown.parse(json)))
-      .catch(() => {});
-    fetch("/api/analytics/occupancy")
-      .then((res) => res.json())
-      .then((json) => setOccupancy(zOccupancy.parse(json)))
-      .catch(() => {});
-  }, []);
+  const chartData = data?.buckets || [];
 
   return (
-    <div className="p-6 space-y-6">
-      <h1 className="text-2xl font-semibold">Analytics</h1>
-
-      <div className="grid gap-4 md:grid-cols-4" data-testid="kpis">
-        <div className="p-4 border rounded" data-testid="kpi-net">
-          <div className="text-sm text-gray-500">Net</div>
-          <div className="text-xl font-bold">{pnl ? pnl.totals.net : '-'}</div>
+    <div className="flex">
+      <div className="flex-1 p-6 space-y-4">
+        <h1 className="text-2xl font-semibold mb-4">Analytics</h1>
+        <div data-testid="viz-section">
+          {state.viz === 'line' && <VizLine data={chartData} />}
+          {state.viz === 'pie' && <VizPie data={chartData} />}
+          {state.viz === 'custom' && <CustomGraphBuilder onRun={() => {}} />}
         </div>
-        <div className="p-4 border rounded" data-testid="kpi-collection">
-          <div className="text-sm text-gray-500">Collection rate</div>
-          <div className="text-xl font-bold">
-            {rent ? `${Math.round(rent.collectionRate * 100)}%` : '-'}
-          </div>
-        </div>
-        <div className="p-4 border rounded" data-testid="kpi-arrears">
-          <div className="text-sm text-gray-500">Arrears amount</div>
-          <div className="text-xl font-bold">{rent ? rent.arrearsAmount : '-'}</div>
-        </div>
-        <div className="p-4 border rounded" data-testid="kpi-occupancy">
-          <div className="text-sm text-gray-500">Occupancy rate</div>
-          <div className="text-xl font-bold">
-            {occupancy ? `${Math.round(occupancy.occupancyRate * 100)}%` : '-'}
-          </div>
-        </div>
+        <ExportButtons csvData={JSON.stringify(chartData)} />
       </div>
-
-      <section>
-        <h2 className="font-semibold mb-2">P&L Trend</h2>
-        {pnl ? <PnLChart data={pnl.series} /> : <Skeleton className="h-64" />}
-        <a className="text-sm text-blue-600" href="/api/analytics/export/pnl.csv">
-          Export CSV
-        </a>
-      </section>
-
-      <section>
-        <h2 className="font-semibold mb-2">Expense Breakdown</h2>
-        {expenseData ? (
-          <>
-            <div className="h-64">
-              <ResponsiveContainer width="100%" height="100%">
-                <PieChart>
-                  <Pie
-                    dataKey="amount"
-                    nameKey="category"
-                    data={expenseData.slices}
-                    label
-                  >
-                    {expenseData.slices.map((_, i) => (
-                      <Cell key={i} fill={COLORS[i % COLORS.length]} />
-                    ))}
-                  </Pie>
-                  <Tooltip />
-                </PieChart>
-              </ResponsiveContainer>
-            </div>
-            <ul className="mt-2">
-              {expenseData.slices.map((s) => (
-                <li key={s.category} data-testid="expense-category">
-                  {s.category}: {s.amount}
-                </li>
-              ))}
-            </ul>
-          </>
-        ) : (
-          <Skeleton className="h-64" />
-        )}
-        <a className="text-sm text-blue-600" href="/api/analytics/export/expenses.csv">
-          Export CSV
-        </a>
-      </section>
-
-      <section>
-        <h2 className="font-semibold mb-2">Rent Collection</h2>
-        {rent ? (
-          <div className="h-64">
-            <ResponsiveContainer width="100%" height="100%">
-              <BarChart data={[{ name: 'Rent', expected: rent.expected, received: rent.received }]}> 
-                <XAxis dataKey="name" stroke="currentColor" />
-                <YAxis stroke="currentColor" />
-                <Tooltip />
-                <Bar dataKey="expected" fill="#8884d8" />
-                <Bar dataKey="received" fill="#82ca9d" />
-              </BarChart>
-            </ResponsiveContainer>
-          </div>
-        ) : (
-          <Skeleton className="h-64" />
-        )}
-        <a className="text-sm text-blue-600" href="/api/analytics/export/rent.csv">
-          Export CSV
-        </a>
-      </section>
-
-      <section>
-        <h2 className="font-semibold mb-2">Occupancy</h2>
-        {occupancy ? (
-          <div className="text-xl font-bold">{Math.round(occupancy.occupancyRate * 100)}%</div>
-        ) : (
-          <Skeleton className="h-8" />
-        )}
-      </section>
+      <div className="w-80 p-4 space-y-4 hidden lg:block">
+        <DateRangeFilter state={state} onChange={() => {}} />
+        <AppliedFiltersPanel state={state} onRemove={() => {}} />
+        <SearchIncomePanel />
+        <SearchExpensesPanel />
+        <PresetMenu />
+      </div>
     </div>
   );
 }

--- a/app/api/analytics/breakdown/route.ts
+++ b/app/api/analytics/breakdown/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const data = {
+    total: 0,
+    items: [
+      { label: 'A', value: 50 },
+      { label: 'B', value: 30 },
+    ],
+  };
+  return NextResponse.json(data);
+}

--- a/app/api/analytics/presets/[id]/route.ts
+++ b/app/api/analytics/presets/[id]/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+let presets: any[] = [];
+
+export async function DELETE(_: Request, { params }: { params: { id: string } }) {
+  presets = presets.filter(p => p.id !== params.id);
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/analytics/presets/route.ts
+++ b/app/api/analytics/presets/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+let presets: any[] = [];
+
+export async function GET() {
+  return NextResponse.json(presets);
+}
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const id = Date.now().toString();
+  presets.push({ id, ...body });
+  return NextResponse.json({ id });
+}

--- a/app/api/analytics/series/route.ts
+++ b/app/api/analytics/series/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const data = {
+    total: 0,
+    buckets: [
+      { label: '2024-01', value: 100 },
+      { label: '2024-02', value: 150 },
+    ],
+  };
+  return NextResponse.json(data);
+}

--- a/components/Clock.tsx
+++ b/components/Clock.tsx
@@ -33,14 +33,21 @@ export default function Clock({
 }: {
   className?: string;
 }) {
-  const [now, setNow] = useState(new Date());
+  const [now, setNow] = useState<Date | null>(null);
   useEffect(() => {
-    const timer = setInterval(() => setNow(new Date()), 1000);
+    const tick = () => setNow(new Date());
+    tick();
+    const timer = setInterval(tick, 1000);
     return () => clearInterval(timer);
   }, []);
+  if (!now) return <span className={className} />;
   const day = weekdays[now.getDay()];
   const date = `${now.getDate()} ${months[now.getMonth()]} ${now.getFullYear()}`;
   const time = `${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`;
-  return <span className={className}>{`${day} ${date} – ${time}`}</span>;
+  return (
+    <span className={className} suppressHydrationWarning>
+      {`${day} ${date} – ${time}`}
+    </span>
+  );
 }
 

--- a/hooks/useAnalytics.ts
+++ b/hooks/useAnalytics.ts
@@ -1,0 +1,43 @@
+import { useQuery, useMutation } from '@tanstack/react-query';
+import type { AnalyticsStateType } from '../lib/schemas';
+
+async function fetchJson(url: string, params?: any) {
+  const u = new URL(url, typeof window === 'undefined' ? 'http://localhost' : window.location.origin);
+  if (params) {
+    Object.entries(params).forEach(([k, v]) => {
+      if (v !== undefined) u.searchParams.set(k, typeof v === 'object' ? JSON.stringify(v) : String(v));
+    });
+  }
+  const res = await fetch(u.toString());
+  if (!res.ok) throw new Error('Network error');
+  return res.json();
+}
+
+export function useSeries(params: AnalyticsStateType) {
+  return useQuery({
+    queryKey: ['series', params],
+    queryFn: () => fetchJson('/api/analytics/series', params),
+    staleTime: 30_000,
+  });
+}
+
+export function useBreakdown(params: any) {
+  return useQuery({
+    queryKey: ['breakdown', params],
+    queryFn: () => fetchJson('/api/analytics/breakdown', params),
+    staleTime: 30_000,
+  });
+}
+
+export function usePresets() {
+  return useQuery({
+    queryKey: ['presets'],
+    queryFn: () => fetchJson('/api/analytics/presets'),
+  });
+}
+
+export function useSavePreset() {
+  return useMutation({
+    mutationFn: (body: any) => fetch('/api/analytics/presets', { method: 'POST', body: JSON.stringify(body), headers: { 'Content-Type': 'application/json' } }).then(r => r.json()),
+  });
+}

--- a/lib/download.ts
+++ b/lib/download.ts
@@ -1,0 +1,23 @@
+export function downloadCsv(data: string, filename: string) {
+  const blob = new Blob([data], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+// Placeholder image export; real implementation may use html2canvas or similar
+export async function downloadPng(node: HTMLElement, filename: string) {
+  const canvas = document.createElement('canvas');
+  canvas.width = node.clientWidth;
+  canvas.height = node.clientHeight;
+  const url = canvas.toDataURL('image/png');
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.click();
+}

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const AnalyticsState = z.object({
+  viz: z.enum(['line', 'pie', 'custom']).default('line'),
+  metric: z.enum(['net', 'income', 'expenses']).default('net'),
+  groupBy: z.enum(['time', 'property', 'category', 'tenant']).default('time'),
+  granularity: z.enum(['week', 'month', 'quarter', 'year']).default('month'),
+  from: z.string(),
+  to: z.string(),
+  filters: z
+    .object({
+      properties: z.array(z.string()).default([]),
+      categories: z.array(z.string()).default([]),
+      incomeTypes: z.array(z.string()).default([]),
+      expenseTypes: z.array(z.string()).default([]),
+      tenants: z.array(z.string()).default([]),
+      tags: z.array(z.string()).default([]),
+    })
+    .default({}),
+});
+
+export type AnalyticsStateType = z.infer<typeof AnalyticsState>;

--- a/lib/urlState.test.ts
+++ b/lib/urlState.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { urlState } from './urlState';
+import { AnalyticsState } from './schemas';
+
+describe('urlState', () => {
+  it('round trips state', () => {
+    const state = AnalyticsState.parse({ from: '2024-01-01', to: '2024-02-01' });
+    const params = urlState.serialize(state);
+    const parsed = urlState.parse(params);
+    expect(parsed).toEqual(state);
+  });
+});

--- a/lib/urlState.ts
+++ b/lib/urlState.ts
@@ -1,0 +1,58 @@
+import { useEffect } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { AnalyticsState, AnalyticsStateType } from './schemas';
+
+function parse(params: URLSearchParams): AnalyticsStateType {
+  const obj: any = {};
+  params.forEach((value, key) => {
+    obj[key] = value;
+  });
+  // filters can be JSON encoded
+  if (obj.filters) {
+    try {
+      obj.filters = JSON.parse(obj.filters);
+    } catch {
+      obj.filters = {};
+    }
+  }
+  return AnalyticsState.parse(obj);
+}
+
+function serialize(state: AnalyticsStateType): URLSearchParams {
+  const params = new URLSearchParams();
+  params.set('viz', state.viz);
+  params.set('metric', state.metric);
+  params.set('groupBy', state.groupBy);
+  params.set('granularity', state.granularity);
+  params.set('from', state.from);
+  params.set('to', state.to);
+  params.set('filters', JSON.stringify(state.filters));
+  return params;
+}
+
+/**
+ * Syncs analytics state with the URL query string.
+ */
+export function useUrlState(state: AnalyticsStateType, onChange: (s: AnalyticsStateType) => void) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const search = useSearchParams();
+
+  useEffect(() => {
+    // Parse initial
+    const parsed = parse(search as any as URLSearchParams);
+    onChange(parsed);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const params = serialize(state);
+    const url = `${pathname}?${params.toString()}`;
+    const t = setTimeout(() => {
+      router.replace(url);
+    }, 300);
+    return () => clearTimeout(t);
+  }, [state, router, pathname]);
+}
+
+export const urlState = { parse, serialize };

--- a/tests/analytics.spec.ts
+++ b/tests/analytics.spec.ts
@@ -1,28 +1,19 @@
 import { test, expect } from '@playwright/test';
 
-test('analytics page loads and KPIs render', async ({ page }) => {
+test('analytics page loads', async ({ page }) => {
   await page.goto('/analytics');
-  await expect(page.getByTestId('kpi-net')).toBeVisible();
-  await expect(page.getByTestId('kpi-collection')).toBeVisible();
+  await expect(page.getByTestId('date-range-filter')).toBeVisible();
+  await expect(page.getByTestId('viz-section')).toBeVisible();
 });
 
-test('pnl series provides multiple points', async ({ request }) => {
-  const res = await request.get('/api/analytics/pnl');
+test('series endpoint responds', async ({ request }) => {
+  const res = await request.get('/api/analytics/series');
   const data = await res.json();
-  expect(data.series.length).toBeGreaterThan(3);
+  expect(Array.isArray(data.buckets)).toBe(true);
 });
 
-test('expense breakdown has categories', async ({ request }) => {
-  const res = await request.get('/api/analytics/expenses');
+test('breakdown endpoint responds', async ({ request }) => {
+  const res = await request.get('/api/analytics/breakdown');
   const data = await res.json();
-  expect(data.slices.length).toBeGreaterThanOrEqual(3);
-});
-
-test('export csv endpoints respond', async ({ request }) => {
-  for (const path of ['/api/analytics/export/pnl.csv', '/api/analytics/export/expenses.csv', '/api/analytics/export/rent.csv']) {
-    const res = await request.get(path);
-    expect(res.status()).toBe(200);
-    const text = await res.text();
-    expect(text.length).toBeGreaterThan(10);
-  }
+  expect(Array.isArray(data.items)).toBe(true);
 });


### PR DESCRIPTION
## Summary
- add analytics state schema and URL sync helpers
- scaffold analytics page with right-rail filters and simple visualisations
- stub analytics API endpoints and hooks
- fix Clock component hydration mismatch causing build error

## Testing
- `npm run test:unit` *(fails: vitest not found)*
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c16da1cab0832ca1f880a6273bb914