### PR TITLE
fix: use rent ledger for core rent analytics

### DIFF
--- a/app/api/analytics/series/route.ts
+++ b/app/api/analytics/series/route.ts
@@ -12,7 +12,7 @@ export async function GET(req: Request) {
   const metric = searchParams.get('metric') ?? 'net';
 
   const incomeEntries = [
-    ...incomes,
+    ...incomes.filter((i) => i.category !== 'Base rent'),
     ...rentLedger
       .filter((r) => r.status === 'paid')
       .map((r) => ({

--- a/tests/analytics.spec.ts
+++ b/tests/analytics.spec.ts
@@ -22,3 +22,10 @@ test('breakdown endpoint responds', async ({ request }) => {
   const data = await res.json();
   expect(Array.isArray(data.items)).toBe(true);
 });
+
+test('series income pulls from rent ledger', async ({ request }) => {
+  const res = await request.get('/api/analytics/series?from=2025-03-01&to=2025-03-31');
+  const data = await res.json();
+  const march = data.buckets.find((b: any) => b.label === '2025-03');
+  expect(march?.income).toBe(2200);
+});


### PR DESCRIPTION
## Summary
- avoid double counting by excluding base rent incomes in analytics series
- add regression test verifying income comes from rent ledger

## Testing
- `npm install` *(fails: 403 Forbidden on @hello-pangea/dnd)*
- `npm test` *(fails: playwright: not found)*
- `npm run test:unit` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3504a3280832cbdab9b865a006dce