### PR TITLE
fix: correct link closing tag

### DIFF
--- a/app/(app)/properties/[id]/page.tsx
+++ b/app/(app)/properties/[id]/page.tsx
@@ -41,7 +41,7 @@ export default function PropertyPage() {
         className="inline-block px-2 py-1 border rounded dark:border-gray-700"
       >
         Edit Property
-      </button>
+      </Link>
       <div className="relative inline-block">
         <button
           className="px-2 py-1 border rounded dark:border-gray-700"


### PR DESCRIPTION
## Summary
- correct closing tag in property detail page to avoid build errors

## Testing
- `npm test` *(fails: playwright: not found)*
- `npm run test:unit` *(fails: vitest: not found)*
- `npm install` *(fails: 403 forbidden for @hello-pangea/dnd)*


------
https://chatgpt.com/codex/tasks/task_e_68c2bbaf4ec4832c8749b6cca7a1f0f6