### PR TITLE
Add archived task management UI

### DIFF
--- a/app/(app)/tasks/archive/page.tsx
+++ b/app/(app)/tasks/archive/page.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import TasksArchive from "../../../../components/tasks/TasksArchive";
+import Clock from "../../../../components/Clock";
+
+export default function TaskArchivePage() {
+  return (
+    <div className="p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Task Archive</h1>
+        <Clock className="text-2xl font-semibold" />
+      </div>
+      <TasksArchive />
+    </div>
+  );
+}

--- a/app/(app)/tasks/page.tsx
+++ b/app/(app)/tasks/page.tsx
@@ -2,13 +2,19 @@
 
 import TasksKanban from "../../../components/tasks/TasksKanban";
 import Clock from "../../../components/Clock";
+import Link from "next/link";
 
 export default function TasksPage() {
   return (
     <div className="p-6 space-y-4">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-semibold">Tasks</h1>
-        <Clock className="text-2xl font-semibold" />
+        <div className="flex items-center gap-4">
+          <Link href="/tasks/archive" className="underline">
+            Archive
+          </Link>
+          <Clock className="text-2xl font-semibold" />
+        </div>
       </div>
       <TasksKanban />
     </div>

--- a/components/tasks/TaskRecoverModal.tsx
+++ b/components/tasks/TaskRecoverModal.tsx
@@ -1,0 +1,95 @@
+"use client";
+import type { TaskDto } from "../../types/tasks";
+
+export default function TaskRecoverModal({
+  task,
+  onClose,
+  onRecover,
+}: {
+  task: TaskDto;
+  onClose: () => void;
+  onRecover: () => void;
+}) {
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      onClick={onClose}
+    >
+      <div
+        className="relative w-[32rem] rounded-xl bg-white p-6 shadow space-y-4 dark:bg-gray-800 dark:text-white"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          className="absolute right-2 top-2 text-xl"
+          onClick={onClose}
+          aria-label="Close"
+        >
+          &times;
+        </button>
+        <h2 className="text-lg font-semibold">Task Details</h2>
+        <div className="space-y-2 text-sm">
+          <div>
+            <div className="font-medium">Title</div>
+            <div>{task.title}</div>
+          </div>
+          {task.description && (
+            <div>
+              <div className="font-medium">Notes</div>
+              <div>{task.description}</div>
+            </div>
+          )}
+          {task.dueDate && (
+            <div>
+              <div className="font-medium">Due</div>
+              <div>
+                {task.dueDate}
+                {task.dueTime ? ` ${task.dueTime}` : ""}
+              </div>
+            </div>
+          )}
+          {task.properties.length > 0 && (
+            <div>
+              <div className="font-medium">Property</div>
+              <ul className="list-inside list-disc">
+                {task.properties.map((p) => (
+                  <li key={p.id}>{p.address}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {task.vendor && (
+            <div>
+              <div className="font-medium">Vendor</div>
+              <div>{task.vendor.name}</div>
+            </div>
+          )}
+          {task.attachments?.length ? (
+            <div>
+              <div className="font-medium">Attachments</div>
+              <ul className="list-inside list-disc">
+                {task.attachments.map((a) => (
+                  <li key={a.url}>
+                    <a
+                      href={a.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="underline hover:no-underline"
+                    >
+                      {a.name}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+        <button
+          className="mt-4 w-full rounded bg-blue-600 py-2 text-white hover:bg-blue-700"
+          onClick={onRecover}
+        >
+          Recover Task
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/tasks/TasksArchive.tsx
+++ b/components/tasks/TasksArchive.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { listTasks, unarchiveTask, bulkTasks } from "../../lib/api";
+import type { TaskDto } from "../../types/tasks";
+import TaskCard from "./TaskCard";
+import TaskRecoverModal from "./TaskRecoverModal";
+
+export default function TasksArchive() {
+  const qc = useQueryClient();
+  const [q, setQ] = useState("");
+  const [from, setFrom] = useState("");
+  const [to, setTo] = useState("");
+
+  const { data: tasks = [] } = useQuery<TaskDto[]>({
+    queryKey: ["tasks", "archive", { q, from, to }],
+    queryFn: () =>
+      listTasks({
+        archived: true,
+        q: q || undefined,
+        from: from || undefined,
+        to: to || undefined,
+      }),
+  });
+
+  const recoverMut = useMutation({
+    mutationFn: (id: string) => unarchiveTask(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["tasks", "archive"] }),
+  });
+
+  const deleteAllMut = useMutation({
+    mutationFn: (ids: string[]) => bulkTasks({ ids, op: "delete" }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["tasks", "archive"] }),
+  });
+
+  const [selected, setSelected] = useState<TaskDto | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [confirmText, setConfirmText] = useState("");
+
+  const canDeleteAll = confirmText === "delete all";
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-end gap-2">
+        <input
+          className="flex-1 rounded border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+          placeholder="Search Task"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+        />
+        <input
+          type="date"
+          className="rounded border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+          value={from}
+          onChange={(e) => setFrom(e.target.value)}
+        />
+        <input
+          type="date"
+          className="rounded border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+          value={to}
+          onChange={(e) => setTo(e.target.value)}
+        />
+        <button
+          className="rounded bg-red-500 px-3 py-2 text-white hover:bg-red-600"
+          onClick={() => setConfirmOpen(true)}
+        >
+          Delete All
+        </button>
+      </div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
+        {tasks.map((t) => (
+          <TaskCard key={t.id} task={t} onClick={() => setSelected(t)} />
+        ))}
+      </div>
+      {selected && (
+        <TaskRecoverModal
+          task={selected}
+          onClose={() => setSelected(null)}
+          onRecover={() => {
+            recoverMut.mutate(selected.id);
+            setSelected(null);
+          }}
+        />
+      )}
+      {confirmOpen && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="w-80 space-y-2 rounded bg-white p-4 dark:bg-gray-800 dark:text-white">
+            <h2 className="text-lg font-medium">Delete All Tasks</h2>
+            <p className="text-sm dark:text-gray-300">
+              Type "delete all" to confirm deleting all archived tasks.
+            </p>
+            <input
+              className="w-full rounded border p-1 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+            />
+            <div className="flex justify-end gap-2 pt-2">
+              <button
+                className="px-2 py-1 bg-gray-100 dark:bg-gray-600 dark:text-white"
+                onClick={() => {
+                  setConfirmOpen(false);
+                  setConfirmText("");
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                disabled={!canDeleteAll}
+                className={`px-2 py-1 text-white ${
+                  canDeleteAll
+                    ? "bg-red-500 hover:bg-red-600 dark:bg-red-600 dark:hover:bg-red-700"
+                    : "bg-red-300 dark:bg-red-300"
+                }`}
+                onClick={() => {
+                  if (!canDeleteAll) return;
+                  deleteAllMut.mutate(tasks.map((t) => t.id));
+                  setConfirmOpen(false);
+                  setConfirmText("");
+                }}
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add archive link to task page and new archive page
- implement archived tasks listing with search, date filter, and bulk delete
- allow viewing and recovering archived tasks

## Testing
- `npm test` *(fails: playwright: not found)*
- `npm run test:unit` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden for @hello-pangea/dnd)*

------
https://chatgpt.com/codex/tasks/task_e_68c1704dcbd4832cbe5157f5c49d83c3