### PR TITLE
feat: group analytics search filters

### DIFF
--- a/app/(app)/analytics/components/SearchIncomePanel.tsx
+++ b/app/(app)/analytics/components/SearchIncomePanel.tsx
@@ -1,13 +1,19 @@
 import { useState } from 'react';
 import IncomeForm from '../../../../components/IncomeForm';
-import { INCOME_CATEGORY_OPTIONS } from '../../../../lib/categories';
+import { INCOME_CATEGORIES } from '../../../../lib/categories';
 
 export default function SearchIncomePanel() {
   const [q, setQ] = useState('');
   const [open, setOpen] = useState(false);
-  const items = INCOME_CATEGORY_OPTIONS.filter(c =>
-    c.toLowerCase().includes(q.toLowerCase())
-  );
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const qLower = q.toLowerCase();
+  const entries = Object.entries(INCOME_CATEGORIES).filter(([group, items]) => {
+    const label = group.replace(/([A-Z])/g, ' $1').trim();
+    return (
+      label.toLowerCase().includes(qLower) ||
+      items.some(i => i.toLowerCase().includes(qLower))
+    );
+  });
   return (
     <div
       data-testid="search-income"
@@ -31,22 +37,61 @@ export default function SearchIncomePanel() {
         className="w-full border rounded p-1 text-sm bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100"
       />
       <div className="space-y-1 max-h-40 overflow-y-auto">
-        {items.map(c => (
-          <div
-            key={c}
-            draggable
-            onDragStart={e =>
-              e.dataTransfer.setData(
-                'application/json',
-                JSON.stringify({ type: 'incomeTypes', value: c })
-              )
-            }
-            className="p-1 text-sm bg-gray-100 dark:bg-gray-700 rounded cursor-grab text-gray-900 dark:text-gray-100"
-          >
-            {c}
-          </div>
-        ))}
-        {items.length === 0 && (
+        {entries.map(([group, items]) => {
+          const label = group.replace(/([A-Z])/g, ' $1').trim();
+          const showItems = expanded[group] || qLower.length > 0;
+          const filteredItems = items.filter(i =>
+            i.toLowerCase().includes(qLower)
+          );
+          return (
+            <div key={group} className="space-y-1">
+              <div
+                draggable
+                onDragStart={e =>
+                  e.dataTransfer.setData(
+                    'application/json',
+                    JSON.stringify({ type: 'incomeTypes', value: label })
+                  )
+                }
+                className="p-1 text-sm bg-gray-100 dark:bg-gray-700 rounded cursor-grab flex items-center justify-between text-gray-900 dark:text-gray-100"
+              >
+                <span>{label}</span>
+                <button
+                  aria-label={`Toggle ${label}`}
+                  onClick={() =>
+                    setExpanded(prev => ({
+                      ...prev,
+                      [group]: !prev[group],
+                    }))
+                  }
+                  className="ml-2 text-xs"
+                >
+                  {expanded[group] || qLower.length > 0 ? '-' : '+'}
+                </button>
+              </div>
+              {showItems &&
+                filteredItems.map(item => (
+                  <div
+                    key={item}
+                    draggable
+                    onDragStart={e =>
+                      e.dataTransfer.setData(
+                        'application/json',
+                        JSON.stringify({
+                          type: 'incomeTypes',
+                          value: item,
+                        })
+                      )
+                    }
+                    className="ml-4 p-1 text-sm bg-gray-100 dark:bg-gray-700 rounded cursor-grab text-gray-900 dark:text-gray-100"
+                  >
+                    {item}
+                  </div>
+                ))}
+            </div>
+          );
+        })}
+        {entries.length === 0 && (
           <div className="text-sm text-gray-500 dark:text-gray-400">No results</div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- display income and expense filters grouped by high-level categories
- allow expanding groups to drag entire category or individual items

## Testing
- `npm run test:unit` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@hello-pangea%2fdnd)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c11aaf78832cb231246d71d3b815