### PR TITLE
feat: scaffold analytics dashboard

### DIFF
--- a/app/(app)/analytics/components/AppliedFiltersPanel.tsx
+++ b/app/(app)/analytics/components/AppliedFiltersPanel.tsx
@@ -1,0 +1,55 @@
+import type { AnalyticsStateType } from '../../../lib/schemas';
+
+interface Props {
+  state: AnalyticsStateType;
+  onAdd: (key: keyof AnalyticsStateType['filters'], value: string) => void;
+  onRemove: (key: keyof AnalyticsStateType['filters'], value: string) => void;
+}
+
+export default function AppliedFiltersPanel({ state, onAdd, onRemove }: Props) {
+  const chips: { key: keyof AnalyticsStateType['filters']; value: string }[] = [];
+  (Object.entries(state.filters) as [keyof AnalyticsStateType['filters'], string[]][]).forEach(([k, arr]) => {
+    (arr || []).forEach(v => chips.push({ key: k, value: v }));
+  });
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    try {
+      const data = JSON.parse(e.dataTransfer.getData('application/json'));
+      if (data && data.type && data.value) {
+        onAdd(data.type, data.value);
+      }
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <div
+      data-testid="applied-filters"
+      className="p-4 border rounded-2xl shadow-sm space-y-2"
+      onDragOver={e => e.preventDefault()}
+      onDrop={handleDrop}
+    >
+      <div className="font-semibold">Currently Applied</div>
+      <div className="flex flex-wrap gap-2">
+        {chips.map(({ key, value }) => (
+          <span
+            key={key + value}
+            className="px-2 py-1 text-sm bg-gray-200 rounded-full flex items-center gap-1"
+          >
+            {key}:{value}
+            <button
+              aria-label={`Remove ${value}`}
+              className="ml-1 text-xs"
+              onClick={() => onRemove(key, value)}
+            >
+              ×
+            </button>
+          </span>
+        ))}
+        {chips.length === 0 && <div className="text-sm text-gray-500">None</div>}
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/analytics/components/CustomGraphBuilder.tsx
+++ b/app/(app)/analytics/components/CustomGraphBuilder.tsx
@@ -1,0 +1,13 @@
+interface Props {
+  onRun: () => void;
+}
+
+export default function CustomGraphBuilder({ onRun }: Props) {
+  return (
+    <div>
+      <button className="px-4 py-2 bg-blue-600 text-white rounded" onClick={onRun} data-testid="custom-builder-run">
+        Run Custom Graph
+      </button>
+    </div>
+  );
+}

--- a/app/(app)/analytics/components/DateRangeFilter.tsx
+++ b/app/(app)/analytics/components/DateRangeFilter.tsx
@@ -1,0 +1,118 @@
+import { useState } from 'react';
+import type { AnalyticsStateType } from '../../../lib/schemas';
+
+interface Props {
+  state: AnalyticsStateType;
+  onChange: (s: Partial<AnalyticsStateType>) => void;
+}
+
+function dayOfYear(d: Date) {
+  const start = new Date(d.getFullYear(), 0, 1);
+  return Math.floor((d.getTime() - start.getTime()) / 86400000) + 1;
+}
+
+function fromDayOfYear(year: number, day: number) {
+  const start = new Date(year, 0, 1);
+  return new Date(start.getTime() + (day - 1) * 86400000);
+}
+
+export default function DateRangeFilter({ state, onChange }: Props) {
+  const [showCal, setShowCal] = useState(false);
+  const from = new Date(state.from);
+  const to = new Date(state.to);
+
+  const update = (a: Date, b: Date) =>
+    onChange({ from: a.toISOString(), to: b.toISOString() });
+
+  const handleYear = (idx: 0 | 1, val: number) => {
+    const a = new Date(state.from);
+    const b = new Date(state.to);
+    if (idx === 0) a.setFullYear(val); else b.setFullYear(val);
+    update(a, b);
+  };
+
+  const handleDay = (idx: 0 | 1, val: number) => {
+    const a = fromDayOfYear(new Date(state.from).getFullYear(), idx === 0 ? val : dayOfYear(new Date(state.from)));
+    const b = fromDayOfYear(new Date(state.to).getFullYear(), idx === 1 ? val : dayOfYear(new Date(state.to)));
+    update(a, b);
+  };
+
+  return (
+    <div
+      data-testid="date-range-filter"
+      className="relative p-4 border rounded-2xl shadow-sm select-none"
+      onClick={() => setShowCal(true)}
+    >
+      <div className="font-semibold mb-2">Date Range</div>
+      <div className="text-sm mb-2">{state.from.slice(0, 10)} → {state.to.slice(0, 10)}</div>
+      <div className="space-y-2">
+        <div className="flex items-center gap-2" onClick={e => e.stopPropagation()}>
+          <input
+            type="range"
+            min="2000"
+            max="2100"
+            value={from.getFullYear()}
+            onChange={e => handleYear(0, Number(e.target.value))}
+            className="w-full"
+          />
+          <input
+            type="range"
+            min="2000"
+            max="2100"
+            value={to.getFullYear()}
+            onChange={e => handleYear(1, Number(e.target.value))}
+            className="w-full"
+          />
+        </div>
+        <div className="flex items-center gap-2" onClick={e => e.stopPropagation()}>
+          <input
+            type="range"
+            min="1"
+            max="365"
+            value={dayOfYear(from)}
+            onChange={e => handleDay(0, Number(e.target.value))}
+            className="w-full"
+          />
+          <input
+            type="range"
+            min="1"
+            max="365"
+            value={dayOfYear(to)}
+            onChange={e => handleDay(1, Number(e.target.value))}
+            className="w-full"
+          />
+        </div>
+      </div>
+      {showCal && (
+        <div
+          className="absolute inset-0 flex items-center justify-center bg-black/20"
+          onClick={() => setShowCal(false)}
+        >
+          <div
+            className="bg-white p-4 rounded shadow-md space-y-2"
+            onClick={e => e.stopPropagation()}
+          >
+            <input
+              type="date"
+              value={state.from.slice(0, 10)}
+              onChange={e => update(new Date(e.target.value), to)}
+              className="border p-1 rounded"
+            />
+            <input
+              type="date"
+              value={state.to.slice(0, 10)}
+              onChange={e => update(from, new Date(e.target.value))}
+              className="border p-1 rounded"
+            />
+            <button
+              className="px-2 py-1 text-sm bg-gray-200 rounded"
+              onClick={() => setShowCal(false)}
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(app)/analytics/components/ExportButtons.tsx
+++ b/app/(app)/analytics/components/ExportButtons.tsx
@@ -1,0 +1,28 @@
+import { downloadCsv, downloadPng } from '../../../../lib/download';
+import { useRef } from 'react';
+
+interface Props {
+  csvData: string;
+}
+
+export default function ExportButtons({ csvData }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  return (
+    <div className="flex gap-2" data-testid="export-buttons" ref={ref}>
+      <button
+        className="px-3 py-1 text-sm bg-gray-200 rounded"
+        onClick={() => downloadCsv(csvData, 'analytics.csv')}
+      >
+        CSV
+      </button>
+      <button
+        className="px-3 py-1 text-sm bg-gray-200 rounded"
+        onClick={() => {
+          if (ref.current) downloadPng(ref.current, 'chart.png');
+        }}
+      >
+        PNG
+      </button>
+    </div>
+  );
+}

--- a/app/(app)/analytics/components/PresetMenu.tsx
+++ b/app/(app)/analytics/components/PresetMenu.tsx
@@ -1,0 +1,16 @@
+import { usePresets } from '../../../../hooks/useAnalytics';
+
+export default function PresetMenu() {
+  const { data } = usePresets();
+  return (
+    <div data-testid="preset-menu" className="p-4 border rounded-2xl shadow-sm">
+      <div className="font-semibold mb-2">Presets</div>
+      <ul className="list-disc pl-4 text-sm">
+        {(data || []).map((p: any) => (
+          <li key={p.id}>{p.name}</li>
+        ))}
+        {!data && <li className="list-none text-gray-500">None</li>}
+      </ul>
+    </div>
+  );
+}

--- a/app/(app)/analytics/components/SearchExpensesPanel.tsx
+++ b/app/(app)/analytics/components/SearchExpensesPanel.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import ExpenseForm from '../../../../components/ExpenseForm';
+import { EXPENSE_CATEGORY_OPTIONS } from '../../../../lib/categories';
+
+export default function SearchExpensesPanel() {
+  const [q, setQ] = useState('');
+  const [open, setOpen] = useState(false);
+  const items = EXPENSE_CATEGORY_OPTIONS.filter(c =>
+    c.toLowerCase().includes(q.toLowerCase())
+  );
+  return (
+    <div
+      data-testid="search-expenses"
+      className="p-4 border rounded-2xl shadow-sm space-y-2"
+    >
+      <div className="flex items-center justify-between">
+        <div className="font-semibold">Search Expenses</div>
+        <button
+          aria-label="Add custom expense"
+          onClick={() => setOpen(true)}
+          className="text-xl leading-none text-blue-600"
+        >
+          +
+        </button>
+      </div>
+      <input
+        type="text"
+        value={q}
+        onChange={e => setQ(e.target.value)}
+        placeholder="Search categories"
+        className="w-full border rounded p-1 text-sm"
+      />
+      <div className="space-y-1 max-h-40 overflow-y-auto">
+        {items.map(c => (
+          <div
+            key={c}
+            draggable
+            onDragStart={e =>
+              e.dataTransfer.setData(
+                'application/json',
+                JSON.stringify({ type: 'expenseTypes', value: c })
+              )
+            }
+            className="p-1 text-sm bg-gray-100 rounded cursor-grab"
+          >
+            {c}
+          </div>
+        ))}
+        {items.length === 0 && (
+          <div className="text-sm text-gray-500">No results</div>
+        )}
+      </div>
+      <ExpenseForm open={open} onOpenChange={setOpen} showTrigger={false} />
+    </div>
+  );
+}

--- a/app/(app)/analytics/components/SearchIncomePanel.tsx
+++ b/app/(app)/analytics/components/SearchIncomePanel.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import IncomeForm from '../../../../components/IncomeForm';
+import { INCOME_CATEGORY_OPTIONS } from '../../../../lib/categories';
+
+export default function SearchIncomePanel() {
+  const [q, setQ] = useState('');
+  const [open, setOpen] = useState(false);
+  const items = INCOME_CATEGORY_OPTIONS.filter(c =>
+    c.toLowerCase().includes(q.toLowerCase())
+  );
+  return (
+    <div
+      data-testid="search-income"
+      className="p-4 border rounded-2xl shadow-sm space-y-2"
+    >
+      <div className="flex items-center justify-between">
+        <div className="font-semibold">Search Income</div>
+        <button
+          aria-label="Add custom income"
+          onClick={() => setOpen(true)}
+          className="text-xl leading-none text-blue-600"
+        >
+          +
+        </button>
+      </div>
+      <input
+        type="text"
+        value={q}
+        onChange={e => setQ(e.target.value)}
+        placeholder="Search categories"
+        className="w-full border rounded p-1 text-sm"
+      />
+      <div className="space-y-1 max-h-40 overflow-y-auto">
+        {items.map(c => (
+          <div
+            key={c}
+            draggable
+            onDragStart={e =>
+              e.dataTransfer.setData(
+                'application/json',
+                JSON.stringify({ type: 'incomeTypes', value: c })
+              )
+            }
+            className="p-1 text-sm bg-gray-100 rounded cursor-grab"
+          >
+            {c}
+          </div>
+        ))}
+        {items.length === 0 && (
+          <div className="text-sm text-gray-500">No results</div>
+        )}
+      </div>
+      <IncomeForm open={open} onOpenChange={setOpen} showTrigger={false} />
+    </div>
+  );
+}

--- a/app/(app)/analytics/components/VizLine.tsx
+++ b/app/(app)/analytics/components/VizLine.tsx
@@ -1,0 +1,20 @@
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
+
+interface Props {
+  data: { label: string; value: number }[];
+}
+
+export default function VizLine({ data }: Props) {
+  return (
+    <div data-testid="viz-line" className="h-64">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={data}>
+          <XAxis dataKey="label" />
+          <YAxis />
+          <Tooltip />
+          <Line type="monotone" dataKey="value" stroke="#8884d8" />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/app/(app)/analytics/components/VizPie.tsx
+++ b/app/(app)/analytics/components/VizPie.tsx
@@ -1,0 +1,24 @@
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts';
+
+interface Props {
+  data: { label: string; value: number }[];
+}
+
+const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042'];
+
+export default function VizPie({ data }: Props) {
+  return (
+    <div data-testid="viz-pie" className="h-64">
+      <ResponsiveContainer width="100%" height="100%">
+        <PieChart>
+          <Pie data={data} dataKey="value" nameKey="label" label>
+            {data.map((_, i) => (
+              <Cell key={i} fill={COLORS[i % COLORS.length]} />
+            ))}
+          </Pie>
+          <Tooltip />
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/app/(app)/analytics/page.tsx
+++ b/app/(app)/analytics/page.tsx
@@ -1,160 +1,69 @@
-"use client";
-import { useEffect, useState } from "react";
-import PnLChart from "../../../components/PnLChart";
-import Skeleton from "../../../components/Skeleton";
-import {
-  zPnlSeries,
-  zRentMetrics,
-  zExpenseBreakdown,
-  zOccupancy,
-} from "../../../lib/validation";
-import type {
-  PnLSeries,
-  RentMetrics,
-  ExpenseBreakdown,
-  Occupancy,
-} from "../../../types/analytics";
-import {
-  PieChart,
-  Pie,
-  Cell,
-  Tooltip,
-  ResponsiveContainer,
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-} from "recharts";
+'use client';
+import { useState } from 'react';
+import DateRangeFilter from './components/DateRangeFilter';
+import AppliedFiltersPanel from './components/AppliedFiltersPanel';
+import SearchIncomePanel from './components/SearchIncomePanel';
+import SearchExpensesPanel from './components/SearchExpensesPanel';
+import VizLine from './components/VizLine';
+import VizPie from './components/VizPie';
+import CustomGraphBuilder from './components/CustomGraphBuilder';
+import ExportButtons from './components/ExportButtons';
+import PresetMenu from './components/PresetMenu';
+import { AnalyticsState, AnalyticsStateType } from '../../../lib/schemas';
+import { useUrlState } from '../../../lib/urlState';
+import { useSeries } from '../../../hooks/useAnalytics';
 
-const COLORS = ["#0088FE", "#00C49F", "#FFBB28", "#FF8042", "#8884d8", "#82ca9d"];
+const now = new Date();
+const defaultState = AnalyticsState.parse({
+  from: new Date(now.getFullYear(), now.getMonth() - 1, now.getDate()).toISOString(),
+  to: now.toISOString(),
+});
 
 export default function AnalyticsPage() {
-  const [pnl, setPnl] = useState<PnLSeries | null>(null);
-  const [rent, setRent] = useState<RentMetrics | null>(null);
-  const [expenseData, setExpenseData] = useState<ExpenseBreakdown | null>(null);
-  const [occupancy, setOccupancy] = useState<Occupancy | null>(null);
+  const [state, setState] = useState<AnalyticsStateType>(defaultState);
+  useUrlState(state, setState);
+  const { data } = useSeries(state);
 
-  useEffect(() => {
-    fetch("/api/analytics/pnl")
-      .then((res) => res.json())
-      .then((json) => setPnl(zPnlSeries.parse(json)))
-      .catch(() => {});
-    fetch("/api/analytics/rent")
-      .then((res) => res.json())
-      .then((json) => setRent(zRentMetrics.parse(json)))
-      .catch(() => {});
-    fetch("/api/analytics/expenses")
-      .then((res) => res.json())
-      .then((json) => setExpenseData(zExpenseBreakdown.parse(json)))
-      .catch(() => {});
-    fetch("/api/analytics/occupancy")
-      .then((res) => res.json())
-      .then((json) => setOccupancy(zOccupancy.parse(json)))
-      .catch(() => {});
-  }, []);
+  const chartData = data?.buckets || [];
 
   return (
-    <div className="p-6 space-y-6">
-      <h1 className="text-2xl font-semibold">Analytics</h1>
-
-      <div className="grid gap-4 md:grid-cols-4" data-testid="kpis">
-        <div className="p-4 border rounded" data-testid="kpi-net">
-          <div className="text-sm text-gray-500">Net</div>
-          <div className="text-xl font-bold">{pnl ? pnl.totals.net : '-'}</div>
+    <div className="flex">
+      <div className="flex-1 p-6 space-y-4">
+        <h1 className="text-2xl font-semibold mb-4">Analytics</h1>
+        <div data-testid="viz-section">
+          {state.viz === 'line' && <VizLine data={chartData} />}
+          {state.viz === 'pie' && <VizPie data={chartData} />}
+          {state.viz === 'custom' && <CustomGraphBuilder onRun={() => {}} />}
         </div>
-        <div className="p-4 border rounded" data-testid="kpi-collection">
-          <div className="text-sm text-gray-500">Collection rate</div>
-          <div className="text-xl font-bold">
-            {rent ? `${Math.round(rent.collectionRate * 100)}%` : '-'}
-          </div>
-        </div>
-        <div className="p-4 border rounded" data-testid="kpi-arrears">
-          <div className="text-sm text-gray-500">Arrears amount</div>
-          <div className="text-xl font-bold">{rent ? rent.arrearsAmount : '-'}</div>
-        </div>
-        <div className="p-4 border rounded" data-testid="kpi-occupancy">
-          <div className="text-sm text-gray-500">Occupancy rate</div>
-          <div className="text-xl font-bold">
-            {occupancy ? `${Math.round(occupancy.occupancyRate * 100)}%` : '-'}
-          </div>
-        </div>
+        <ExportButtons csvData={JSON.stringify(chartData)} />
       </div>
-
-      <section>
-        <h2 className="font-semibold mb-2">P&L Trend</h2>
-        {pnl ? <PnLChart data={pnl.series} /> : <Skeleton className="h-64" />}
-        <a className="text-sm text-blue-600" href="/api/analytics/export/pnl.csv">
-          Export CSV
-        </a>
-      </section>
-
-      <section>
-        <h2 className="font-semibold mb-2">Expense Breakdown</h2>
-        {expenseData ? (
-          <>
-            <div className="h-64">
-              <ResponsiveContainer width="100%" height="100%">
-                <PieChart>
-                  <Pie
-                    dataKey="amount"
-                    nameKey="category"
-                    data={expenseData.slices}
-                    label
-                  >
-                    {expenseData.slices.map((_, i) => (
-                      <Cell key={i} fill={COLORS[i % COLORS.length]} />
-                    ))}
-                  </Pie>
-                  <Tooltip />
-                </PieChart>
-              </ResponsiveContainer>
-            </div>
-            <ul className="mt-2">
-              {expenseData.slices.map((s) => (
-                <li key={s.category} data-testid="expense-category">
-                  {s.category}: {s.amount}
-                </li>
-              ))}
-            </ul>
-          </>
-        ) : (
-          <Skeleton className="h-64" />
-        )}
-        <a className="text-sm text-blue-600" href="/api/analytics/export/expenses.csv">
-          Export CSV
-        </a>
-      </section>
-
-      <section>
-        <h2 className="font-semibold mb-2">Rent Collection</h2>
-        {rent ? (
-          <div className="h-64">
-            <ResponsiveContainer width="100%" height="100%">
-              <BarChart data={[{ name: 'Rent', expected: rent.expected, received: rent.received }]}> 
-                <XAxis dataKey="name" stroke="currentColor" />
-                <YAxis stroke="currentColor" />
-                <Tooltip />
-                <Bar dataKey="expected" fill="#8884d8" />
-                <Bar dataKey="received" fill="#82ca9d" />
-              </BarChart>
-            </ResponsiveContainer>
-          </div>
-        ) : (
-          <Skeleton className="h-64" />
-        )}
-        <a className="text-sm text-blue-600" href="/api/analytics/export/rent.csv">
-          Export CSV
-        </a>
-      </section>
-
-      <section>
-        <h2 className="font-semibold mb-2">Occupancy</h2>
-        {occupancy ? (
-          <div className="text-xl font-bold">{Math.round(occupancy.occupancyRate * 100)}%</div>
-        ) : (
-          <Skeleton className="h-8" />
-        )}
-      </section>
+      <div className="w-80 p-4 space-y-4 hidden lg:block">
+        <DateRangeFilter state={state} onChange={(s) => setState(prev => ({ ...prev, ...s }))} />
+        <AppliedFiltersPanel
+          state={state}
+          onAdd={(key, value) =>
+            setState(prev => ({
+              ...prev,
+              filters: {
+                ...prev.filters,
+                [key]: Array.from(new Set([...(prev.filters[key] || []), value])),
+              },
+            }))
+          }
+          onRemove={(key, value) =>
+            setState(prev => ({
+              ...prev,
+              filters: {
+                ...prev.filters,
+                [key]: (prev.filters[key] || []).filter(v => v !== value),
+              },
+            }))
+          }
+        />
+        <SearchIncomePanel />
+        <SearchExpensesPanel />
+        <PresetMenu />
+      </div>
     </div>
   );
 }

--- a/app/api/analytics/breakdown/route.ts
+++ b/app/api/analytics/breakdown/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const data = {
+    total: 0,
+    items: [
+      { label: 'A', value: 50 },
+      { label: 'B', value: 30 },
+    ],
+  };
+  return NextResponse.json(data);
+}

--- a/app/api/analytics/presets/[id]/route.ts
+++ b/app/api/analytics/presets/[id]/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+let presets: any[] = [];
+
+export async function DELETE(_: Request, { params }: { params: { id: string } }) {
+  presets = presets.filter(p => p.id !== params.id);
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/analytics/presets/route.ts
+++ b/app/api/analytics/presets/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+let presets: any[] = [];
+
+export async function GET() {
+  return NextResponse.json(presets);
+}
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const id = Date.now().toString();
+  presets.push({ id, ...body });
+  return NextResponse.json({ id });
+}

--- a/app/api/analytics/series/route.ts
+++ b/app/api/analytics/series/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from 'next/server';
+import { incomes, expenses, rentLedger } from '../../store';
+
+function monthKey(d: Date) {
+  return d.toISOString().slice(0, 7);
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const from = new Date(searchParams.get('from') ?? '2000-01-01');
+  const to = new Date(searchParams.get('to') ?? '2100-01-01');
+  const metric = searchParams.get('metric') ?? 'net';
+
+  const incomeEntries = [
+    ...incomes,
+    ...rentLedger
+      .filter((r) => r.status === 'paid')
+      .map((r) => ({
+        propertyId: r.propertyId,
+        date: r.paidDate ?? r.dueDate,
+        category: 'Base rent',
+        amount: r.amount,
+      })),
+  ];
+
+  const incomeByMonth = new Map<string, number>();
+  for (const i of incomeEntries) {
+    const d = new Date(i.date);
+    if (d < from || d > to) continue;
+    const key = monthKey(d);
+    incomeByMonth.set(key, (incomeByMonth.get(key) || 0) + i.amount);
+  }
+
+  const expenseByMonth = new Map<string, number>();
+  for (const e of expenses) {
+    const d = new Date(e.date);
+    if (d < from || d > to) continue;
+    const key = monthKey(d);
+    expenseByMonth.set(key, (expenseByMonth.get(key) || 0) + e.amount);
+  }
+
+  const labels = Array.from(new Set([...incomeByMonth.keys(), ...expenseByMonth.keys()])).sort();
+  const buckets = labels.map((label) => {
+    const inc = incomeByMonth.get(label) || 0;
+    const exp = expenseByMonth.get(label) || 0;
+    const value = metric === 'income' ? inc : metric === 'expenses' ? exp : inc - exp;
+    return { label, value };
+  });
+  const total = buckets.reduce((sum, b) => sum + b.value, 0);
+  return NextResponse.json({ total, buckets });
+}

--- a/components/Clock.tsx
+++ b/components/Clock.tsx
@@ -33,14 +33,21 @@ export default function Clock({
 }: {
   className?: string;
 }) {
-  const [now, setNow] = useState(new Date());
+  const [now, setNow] = useState<Date | null>(null);
   useEffect(() => {
-    const timer = setInterval(() => setNow(new Date()), 1000);
+    const tick = () => setNow(new Date());
+    tick();
+    const timer = setInterval(tick, 1000);
     return () => clearInterval(timer);
   }, []);
+  if (!now) return <span className={className} />;
   const day = weekdays[now.getDay()];
   const date = `${now.getDate()} ${months[now.getMonth()]} ${now.getFullYear()}`;
   const time = `${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`;
-  return <span className={className}>{`${day} ${date} – ${time}`}</span>;
+  return (
+    <span className={className} suppressHydrationWarning>
+      {`${day} ${date} – ${time}`}
+    </span>
+  );
 }
 

--- a/components/ExpenseForm.tsx
+++ b/components/ExpenseForm.tsx
@@ -7,6 +7,8 @@ import { logEvent } from "../lib/log";
 import { useToast } from "./ui/use-toast";
 import type { PropertySummary } from "../types/property";
 import { EXPENSE_CATEGORIES } from "../lib/categories";
+
+const humanize = (key: string) => key.replace(/([A-Z])/g, " $1").trim();
 type FormState = {
   propertyId: string;
   date: string;
@@ -59,7 +61,10 @@ export default function ExpenseForm({
 
   useEffect(() => {
     const stored = localStorage.getItem("recentExpenseCategories");
-    if (stored) setRecent(JSON.parse(stored));
+    if (stored) {
+      const parsed = JSON.parse(stored) as string[];
+      setRecent(parsed.filter((cat) => cat in EXPENSE_CATEGORIES));
+    }
   }, []);
 
   const addRecent = (cat: string) => {
@@ -186,24 +191,25 @@ export default function ExpenseForm({
                   <optgroup label="Recent">
                     {recent.map((cat) => (
                       <option key={cat} value={cat}>
-                        {cat}
+                        {humanize(cat)}
                       </option>
                     ))}
                   </optgroup>
                 )}
-                {Object.entries(EXPENSE_CATEGORIES).map(([group, items]) => (
-                  <optgroup
-                    key={group}
-                    label={group.replace(/([A-Z])/g, " $1").trim()}
-                  >
-                    {items.map((item) => (
-                      <option key={item} value={item}>
-                        {item}
-                      </option>
-                    ))}
-                  </optgroup>
+                {Object.keys(EXPENSE_CATEGORIES).map((group) => (
+                  <option key={group} value={group}>
+                    {humanize(group)}
+                  </option>
                 ))}
               </select>
+            </label>
+            <label className="block">
+              Custom label
+              <input
+                className="border p-1 w-full"
+                value={form.label}
+                onChange={(e) => setForm({ ...form, label: e.target.value })}
+              />
             </label>
             <label className="block">
               Vendor
@@ -237,14 +243,6 @@ export default function ExpenseForm({
                 className="border p-1 w-full"
                 value={form.notes}
                 onChange={(e) => setForm({ ...form, notes: e.target.value })}
-              />
-            </label>
-            <label className="block">
-              Custom label
-              <input
-                className="border p-1 w-full"
-                value={form.label}
-                onChange={(e) => setForm({ ...form, label: e.target.value })}
               />
             </label>
             {error && <p className="text-red-600 text-sm">{error}</p>}

--- a/hooks/useAnalytics.ts
+++ b/hooks/useAnalytics.ts
@@ -1,0 +1,48 @@
+import { useQuery, useMutation } from '@tanstack/react-query';
+import type { AnalyticsStateType } from '../lib/schemas';
+
+async function fetchJson(url: string, params?: any) {
+  const u = new URL(url, typeof window === 'undefined' ? 'http://localhost' : window.location.origin);
+  if (params) {
+    Object.entries(params).forEach(([k, v]) => {
+      if (v !== undefined) u.searchParams.set(k, typeof v === 'object' ? JSON.stringify(v) : String(v));
+    });
+  }
+  const res = await fetch(u.toString());
+  if (!res.ok) throw new Error('Network error');
+  return res.json();
+}
+
+export function useSeries(params: AnalyticsStateType) {
+  return useQuery({
+    queryKey: ['series', params],
+    queryFn: () => fetchJson('/api/analytics/series', params),
+    staleTime: 30_000,
+  });
+}
+
+export function useBreakdown(params: any) {
+  return useQuery({
+    queryKey: ['breakdown', params],
+    queryFn: () => fetchJson('/api/analytics/breakdown', params),
+    staleTime: 30_000,
+  });
+}
+
+export function usePresets() {
+  return useQuery({
+    queryKey: ['presets'],
+    queryFn: () => fetchJson('/api/analytics/presets'),
+  });
+}
+
+export function useSavePreset() {
+  return useMutation({
+    mutationFn: (body: any) =>
+      fetch('/api/analytics/presets', {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers: { 'Content-Type': 'application/json' },
+      }).then(r => r.json()),
+  });
+}

--- a/lib/download.ts
+++ b/lib/download.ts
@@ -1,0 +1,23 @@
+export function downloadCsv(data: string, filename: string) {
+  const blob = new Blob([data], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+// Placeholder image export; real implementation may use html2canvas or similar
+export async function downloadPng(node: HTMLElement, filename: string) {
+  const canvas = document.createElement('canvas');
+  canvas.width = node.clientWidth;
+  canvas.height = node.clientHeight;
+  const url = canvas.toDataURL('image/png');
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.click();
+}

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const AnalyticsState = z.object({
+  viz: z.enum(['line', 'pie', 'custom']).default('line'),
+  metric: z.enum(['net', 'income', 'expenses']).default('net'),
+  groupBy: z.enum(['time', 'property', 'category', 'tenant']).default('time'),
+  granularity: z.enum(['week', 'month', 'quarter', 'year']).default('month'),
+  from: z.string(),
+  to: z.string(),
+  filters: z
+    .object({
+      properties: z.array(z.string()).default([]),
+      categories: z.array(z.string()).default([]),
+      incomeTypes: z.array(z.string()).default([]),
+      expenseTypes: z.array(z.string()).default([]),
+      tenants: z.array(z.string()).default([]),
+      tags: z.array(z.string()).default([]),
+    })
+    .default({}),
+});
+
+export type AnalyticsStateType = z.infer<typeof AnalyticsState>;

--- a/lib/urlState.test.ts
+++ b/lib/urlState.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { urlState } from './urlState';
+import { AnalyticsState } from './schemas';
+
+describe('urlState', () => {
+  it('round trips state', () => {
+    const state = AnalyticsState.parse({ from: '2024-01-01', to: '2024-02-01' });
+    const params = urlState.serialize(state);
+    const parsed = urlState.parse(params);
+    expect(parsed).toEqual(state);
+  });
+
+  it('provides defaults when params missing', () => {
+    const params = new URLSearchParams();
+    const parsed = urlState.parse(params);
+    expect(typeof parsed.from).toBe('string');
+    expect(typeof parsed.to).toBe('string');
+  });
+});

--- a/lib/urlState.ts
+++ b/lib/urlState.ts
@@ -1,0 +1,69 @@
+import { useEffect } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { AnalyticsState, AnalyticsStateType } from './schemas';
+
+function defaultRange() {
+  const to = new Date();
+  const from = new Date(to.getTime() - 30 * 24 * 60 * 60 * 1000);
+  return { from: from.toISOString(), to: to.toISOString() };
+}
+
+function parse(params: URLSearchParams): AnalyticsStateType {
+  const obj: any = {};
+  params.forEach((value, key) => {
+    obj[key] = value;
+  });
+  // filters can be JSON encoded
+  if (obj.filters) {
+    try {
+      obj.filters = JSON.parse(obj.filters);
+    } catch {
+      obj.filters = {};
+    }
+  }
+  const defaults = defaultRange();
+  try {
+    return AnalyticsState.parse({ ...defaults, ...obj });
+  } catch {
+    return AnalyticsState.parse(defaults);
+  }
+}
+
+function serialize(state: AnalyticsStateType): URLSearchParams {
+  const params = new URLSearchParams();
+  params.set('viz', state.viz);
+  params.set('metric', state.metric);
+  params.set('groupBy', state.groupBy);
+  params.set('granularity', state.granularity);
+  params.set('from', state.from);
+  params.set('to', state.to);
+  params.set('filters', JSON.stringify(state.filters));
+  return params;
+}
+
+/**
+ * Syncs analytics state with the URL query string.
+ */
+export function useUrlState(state: AnalyticsStateType, onChange: (s: AnalyticsStateType) => void) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const search = useSearchParams();
+
+  useEffect(() => {
+    // Parse initial
+    const parsed = parse(search as any as URLSearchParams);
+    onChange(parsed);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const params = serialize(state);
+    const url = `${pathname}?${params.toString()}`;
+    const t = setTimeout(() => {
+      router.replace(url);
+    }, 300);
+    return () => clearTimeout(t);
+  }, [state, router, pathname]);
+}
+
+export const urlState = { parse, serialize };

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
-import { EXPENSE_CATEGORY_OPTIONS, INCOME_CATEGORY_OPTIONS } from './categories';
+import {
+  EXPENSE_CATEGORIES,
+  EXPENSE_CATEGORY_OPTIONS,
+  INCOME_CATEGORY_OPTIONS,
+} from './categories';
 
 export const inspectionSchema = z.object({
   propertyId: z.string(),
@@ -8,9 +12,16 @@ export const inspectionSchema = z.object({
   templateId: z.string().optional(),
 });
 
-export const zExpenseCategory = z.enum(
-  [...EXPENSE_CATEGORY_OPTIONS] as [string, ...string[]]
-);
+// Allow either a top-level expense group or a specific subcategory.
+// Custom expense entries only expose group names in the UI but the backend
+// previously only accepted subcategory labels, so include both here to avoid
+// validation errors when saving.
+const EXPENSE_CATEGORY_ENUM = [
+  ...Object.keys(EXPENSE_CATEGORIES),
+  ...EXPENSE_CATEGORY_OPTIONS,
+] as [string, ...string[]];
+
+export const zExpenseCategory = z.enum(EXPENSE_CATEGORY_ENUM);
 export const zIncomeCategory = z.enum(
   [...INCOME_CATEGORY_OPTIONS] as [string, ...string[]]
 );

--- a/tests/analytics.spec.ts
+++ b/tests/analytics.spec.ts
@@ -1,28 +1,19 @@
 import { test, expect } from '@playwright/test';
 
-test('analytics page loads and KPIs render', async ({ page }) => {
+test('analytics page loads', async ({ page }) => {
   await page.goto('/analytics');
-  await expect(page.getByTestId('kpi-net')).toBeVisible();
-  await expect(page.getByTestId('kpi-collection')).toBeVisible();
+  await expect(page.getByTestId('date-range-filter')).toBeVisible();
+  await expect(page.getByTestId('viz-section')).toBeVisible();
 });
 
-test('pnl series provides multiple points', async ({ request }) => {
-  const res = await request.get('/api/analytics/pnl');
+test('series endpoint responds', async ({ request }) => {
+  const res = await request.get('/api/analytics/series');
   const data = await res.json();
-  expect(data.series.length).toBeGreaterThan(3);
+  expect(Array.isArray(data.buckets)).toBe(true);
 });
 
-test('expense breakdown has categories', async ({ request }) => {
-  const res = await request.get('/api/analytics/expenses');
+test('breakdown endpoint responds', async ({ request }) => {
+  const res = await request.get('/api/analytics/breakdown');
   const data = await res.json();
-  expect(data.slices.length).toBeGreaterThanOrEqual(3);
-});
-
-test('export csv endpoints respond', async ({ request }) => {
-  for (const path of ['/api/analytics/export/pnl.csv', '/api/analytics/export/expenses.csv', '/api/analytics/export/rent.csv']) {
-    const res = await request.get(path);
-    expect(res.status()).toBe(200);
-    const text = await res.text();
-    expect(text.length).toBeGreaterThan(10);
-  }
+  expect(Array.isArray(data.items)).toBe(true);
 });


### PR DESCRIPTION
## Summary
- add analytics state schema and URL sync helpers
- scaffold analytics page with right-rail filters and simple visualisations
- stub analytics API endpoints and hooks
- fix Clock component hydration mismatch causing build error
- fix broken download helper import in export buttons
- correct PresetMenu hook path and header formatting in analytics hooks
- default analytics date range to prevent runtime parse errors
- enhance date range filter with sliders and calendar popup
- support dragging searched categories into applied filters
- wire analytics series data to property incomes and expenses
- show full expense categories in search panel
- limit income and expense search panels to scrollable lists and allow adding custom expenses
- show only top-level expense categories in custom expense form and move custom label field directly under category
- replace "Add custom expense" link with a '+' icon and add a matching control for income
- allow top-level expense group categories in validation to fix custom expense saves

## Testing
- `npm run test:unit` *(fails: vitest not found)*
- `npm test` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c16da1cab0832ca1f880a6273bb914