### PR TITLE
feat: add hierarchical drag-and-drop categories

### DIFF
--- a/app/(app)/analytics/components/AppliedFiltersPanel.tsx
+++ b/app/(app)/analytics/components/AppliedFiltersPanel.tsx
@@ -27,7 +27,7 @@ export default function AppliedFiltersPanel({ state, onAdd, onRemove }: Props) {
   return (
     <div
       data-testid="applied-filters"
-      className="p-4 border rounded-2xl shadow-sm space-y-2"
+      className="p-4 border rounded-2xl shadow-sm space-y-2 bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700"
       onDragOver={e => e.preventDefault()}
       onDrop={handleDrop}
     >
@@ -36,7 +36,7 @@ export default function AppliedFiltersPanel({ state, onAdd, onRemove }: Props) {
         {chips.map(({ key, value }) => (
           <span
             key={key + value}
-            className="px-2 py-1 text-sm bg-gray-200 rounded-full flex items-center gap-1"
+            className="px-2 py-1 text-sm bg-gray-200 dark:bg-gray-700 rounded-full flex items-center gap-1"
           >
             {key}:{value}
             <button
@@ -48,7 +48,9 @@ export default function AppliedFiltersPanel({ state, onAdd, onRemove }: Props) {
             </button>
           </span>
         ))}
-        {chips.length === 0 && <div className="text-sm text-gray-500">None</div>}
+        {chips.length === 0 && (
+          <div className="text-sm text-gray-500 dark:text-gray-400">None</div>
+        )}
       </div>
     </div>
   );

--- a/app/(app)/analytics/components/DateRangeFilter.tsx
+++ b/app/(app)/analytics/components/DateRangeFilter.tsx
@@ -40,7 +40,7 @@ export default function DateRangeFilter({ state, onChange }: Props) {
   return (
     <div
       data-testid="date-range-filter"
-      className="relative p-4 border rounded-2xl shadow-sm select-none"
+      className="relative p-4 border rounded-2xl shadow-sm select-none bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700"
       onClick={() => setShowCal(true)}
     >
       <div className="font-semibold mb-2">Date Range</div>
@@ -89,23 +89,23 @@ export default function DateRangeFilter({ state, onChange }: Props) {
           onClick={() => setShowCal(false)}
         >
           <div
-            className="bg-white p-4 rounded shadow-md space-y-2"
+            className="bg-white dark:bg-gray-800 p-4 rounded shadow-md space-y-2"
             onClick={e => e.stopPropagation()}
           >
             <input
               type="date"
               value={state.from.slice(0, 10)}
               onChange={e => update(new Date(e.target.value), to)}
-              className="border p-1 rounded"
+              className="border p-1 rounded bg-white dark:bg-gray-700 border-gray-200 dark:border-gray-700"
             />
             <input
               type="date"
               value={state.to.slice(0, 10)}
               onChange={e => update(from, new Date(e.target.value))}
-              className="border p-1 rounded"
+              className="border p-1 rounded bg-white dark:bg-gray-700 border-gray-200 dark:border-gray-700"
             />
             <button
-              className="px-2 py-1 text-sm bg-gray-200 rounded"
+              className="px-2 py-1 text-sm bg-gray-200 dark:bg-gray-700 rounded"
               onClick={() => setShowCal(false)}
             >
               Close

--- a/app/(app)/analytics/components/PresetMenu.tsx
+++ b/app/(app)/analytics/components/PresetMenu.tsx
@@ -3,13 +3,16 @@ import { usePresets } from '../../../../hooks/useAnalytics';
 export default function PresetMenu() {
   const { data } = usePresets();
   return (
-    <div data-testid="preset-menu" className="p-4 border rounded-2xl shadow-sm">
+    <div
+      data-testid="preset-menu"
+      className="p-4 border rounded-2xl shadow-sm bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700"
+    >
       <div className="font-semibold mb-2">Presets</div>
       <ul className="list-disc pl-4 text-sm">
         {(data || []).map((p: any) => (
           <li key={p.id}>{p.name}</li>
         ))}
-        {!data && <li className="list-none text-gray-500">None</li>}
+        {!data && <li className="list-none text-gray-500 dark:text-gray-400">None</li>}
       </ul>
     </div>
   );

--- a/app/(app)/analytics/components/SearchExpensesPanel.tsx
+++ b/app/(app)/analytics/components/SearchExpensesPanel.tsx
@@ -1,24 +1,42 @@
 import { useState } from 'react';
 import ExpenseForm from '../../../../components/ExpenseForm';
-import { EXPENSE_CATEGORY_OPTIONS } from '../../../../lib/categories';
+import { EXPENSE_CATEGORIES } from '../../../../lib/categories';
+
+const humanize = (key: string) => key.replace(/([A-Z])/g, ' $1').trim();
 
 export default function SearchExpensesPanel() {
   const [q, setQ] = useState('');
   const [open, setOpen] = useState(false);
-  const items = EXPENSE_CATEGORY_OPTIONS.filter(c =>
-    c.toLowerCase().includes(q.toLowerCase())
-  );
+  const [openGroups, setOpenGroups] = useState<Record<string, boolean>>({});
+
+  const entries = Object.entries(EXPENSE_CATEGORIES)
+    .map(([group, children]) => {
+      const matchGroup = humanize(group).toLowerCase().includes(q.toLowerCase());
+      const filteredChildren = children.filter(c =>
+        c.toLowerCase().includes(q.toLowerCase())
+      );
+      return {
+        group,
+        children: q ? (matchGroup ? children : filteredChildren) : children,
+        matchGroup,
+      };
+    })
+    .filter(({ matchGroup, children }) => matchGroup || children.length > 0);
+
+  const toggle = (group: string) =>
+    setOpenGroups(prev => ({ ...prev, [group]: !prev[group] }));
+
   return (
     <div
       data-testid="search-expenses"
-      className="p-4 border rounded-2xl shadow-sm space-y-2"
+      className="p-4 border rounded-2xl shadow-sm space-y-2 bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700"
     >
       <div className="flex items-center justify-between">
         <div className="font-semibold">Search Expenses</div>
         <button
           aria-label="Add custom expense"
           onClick={() => setOpen(true)}
-          className="text-xl leading-none text-blue-600"
+          className="text-xl leading-none text-blue-600 dark:text-blue-400"
         >
           +
         </button>
@@ -28,29 +46,63 @@ export default function SearchExpensesPanel() {
         value={q}
         onChange={e => setQ(e.target.value)}
         placeholder="Search categories"
-        className="w-full border rounded p-1 text-sm"
+        className="w-full border rounded p-1 text-sm bg-white dark:bg-gray-700 border-gray-200 dark:border-gray-700"
       />
       <div className="space-y-1 max-h-40 overflow-y-auto">
-        {items.map(c => (
-          <div
-            key={c}
-            draggable
-            onDragStart={e =>
-              e.dataTransfer.setData(
-                'application/json',
-                JSON.stringify({ type: 'expenseTypes', value: c })
-              )
-            }
-            className="p-1 text-sm bg-gray-100 rounded cursor-grab"
-          >
-            {c}
-          </div>
-        ))}
-        {items.length === 0 && (
-          <div className="text-sm text-gray-500">No results</div>
+        {entries.map(({ group, children }) => {
+          const isOpen = openGroups[group] || q !== '';
+          return (
+            <div key={group}>
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  aria-label={`Toggle ${humanize(group)}`}
+                  className="text-xs"
+                  onClick={() => toggle(group)}
+                >
+                  {isOpen ? '-' : '+'}
+                </button>
+                <div
+                  draggable
+                  onDragStart={e =>
+                    e.dataTransfer.setData(
+                      'application/json',
+                      JSON.stringify({ type: 'categories', value: group })
+                    )
+                  }
+                  className="flex-1 p-1 text-sm bg-gray-200 dark:bg-gray-700 rounded cursor-grab"
+                >
+                  {humanize(group)}
+                </div>
+              </div>
+              {isOpen && (
+                <div className="ml-4 mt-1 space-y-1">
+                  {children.map(c => (
+                    <div
+                      key={c}
+                      draggable
+                      onDragStart={e =>
+                        e.dataTransfer.setData(
+                          'application/json',
+                          JSON.stringify({ type: 'expenseTypes', value: c })
+                        )
+                      }
+                      className="p-1 text-sm bg-gray-100 dark:bg-gray-600 rounded cursor-grab"
+                    >
+                      {c}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
+        {entries.length === 0 && (
+          <div className="text-sm text-gray-500 dark:text-gray-400">No results</div>
         )}
       </div>
       <ExpenseForm open={open} onOpenChange={setOpen} showTrigger={false} />
     </div>
   );
 }
+

--- a/app/(app)/analytics/components/SearchIncomePanel.tsx
+++ b/app/(app)/analytics/components/SearchIncomePanel.tsx
@@ -1,24 +1,42 @@
 import { useState } from 'react';
 import IncomeForm from '../../../../components/IncomeForm';
-import { INCOME_CATEGORY_OPTIONS } from '../../../../lib/categories';
+import { INCOME_CATEGORIES } from '../../../../lib/categories';
+
+const humanize = (key: string) => key.replace(/([A-Z])/g, ' $1').trim();
 
 export default function SearchIncomePanel() {
   const [q, setQ] = useState('');
   const [open, setOpen] = useState(false);
-  const items = INCOME_CATEGORY_OPTIONS.filter(c =>
-    c.toLowerCase().includes(q.toLowerCase())
-  );
+  const [openGroups, setOpenGroups] = useState<Record<string, boolean>>({});
+
+  const entries = Object.entries(INCOME_CATEGORIES)
+    .map(([group, children]) => {
+      const matchGroup = humanize(group).toLowerCase().includes(q.toLowerCase());
+      const filteredChildren = children.filter(c =>
+        c.toLowerCase().includes(q.toLowerCase())
+      );
+      return {
+        group,
+        children: q ? (matchGroup ? children : filteredChildren) : children,
+        matchGroup,
+      };
+    })
+    .filter(({ matchGroup, children }) => matchGroup || children.length > 0);
+
+  const toggle = (group: string) =>
+    setOpenGroups(prev => ({ ...prev, [group]: !prev[group] }));
+
   return (
     <div
       data-testid="search-income"
-      className="p-4 border rounded-2xl shadow-sm space-y-2"
+      className="p-4 border rounded-2xl shadow-sm space-y-2 bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700"
     >
       <div className="flex items-center justify-between">
         <div className="font-semibold">Search Income</div>
         <button
           aria-label="Add custom income"
           onClick={() => setOpen(true)}
-          className="text-xl leading-none text-blue-600"
+          className="text-xl leading-none text-blue-600 dark:text-blue-400"
         >
           +
         </button>
@@ -28,29 +46,63 @@ export default function SearchIncomePanel() {
         value={q}
         onChange={e => setQ(e.target.value)}
         placeholder="Search categories"
-        className="w-full border rounded p-1 text-sm"
+        className="w-full border rounded p-1 text-sm bg-white dark:bg-gray-700 border-gray-200 dark:border-gray-700"
       />
       <div className="space-y-1 max-h-40 overflow-y-auto">
-        {items.map(c => (
-          <div
-            key={c}
-            draggable
-            onDragStart={e =>
-              e.dataTransfer.setData(
-                'application/json',
-                JSON.stringify({ type: 'incomeTypes', value: c })
-              )
-            }
-            className="p-1 text-sm bg-gray-100 rounded cursor-grab"
-          >
-            {c}
-          </div>
-        ))}
-        {items.length === 0 && (
-          <div className="text-sm text-gray-500">No results</div>
+        {entries.map(({ group, children }) => {
+          const isOpen = openGroups[group] || q !== '';
+          return (
+            <div key={group}>
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  aria-label={`Toggle ${humanize(group)}`}
+                  className="text-xs"
+                  onClick={() => toggle(group)}
+                >
+                  {isOpen ? '-' : '+'}
+                </button>
+                <div
+                  draggable
+                  onDragStart={e =>
+                    e.dataTransfer.setData(
+                      'application/json',
+                      JSON.stringify({ type: 'categories', value: group })
+                    )
+                  }
+                  className="flex-1 p-1 text-sm bg-gray-200 dark:bg-gray-700 rounded cursor-grab"
+                >
+                  {humanize(group)}
+                </div>
+              </div>
+              {isOpen && (
+                <div className="ml-4 mt-1 space-y-1">
+                  {children.map(c => (
+                    <div
+                      key={c}
+                      draggable
+                      onDragStart={e =>
+                        e.dataTransfer.setData(
+                          'application/json',
+                          JSON.stringify({ type: 'incomeTypes', value: c })
+                        )
+                      }
+                      className="p-1 text-sm bg-gray-100 dark:bg-gray-600 rounded cursor-grab"
+                    >
+                      {c}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
+        {entries.length === 0 && (
+          <div className="text-sm text-gray-500 dark:text-gray-400">No results</div>
         )}
       </div>
       <IncomeForm open={open} onOpenChange={setOpen} showTrigger={false} />
     </div>
   );
 }
+

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,31 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Global scrollbar styling for light and dark modes */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: #9ca3af transparent; /* gray-400 */
+}
+
+.dark * {
+  scrollbar-color: #4b5563 transparent; /* gray-600 */
+}
+
+*::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: #9ca3af; /* gray-400 */
+  border-radius: 4px;
+}
+
+.dark *::-webkit-scrollbar-thumb {
+  background-color: #4b5563; /* gray-600 */
+}

--- a/tests/SearchPanels.test.tsx
+++ b/tests/SearchPanels.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import SearchExpensesPanel from '../app/(app)/analytics/components/SearchExpensesPanel';
+import SearchIncomePanel from '../app/(app)/analytics/components/SearchIncomePanel';
+
+vi.mock('../components/ExpenseForm', () => ({ __esModule: true, default: () => null }));
+vi.mock('../components/IncomeForm', () => ({ __esModule: true, default: () => null }));
+
+describe('SearchExpensesPanel', () => {
+  it('shows categories and allows expanding to items', () => {
+    render(<SearchExpensesPanel />);
+    const category = screen.getByText('Finance Holding');
+    expect(category).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('Toggle Finance Holding'));
+    expect(screen.getByText('Mortgage interest')).toBeInTheDocument();
+    expect(category).toHaveAttribute('draggable', 'true');
+    expect(screen.getByText('Mortgage interest')).toHaveAttribute('draggable', 'true');
+  });
+});
+
+describe('SearchIncomePanel', () => {
+  it('shows categories and allows expanding to items', () => {
+    render(<SearchIncomePanel />);
+    const category = screen.getByText('Core Rent');
+    expect(category).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('Toggle Core Rent'));
+    expect(screen.getByText('Base rent')).toBeInTheDocument();
+    expect(category).toHaveAttribute('draggable', 'true');
+    expect(screen.getByText('Base rent')).toHaveAttribute('draggable', 'true');
+  });
+});
+


### PR DESCRIPTION
## Summary
- allow dragging parent expense categories and expand to drag individual expense items
- enable same behavior for income categories and items
- test category expansion and dragging
- integrate filter components with dark mode styling
- theme scrollbars to match light and dark modes

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@hello-pangea%2fdnd)*
- `npm run test:unit` *(fails: sh: 1: vitest: not found)*
- `npm test` *(fails: sh: 1: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2283ef650832caac961d696ad3bf1