### PR TITLE
Improve expense logging popup and dark mode

### DIFF
--- a/components/ExpenseForm.tsx
+++ b/components/ExpenseForm.tsx
@@ -106,6 +106,12 @@ export default function ExpenseForm({
     },
   });
 
+  const handleClose = () => {
+    setOpen(false);
+    setForm(getInitialForm());
+    setError(null);
+  };
+
   return (
     <div>
       {showTrigger && (
@@ -118,9 +124,13 @@ export default function ExpenseForm({
       )}
 
       {open && (
-        <div className="fixed inset-0 bg-black/50 flex justify-end">
+        <div
+          className="fixed inset-0 bg-black/50 flex items-center justify-center"
+          onClick={handleClose}
+        >
           <form
-            className="bg-white w-96 h-full p-4 space-y-2 overflow-y-auto"
+            className="bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 w-full max-w-md p-4 space-y-2 rounded-lg shadow-lg overflow-y-auto"
+            onClick={(e) => e.stopPropagation()}
             onSubmit={(e) => {
               e.preventDefault();
               setError(null);
@@ -152,10 +162,10 @@ export default function ExpenseForm({
             }}
           >
             {!propertyId && (
-              <label className="block">
+              <label className="block text-gray-700 dark:text-gray-300">
                 Property
                 <select
-                  className="border p-1 w-full"
+                  className="border p-1 w-full rounded bg-white dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
                   value={form.propertyId}
                   onChange={(e) =>
                     setForm({ ...form, propertyId: e.target.value })
@@ -170,19 +180,19 @@ export default function ExpenseForm({
                 </select>
               </label>
             )}
-            <label className="block">
+            <label className="block text-gray-700 dark:text-gray-300">
               Date
               <input
                 type="date"
-                className="border p-1 w-full"
+                className="border p-1 w-full rounded bg-white dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
                 value={form.date}
                 onChange={(e) => setForm({ ...form, date: e.target.value })}
               />
             </label>
-            <label className="block">
+            <label className="block text-gray-700 dark:text-gray-300">
               Category
               <select
-                className="border p-1 w-full"
+                className="border p-1 w-full rounded bg-white dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
                 value={form.category}
                 onChange={(e) => setForm({ ...form, category: e.target.value })}
               >
@@ -203,44 +213,44 @@ export default function ExpenseForm({
                 ))}
               </select>
             </label>
-            <label className="block">
+            <label className="block text-gray-700 dark:text-gray-300">
               Custom label
               <input
-                className="border p-1 w-full"
+                className="border p-1 w-full rounded bg-white dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
                 value={form.label}
                 onChange={(e) => setForm({ ...form, label: e.target.value })}
               />
             </label>
-            <label className="block">
+            <label className="block text-gray-700 dark:text-gray-300">
               Vendor
               <input
-                className="border p-1 w-full"
+                className="border p-1 w-full rounded bg-white dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
                 value={form.vendor}
                 onChange={(e) => setForm({ ...form, vendor: e.target.value })}
               />
             </label>
-            <label className="block">
+            <label className="block text-gray-700 dark:text-gray-300">
               Amount
               <input
                 type="number"
-                className="border p-1 w-full"
+                className="border p-1 w-full rounded bg-white dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
                 value={form.amount}
                 onChange={(e) => setForm({ ...form, amount: e.target.value })}
               />
             </label>
-            <label className="block">
+            <label className="block text-gray-700 dark:text-gray-300">
               GST
               <input
                 type="number"
-                className="border p-1 w-full"
+                className="border p-1 w-full rounded bg-white dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
                 value={form.gst}
                 onChange={(e) => setForm({ ...form, gst: e.target.value })}
               />
             </label>
-            <label className="block">
+            <label className="block text-gray-700 dark:text-gray-300">
               Notes
               <textarea
-                className="border p-1 w-full"
+                className="border p-1 w-full rounded bg-white dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
                 value={form.notes}
                 onChange={(e) => setForm({ ...form, notes: e.target.value })}
               />
@@ -249,14 +259,14 @@ export default function ExpenseForm({
             <div className="flex justify-end gap-2 pt-2">
               <button
                 type="button"
-                className="px-2 py-1 bg-gray-100"
-                onClick={() => setOpen(false)}
+                className="px-2 py-1 bg-gray-100 dark:bg-gray-700 dark:text-gray-100 rounded"
+                onClick={handleClose}
               >
                 Cancel
               </button>
               <button
                 type="submit"
-                className="px-2 py-1 bg-green-500 text-white"
+                className="px-2 py-1 bg-green-500 text-white rounded"
               >
                 Save
               </button>


### PR DESCRIPTION
## Summary
- Replace slide-out expense form with centered popup card
- Add dark mode styling to expense form fields
- Close and reset expense form when clicking outside the popup

## Testing
- `npm test` *(fails: playwright not found)*
- `npm install` *(fails: 403 Forbidden on @hello-pangea/dnd)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b7ebb1ac832cbeaecc3fb9e9d2c0