### PR TITLE
feat: make rent ledger entries editable via popup

### DIFF
--- a/components/EditLedgerEntryModal.tsx
+++ b/components/EditLedgerEntryModal.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { LedgerEntry } from "../types/property";
+
+interface Props {
+  entry: LedgerEntry;
+  onSave: (entry: LedgerEntry) => void;
+  onClose: () => void;
+}
+
+export default function EditLedgerEntryModal({ entry, onSave, onClose }: Props) {
+  const [datePaid, setDatePaid] = useState(entry.date);
+  const [amount, setAmount] = useState(entry.amount.toString());
+
+  useEffect(() => {
+    setDatePaid(entry.date);
+    setAmount(entry.amount.toString());
+  }, [entry]);
+
+  const daysLate = Math.max(
+    0,
+    Math.floor(
+      (new Date(datePaid).getTime() - new Date(entry.date).getTime()) /
+        (1000 * 60 * 60 * 24)
+    )
+  );
+
+  const handleSave = () => {
+    onSave({ ...entry, date: datePaid, amount: parseFloat(amount) || 0 });
+  };
+
+  const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  return (
+    <div
+      onClick={handleOverlayClick}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    >
+      <div className="w-80 rounded-lg bg-white p-4 dark:bg-gray-800" onClick={(e) => e.stopPropagation()}>
+        <h2 className="mb-4 text-lg font-semibold">Ledger Entry</h2>
+        <div className="mb-2">
+          <label className="mb-1 block text-sm">Date Paid</label>
+          <input
+            type="date"
+            className="w-full rounded border p-2 dark:bg-gray-700 dark:border-gray-600"
+            value={datePaid}
+            onChange={(e) => setDatePaid(e.target.value)}
+          />
+          {daysLate > 0 && (
+            <p className="mt-1 text-sm text-red-500">Late by {daysLate} day(s)</p>
+          )}
+        </div>
+        <div className="mb-2">
+          <label className="mb-1 block text-sm">Amount</label>
+          <input
+            type="number"
+            className="w-full rounded border p-2 dark:bg-gray-700 dark:border-gray-600"
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+          />
+        </div>
+        <div className="mb-2 text-sm">
+          <p>Description: {entry.description}</p>
+          <p>Balance: {entry.balance}</p>
+        </div>
+        <div className="mt-4 flex justify-end gap-2">
+          <button
+            className="rounded bg-gray-200 px-4 py-2 dark:bg-gray-700"
+            onClick={onClose}
+          >
+            Cancel
+          </button>
+          <button
+            className="rounded bg-blue-600 px-4 py-2 text-white"
+            onClick={handleSave}
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/components/RentLedgerTable.tsx
+++ b/components/RentLedgerTable.tsx
@@ -2,8 +2,10 @@
 
 import { useParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
 import { listLedger } from "../lib/api";
 import type { LedgerEntry } from "../types/property";
+import EditLedgerEntryModal from "./EditLedgerEntryModal";
 
 export default function RentLedgerTable({
   propertyId: propId,
@@ -17,6 +19,27 @@ export default function RentLedgerTable({
     queryFn: () => listLedger(propertyId),
   });
 
+  const [entries, setEntries] = useState<LedgerEntry[]>([]);
+  const [selected, setSelected] = useState<LedgerEntry | null>(null);
+
+  const calculateBalances = (items: LedgerEntry[]) => {
+    let balance = 0;
+    return items.map((e) => {
+      balance += e.amount;
+      return { ...e, balance };
+    });
+  };
+
+  useEffect(() => {
+    setEntries(calculateBalances(data));
+  }, [data]);
+
+  const handleSave = (entry: LedgerEntry) => {
+    const updated = entries.map((e) => (e.id === entry.id ? entry : e));
+    setEntries(calculateBalances(updated));
+    setSelected(null);
+  };
+
   return (
     <table className="min-w-full border bg-white dark:bg-gray-800 dark:border-gray-700">
       <thead className="bg-gray-100 dark:bg-gray-700">
@@ -28,8 +51,12 @@ export default function RentLedgerTable({
         </tr>
       </thead>
       <tbody>
-        {data.map((e) => (
-          <tr key={e.id} className="border-t dark:border-gray-700">
+        {entries.map((e) => (
+          <tr
+            key={e.id}
+            className="cursor-pointer border-t hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700"
+            onClick={() => setSelected(e)}
+          >
             <td className="p-2">{e.date}</td>
             <td className="p-2">{e.description}</td>
             <td className="p-2">{e.amount}</td>
@@ -38,6 +65,13 @@ export default function RentLedgerTable({
         ))}
       </tbody>
     </table>
+    {selected && (
+      <EditLedgerEntryModal
+        entry={selected}
+        onSave={handleSave}
+        onClose={() => setSelected(null)}
+      />
+    )}
   );
 }
 


### PR DESCRIPTION
## Summary
- make rent ledger rows clickable and editable
- add modal to edit date and amount with late payment warning

## Testing
- `npm run test:unit` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden on @hello-pangea/dnd)*
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2be165870832c8237a0da2264b82b