### PR TITLE
feat: add dark mode styling to analytics filters

### DIFF
--- a/app/(app)/analytics/components/AppliedFiltersPanel.tsx
+++ b/app/(app)/analytics/components/AppliedFiltersPanel.tsx
@@ -27,7 +27,7 @@ export default function AppliedFiltersPanel({ state, onAdd, onRemove }: Props) {
   return (
     <div
       data-testid="applied-filters"
-      className="p-4 border rounded-2xl shadow-sm space-y-2"
+      className="p-4 border rounded-2xl shadow-sm space-y-2 bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700"
       onDragOver={e => e.preventDefault()}
       onDrop={handleDrop}
     >
@@ -36,7 +36,7 @@ export default function AppliedFiltersPanel({ state, onAdd, onRemove }: Props) {
         {chips.map(({ key, value }) => (
           <span
             key={key + value}
-            className="px-2 py-1 text-sm bg-gray-200 rounded-full flex items-center gap-1"
+            className="px-2 py-1 text-sm bg-gray-200 dark:bg-gray-700 rounded-full flex items-center gap-1 text-gray-900 dark:text-gray-100"
           >
             {key}:{value}
             <button
@@ -48,7 +48,7 @@ export default function AppliedFiltersPanel({ state, onAdd, onRemove }: Props) {
             </button>
           </span>
         ))}
-        {chips.length === 0 && <div className="text-sm text-gray-500">None</div>}
+        {chips.length === 0 && <div className="text-sm text-gray-500 dark:text-gray-400">None</div>}
       </div>
     </div>
   );

--- a/app/(app)/analytics/components/DateRangeFilter.tsx
+++ b/app/(app)/analytics/components/DateRangeFilter.tsx
@@ -40,7 +40,7 @@ export default function DateRangeFilter({ state, onChange }: Props) {
   return (
     <div
       data-testid="date-range-filter"
-      className="relative p-4 border rounded-2xl shadow-sm select-none"
+      className="relative p-4 border rounded-2xl shadow-sm select-none bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700"
       onClick={() => setShowCal(true)}
     >
       <div className="font-semibold mb-2">Date Range</div>
@@ -85,27 +85,27 @@ export default function DateRangeFilter({ state, onChange }: Props) {
       </div>
       {showCal && (
         <div
-          className="absolute inset-0 flex items-center justify-center bg-black/20"
+          className="absolute inset-0 flex items-center justify-center bg-black/20 dark:bg-black/50"
           onClick={() => setShowCal(false)}
         >
           <div
-            className="bg-white p-4 rounded shadow-md space-y-2"
+            className="bg-white dark:bg-gray-800 p-4 rounded shadow-md space-y-2"
             onClick={e => e.stopPropagation()}
           >
             <input
               type="date"
               value={state.from.slice(0, 10)}
               onChange={e => update(new Date(e.target.value), to)}
-              className="border p-1 rounded"
+              className="border p-1 rounded bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100"
             />
             <input
               type="date"
               value={state.to.slice(0, 10)}
               onChange={e => update(from, new Date(e.target.value))}
-              className="border p-1 rounded"
+              className="border p-1 rounded bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100"
             />
             <button
-              className="px-2 py-1 text-sm bg-gray-200 rounded"
+              className="px-2 py-1 text-sm bg-gray-200 dark:bg-gray-700 rounded"
               onClick={() => setShowCal(false)}
             >
               Close

--- a/app/(app)/analytics/components/PresetMenu.tsx
+++ b/app/(app)/analytics/components/PresetMenu.tsx
@@ -3,13 +3,16 @@ import { usePresets } from '../../../../hooks/useAnalytics';
 export default function PresetMenu() {
   const { data } = usePresets();
   return (
-    <div data-testid="preset-menu" className="p-4 border rounded-2xl shadow-sm">
+    <div
+      data-testid="preset-menu"
+      className="p-4 border rounded-2xl shadow-sm bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700"
+    >
       <div className="font-semibold mb-2">Presets</div>
       <ul className="list-disc pl-4 text-sm">
         {(data || []).map((p: any) => (
           <li key={p.id}>{p.name}</li>
         ))}
-        {!data && <li className="list-none text-gray-500">None</li>}
+        {!data && <li className="list-none text-gray-500 dark:text-gray-400">None</li>}
       </ul>
     </div>
   );

--- a/app/(app)/analytics/components/SearchExpensesPanel.tsx
+++ b/app/(app)/analytics/components/SearchExpensesPanel.tsx
@@ -11,14 +11,14 @@ export default function SearchExpensesPanel() {
   return (
     <div
       data-testid="search-expenses"
-      className="p-4 border rounded-2xl shadow-sm space-y-2"
+      className="p-4 border rounded-2xl shadow-sm space-y-2 bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700"
     >
       <div className="flex items-center justify-between">
         <div className="font-semibold">Search Expenses</div>
         <button
           aria-label="Add custom expense"
           onClick={() => setOpen(true)}
-          className="text-xl leading-none text-blue-600"
+          className="text-xl leading-none text-blue-600 dark:text-blue-400"
         >
           +
         </button>
@@ -28,7 +28,7 @@ export default function SearchExpensesPanel() {
         value={q}
         onChange={e => setQ(e.target.value)}
         placeholder="Search categories"
-        className="w-full border rounded p-1 text-sm"
+        className="w-full border rounded p-1 text-sm bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100"
       />
       <div className="space-y-1 max-h-40 overflow-y-auto">
         {items.map(c => (
@@ -41,13 +41,13 @@ export default function SearchExpensesPanel() {
                 JSON.stringify({ type: 'expenseTypes', value: c })
               )
             }
-            className="p-1 text-sm bg-gray-100 rounded cursor-grab"
+            className="p-1 text-sm bg-gray-100 dark:bg-gray-700 rounded cursor-grab text-gray-900 dark:text-gray-100"
           >
             {c}
           </div>
         ))}
         {items.length === 0 && (
-          <div className="text-sm text-gray-500">No results</div>
+          <div className="text-sm text-gray-500 dark:text-gray-400">No results</div>
         )}
       </div>
       <ExpenseForm open={open} onOpenChange={setOpen} showTrigger={false} />

--- a/app/(app)/analytics/components/SearchIncomePanel.tsx
+++ b/app/(app)/analytics/components/SearchIncomePanel.tsx
@@ -11,14 +11,14 @@ export default function SearchIncomePanel() {
   return (
     <div
       data-testid="search-income"
-      className="p-4 border rounded-2xl shadow-sm space-y-2"
+      className="p-4 border rounded-2xl shadow-sm space-y-2 bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700"
     >
       <div className="flex items-center justify-between">
         <div className="font-semibold">Search Income</div>
         <button
           aria-label="Add custom income"
           onClick={() => setOpen(true)}
-          className="text-xl leading-none text-blue-600"
+          className="text-xl leading-none text-blue-600 dark:text-blue-400"
         >
           +
         </button>
@@ -28,7 +28,7 @@ export default function SearchIncomePanel() {
         value={q}
         onChange={e => setQ(e.target.value)}
         placeholder="Search categories"
-        className="w-full border rounded p-1 text-sm"
+        className="w-full border rounded p-1 text-sm bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100"
       />
       <div className="space-y-1 max-h-40 overflow-y-auto">
         {items.map(c => (
@@ -41,13 +41,13 @@ export default function SearchIncomePanel() {
                 JSON.stringify({ type: 'incomeTypes', value: c })
               )
             }
-            className="p-1 text-sm bg-gray-100 rounded cursor-grab"
+            className="p-1 text-sm bg-gray-100 dark:bg-gray-700 rounded cursor-grab text-gray-900 dark:text-gray-100"
           >
             {c}
           </div>
         ))}
         {items.length === 0 && (
-          <div className="text-sm text-gray-500">No results</div>
+          <div className="text-sm text-gray-500 dark:text-gray-400">No results</div>
         )}
       </div>
       <IncomeForm open={open} onOpenChange={setOpen} showTrigger={false} />


### PR DESCRIPTION
## Summary
- style analytics filter panels for dark mode
- ensure drag chip backgrounds and inputs adapt to theme

## Testing
- `npm test` *(fails: playwright not found)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2beb248f8832cbf54f5c24294fbf3