### PR TITLE
feat: edit property in modal

### DIFF
--- a/app/(app)/properties/[id]/page.tsx
+++ b/app/(app)/properties/[id]/page.tsx
@@ -10,6 +10,7 @@ import DocumentUploadModal from "../../../../components/DocumentUploadModal";
 import MessageTenantModal from "../../../../components/MessageTenantModal";
 import PropertyOverviewCard from "../../../../components/PropertyOverviewCard";
 import PropertyDetailTabs from "../../../../components/PropertyDetailTabs";
+import PropertyEditModal from "../../../../components/PropertyEditModal";
 import { getProperty } from "../../../../lib/api";
 import type { PropertySummary } from "../../../../types/property";
 
@@ -18,6 +19,7 @@ export default function PropertyPage() {
   const [docOpen, setDocOpen] = useState(false);
   const [messageOpen, setMessageOpen] = useState(false);
   const [moreOpen, setMoreOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
   const { id } = useParams<{ id: string }>();
 
   const { data: property } = useQuery<PropertySummary>({
@@ -34,12 +36,12 @@ export default function PropertyPage() {
         onUploadDocument={() => setDocOpen(true)}
         onMessageTenant={() => setMessageOpen(true)}
       />
-      <Link
-        href={`/properties/${id}/edit`}
+      <button
         className="inline-block px-2 py-1 border rounded"
+        onClick={() => setEditOpen(true)}
       >
         Edit Property
-      </Link>
+      </button>
       <div className="relative inline-block">
         <button
           className="px-2 py-1 border rounded"
@@ -90,6 +92,11 @@ export default function PropertyPage() {
         onClose={() => setDocOpen(false)}
       />
       <MessageTenantModal open={messageOpen} onClose={() => setMessageOpen(false)} />
+      <PropertyEditModal
+        property={property}
+        open={editOpen}
+        onClose={() => setEditOpen(false)}
+      />
       <h1 className="text-2xl font-semibold">Property Details</h1>
       <PropertyOverviewCard property={property} />
       <PropertyDetailTabs propertyId={id} />

--- a/components/PropertyEditModal.tsx
+++ b/components/PropertyEditModal.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import PropertyForm from "./PropertyForm";
+import type { PropertySummary } from "../types/property";
+
+interface Props {
+  open: boolean;
+  property: PropertySummary;
+  onClose: () => void;
+}
+
+export default function PropertyEditModal({ open, property, onClose }: Props) {
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white dark:bg-gray-800 p-4 rounded w-full max-w-md"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-lg font-medium mb-2">Edit Property</h2>
+        <PropertyForm property={property} onSaved={onClose} />
+      </div>
+    </div>
+  );
+}
+

--- a/components/PropertyForm.tsx
+++ b/components/PropertyForm.tsx
@@ -9,9 +9,10 @@ import { useToast } from "./ui/use-toast";
 
 interface Props {
   property?: PropertySummary;
+  onSaved?: (property: PropertySummary) => void;
 }
 
-export default function PropertyForm({ property }: Props) {
+export default function PropertyForm({ property, onSaved }: Props) {
   const isEdit = !!property;
   const [form, setForm] = useState({
     address: property?.address ?? "",
@@ -35,7 +36,10 @@ export default function PropertyForm({ property }: Props) {
       queryClient.invalidateQueries({ queryKey: ["properties"] });
       if (isEdit) {
         queryClient.invalidateQueries({ queryKey: ["property", property!.id] });
-        router.push(`/properties/${property!.id}`);
+        onSaved?.(p);
+        if (!onSaved) {
+          router.push(`/properties/${property!.id}`);
+        }
       } else {
         router.push(`/properties/${p.id}`);
       }


### PR DESCRIPTION
## Summary
- show property edit form in a modal instead of full page
- allow closing modal by clicking outside without saving
- close modal after successful save

## Testing
- `npm test` *(fails: playwright: not found)*
- `npm run test:unit` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b78fb3e8832c8460c0f71f9820f8