### PR TITLE
Hide irrelevant analytics metrics when filters missing

### DIFF
--- a/app/(app)/analytics/components/VizLine.tsx
+++ b/app/(app)/analytics/components/VizLine.tsx
@@ -2,6 +2,9 @@ import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } f
 
 interface Props {
   data: { label: string; income: number; expenses: number; net: number }[];
+  showIncome?: boolean;
+  showExpenses?: boolean;
+  showNet?: boolean;
 }
 
 const formatLabel = (label: string) => {
@@ -11,11 +14,13 @@ const formatLabel = (label: string) => {
   return `${monthName} '${year.slice(2)}`;
 };
 
-export default function VizLine({ data }: Props) {
+export default function VizLine({ data, showIncome = true, showExpenses = true, showNet = true }: Props) {
+  const hasData = data.length > 0;
+  const chartData = hasData ? data : [{ label: '', income: 0, expenses: 0, net: 0 }];
   return (
     <div data-testid="viz-line" className="h-64">
       <ResponsiveContainer width="100%" height="100%">
-        <LineChart data={data}>
+        <LineChart data={chartData}>
           <XAxis dataKey="label" tickFormatter={formatLabel} />
           <YAxis />
           <Tooltip
@@ -23,9 +28,15 @@ export default function VizLine({ data }: Props) {
             formatter={(value: number, name: string) => [value, name.charAt(0).toUpperCase() + name.slice(1)]}
           />
           <Legend />
-          <Line type="monotone" dataKey="net" stroke="#10b981" name="Net" dot={false} />
-          <Line type="monotone" dataKey="income" stroke="#3b82f6" name="Income" dot={false} />
-          <Line type="monotone" dataKey="expenses" stroke="#ef4444" name="Expenses" dot={false} />
+          {showNet && hasData && (
+            <Line type="monotone" dataKey="net" stroke="#10b981" name="Net" dot={false} />
+          )}
+          {showIncome && hasData && (
+            <Line type="monotone" dataKey="income" stroke="#3b82f6" name="Income" dot={false} />
+          )}
+          {showExpenses && hasData && (
+            <Line type="monotone" dataKey="expenses" stroke="#ef4444" name="Expenses" dot={false} />
+          )}
         </LineChart>
       </ResponsiveContainer>
     </div>

--- a/app/(app)/analytics/page.tsx
+++ b/app/(app)/analytics/page.tsx
@@ -24,15 +24,38 @@ export default function AnalyticsPage() {
   useUrlState(state, setState);
   const { data } = useSeries(state);
 
-  const lineData = data?.buckets || [];
-  const pieData = (data?.buckets || []).map(b => ({ label: b.label, value: b[state.metric] }));
+  const filtersApplied = Object.values(state.filters).some(arr => (arr || []).length > 0);
+  const hasIncomeFilters = (state.filters.incomeTypes || []).length > 0;
+  const hasExpenseFilters = (state.filters.expenseTypes || []).length > 0;
+
+  const lineData = filtersApplied ? data?.buckets || [] : [];
+  const pieData = (filtersApplied ? data?.buckets || [] : []).map(b => ({ label: b.label, value: b[state.metric] }));
+
+  let showIncome = filtersApplied;
+  let showExpenses = filtersApplied;
+  let showNet = filtersApplied;
+
+  if (hasIncomeFilters && !hasExpenseFilters) {
+    showExpenses = false;
+    showNet = false;
+  } else if (hasExpenseFilters && !hasIncomeFilters) {
+    showIncome = false;
+    showNet = false;
+  }
 
   return (
     <div className="flex">
       <div className="flex-1 p-6 space-y-4">
         <h1 className="text-2xl font-semibold mb-4">Analytics</h1>
         <div data-testid="viz-section">
-          {state.viz === 'line' && <VizLine data={lineData} />}
+          {state.viz === 'line' && (
+            <VizLine
+              data={lineData}
+              showIncome={showIncome}
+              showExpenses={showExpenses}
+              showNet={showNet}
+            />
+          )}
           {state.viz === 'pie' && <VizPie data={pieData} />}
           {state.viz === 'custom' && <CustomGraphBuilder onRun={() => {}} />}
         </div>

--- a/tests/VizLine.test.tsx
+++ b/tests/VizLine.test.tsx
@@ -1,0 +1,34 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import VizLine from '../app/(app)/analytics/components/VizLine';
+
+beforeAll(() => {
+  (global as any).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+describe('VizLine', () => {
+  const sample = [{ label: '2024-01', income: 100, expenses: 50, net: 50 }];
+
+  it('shows only income line when only income is enabled', () => {
+    const { container } = render(
+      <VizLine data={sample} showIncome showExpenses={false} showNet={false} />
+    );
+    expect(container.querySelector('path[stroke="#3b82f6"]')).not.toBeNull();
+    expect(container.querySelector('path[stroke="#ef4444"]')).toBeNull();
+    expect(container.querySelector('path[stroke="#10b981"]')).toBeNull();
+  });
+
+  it('renders axes without data', () => {
+    const { container } = render(
+      <VizLine data={[]} showIncome={false} showExpenses={false} showNet={false} />
+    );
+    expect(container.querySelector('path[stroke="#3b82f6"]')).toBeNull();
+    expect(container.querySelector('path[stroke="#ef4444"]')).toBeNull();
+    expect(container.querySelector('path[stroke="#10b981"]')).toBeNull();
+    expect(container.querySelectorAll('.recharts-cartesian-axis').length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Suppress expense and net lines when only income filters are active
- Keep chart axes visible with no filters and add unit tests for VizLine

## Testing
- `npm test` *(fails: playwright not found)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c2de7af8832ca9ac03a56affd201