### PR TITLE
feat: add hierarchical drag-and-drop categories

### DIFF
--- a/app/(app)/analytics/components/SearchIncomePanel.tsx
+++ b/app/(app)/analytics/components/SearchIncomePanel.tsx
@@ -1,13 +1,31 @@
 import { useState } from 'react';
 import IncomeForm from '../../../../components/IncomeForm';
-import { INCOME_CATEGORY_OPTIONS } from '../../../../lib/categories';
+import { INCOME_CATEGORIES } from '../../../../lib/categories';
+
+const humanize = (key: string) => key.replace(/([A-Z])/g, ' $1').trim();
 
 export default function SearchIncomePanel() {
   const [q, setQ] = useState('');
   const [open, setOpen] = useState(false);
-  const items = INCOME_CATEGORY_OPTIONS.filter(c =>
-    c.toLowerCase().includes(q.toLowerCase())
-  );
+  const [openGroups, setOpenGroups] = useState<Record<string, boolean>>({});
+
+  const entries = Object.entries(INCOME_CATEGORIES)
+    .map(([group, children]) => {
+      const matchGroup = humanize(group).toLowerCase().includes(q.toLowerCase());
+      const filteredChildren = children.filter(c =>
+        c.toLowerCase().includes(q.toLowerCase())
+      );
+      return {
+        group,
+        children: q ? (matchGroup ? children : filteredChildren) : children,
+        matchGroup,
+      };
+    })
+    .filter(({ matchGroup, children }) => matchGroup || children.length > 0);
+
+  const toggle = (group: string) =>
+    setOpenGroups(prev => ({ ...prev, [group]: !prev[group] }));
+
   return (
     <div
       data-testid="search-income"
@@ -31,22 +49,55 @@ export default function SearchIncomePanel() {
         className="w-full border rounded p-1 text-sm"
       />
       <div className="space-y-1 max-h-40 overflow-y-auto">
-        {items.map(c => (
-          <div
-            key={c}
-            draggable
-            onDragStart={e =>
-              e.dataTransfer.setData(
-                'application/json',
-                JSON.stringify({ type: 'incomeTypes', value: c })
-              )
-            }
-            className="p-1 text-sm bg-gray-100 rounded cursor-grab"
-          >
-            {c}
-          </div>
-        ))}
-        {items.length === 0 && (
+        {entries.map(({ group, children }) => {
+          const isOpen = openGroups[group] || q !== '';
+          return (
+            <div key={group}>
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  aria-label={`Toggle ${humanize(group)}`}
+                  className="text-xs"
+                  onClick={() => toggle(group)}
+                >
+                  {isOpen ? '-' : '+'}
+                </button>
+                <div
+                  draggable
+                  onDragStart={e =>
+                    e.dataTransfer.setData(
+                      'application/json',
+                      JSON.stringify({ type: 'categories', value: group })
+                    )
+                  }
+                  className="flex-1 p-1 text-sm bg-gray-200 rounded cursor-grab"
+                >
+                  {humanize(group)}
+                </div>
+              </div>
+              {isOpen && (
+                <div className="ml-4 mt-1 space-y-1">
+                  {children.map(c => (
+                    <div
+                      key={c}
+                      draggable
+                      onDragStart={e =>
+                        e.dataTransfer.setData(
+                          'application/json',
+                          JSON.stringify({ type: 'incomeTypes', value: c })
+                        )
+                      }
+                      className="p-1 text-sm bg-gray-100 rounded cursor-grab"
+                    >
+                      {c}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
+        {entries.length === 0 && (
           <div className="text-sm text-gray-500">No results</div>
         )}
       </div>
@@ -54,3 +105,4 @@ export default function SearchIncomePanel() {
     </div>
   );
 }
+

--- a/tests/SearchPanels.test.tsx
+++ b/tests/SearchPanels.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import SearchExpensesPanel from '../app/(app)/analytics/components/SearchExpensesPanel';
+import SearchIncomePanel from '../app/(app)/analytics/components/SearchIncomePanel';
+
+vi.mock('../components/ExpenseForm', () => ({ __esModule: true, default: () => null }));
+vi.mock('../components/IncomeForm', () => ({ __esModule: true, default: () => null }));
+
+describe('SearchExpensesPanel', () => {
+  it('shows categories and allows expanding to items', () => {
+    render(<SearchExpensesPanel />);
+    const category = screen.getByText('Finance Holding');
+    expect(category).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('Toggle Finance Holding'));
+    expect(screen.getByText('Mortgage interest')).toBeInTheDocument();
+    expect(category).toHaveAttribute('draggable', 'true');
+    expect(screen.getByText('Mortgage interest')).toHaveAttribute('draggable', 'true');
+  });
+});
+
+describe('SearchIncomePanel', () => {
+  it('shows categories and allows expanding to items', () => {
+    render(<SearchIncomePanel />);
+    const category = screen.getByText('Core Rent');
+    expect(category).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('Toggle Core Rent'));
+    expect(screen.getByText('Base rent')).toBeInTheDocument();
+    expect(category).toHaveAttribute('draggable', 'true');
+    expect(screen.getByText('Base rent')).toHaveAttribute('draggable', 'true');
+  });
+});
+


### PR DESCRIPTION
## Summary
- allow dragging parent expense categories and expand to drag individual expense items
- enable same behavior for income categories and items
- test category expansion and dragging

## Testing
- `npm run test:unit` *(fails: sh: 1: vitest: not found)*
- `npm test` *(fails: sh: 1: playwright: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@hello-pangea%2fdnd)*

------
https://chatgpt.com/codex/tasks/task_e_68c2283ef650832caac961d696ad3bf1