### PR TITLE
feat: enforce choice between expense and custom label

### DIFF
--- a/components/ExpenseForm.tsx
+++ b/components/ExpenseForm.tsx
@@ -146,11 +146,15 @@ export default function ExpenseForm({
                 !form.propertyId ||
                 !form.date ||
                 !form.group ||
-                !form.category ||
                 !form.vendor ||
-                !form.amount
+                !form.amount ||
+                (!form.category && !form.label)
               ) {
                 setError("Please fill in all required fields");
+                return;
+              }
+              if (form.category && form.label) {
+                setError("Please choose either an expense or a custom label");
                 return;
               }
               if (isNaN(parseFloat(form.amount))) {
@@ -225,32 +229,47 @@ export default function ExpenseForm({
               </select>
             </label>
             {form.group && (
+              <div className="flex items-end gap-2">
+                <label className="block flex-1 text-gray-700 dark:text-gray-300">
+                  Expense
+                  <select
+                    className="border p-1 w-full rounded bg-white dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100 disabled:bg-gray-200 disabled:text-gray-500 dark:disabled:bg-gray-700 dark:disabled:text-gray-400"
+                    value={form.category}
+                    disabled={form.label.trim() !== ""}
+                    onChange={(e) =>
+                      setForm({ ...form, category: e.target.value })
+                    }
+                  >
+                    <option value="">Select expense</option>
+                    {EXPENSE_CATEGORIES[form.group].map((item) => (
+                      <option key={item} value={item}>
+                        {item}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <span className="self-center text-gray-500">OR</span>
+                <label className="block flex-1 text-gray-700 dark:text-gray-300">
+                  Custom label
+                  <input
+                    className="border p-1 w-full rounded bg-white dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100 disabled:bg-gray-200 disabled:text-gray-500 dark:disabled:bg-gray-700 dark:disabled:text-gray-400"
+                    value={form.label}
+                    disabled={form.category !== ""}
+                    onChange={(e) => setForm({ ...form, label: e.target.value })}
+                  />
+                </label>
+              </div>
+            )}
+            {!form.group && (
               <label className="block text-gray-700 dark:text-gray-300">
-                Expense
-                <select
+                Custom label
+                <input
                   className="border p-1 w-full rounded bg-white dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
-                  value={form.category}
-                  onChange={(e) =>
-                    setForm({ ...form, category: e.target.value })
-                  }
-                >
-                  <option value="">Select expense</option>
-                  {EXPENSE_CATEGORIES[form.group].map((item) => (
-                    <option key={item} value={item}>
-                      {item}
-                    </option>
-                  ))}
-                </select>
+                  value={form.label}
+                  onChange={(e) => setForm({ ...form, label: e.target.value })}
+                />
               </label>
             )}
-            <label className="block text-gray-700 dark:text-gray-300">
-              Custom label
-              <input
-                className="border p-1 w-full rounded bg-white dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
-                value={form.label}
-                onChange={(e) => setForm({ ...form, label: e.target.value })}
-              />
-            </label>
             <label className="block text-gray-700 dark:text-gray-300">
               Vendor
               <input

--- a/tests/ExpenseForm.test.tsx
+++ b/tests/ExpenseForm.test.tsx
@@ -17,16 +17,31 @@ const renderForm = () => {
   );
 };
 
-describe('ExpenseForm', () => {
-  it('shows expense options after selecting a category', async () => {
-    renderForm();
-    fireEvent.change(screen.getByLabelText('Category'), {
-      target: { value: 'FinanceHolding' },
+  describe('ExpenseForm', () => {
+    it('shows expense options after selecting a category', async () => {
+      renderForm();
+      fireEvent.change(screen.getByLabelText('Category'), {
+        target: { value: 'FinanceHolding' },
+      });
+      const expenseSelect = await screen.findByLabelText('Expense');
+      fireEvent.change(expenseSelect, {
+        target: { value: 'Mortgage interest' },
+      });
+      expect((expenseSelect as HTMLSelectElement).value).toBe('Mortgage interest');
     });
-    const expenseSelect = await screen.findByLabelText('Expense');
-    fireEvent.change(expenseSelect, {
-      target: { value: 'Mortgage interest' },
+
+    it('disables the alternative field when one is filled', async () => {
+      renderForm();
+      fireEvent.change(screen.getByLabelText('Category'), {
+        target: { value: 'FinanceHolding' },
+      });
+      const expenseSelect = await screen.findByLabelText('Expense');
+      const customInput = screen.getByLabelText('Custom label');
+      fireEvent.change(customInput, { target: { value: 'Other' } });
+      expect(expenseSelect).toBeDisabled();
+      fireEvent.change(customInput, { target: { value: '' } });
+      expect(expenseSelect).toBeEnabled();
+      fireEvent.change(expenseSelect, { target: { value: 'Mortgage interest' } });
+      expect(customInput).toBeDisabled();
     });
-    expect((expenseSelect as HTMLSelectElement).value).toBe('Mortgage interest');
   });
-});


### PR DESCRIPTION
## Summary
- show expense and custom label fields side-by-side with an OR divider
- disable one field when the other has content and validate mutually exclusive choice
- test mutual exclusion between expense and custom label fields

## Testing
- `npm test` *(fails: playwright: not found)*
- `npm install` *(fails: 403 Forbidden for @hello-pangea/dnd)*
- `npm run test:unit` *(fails: vitest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c35f3e3bb8832ca7188a4185a660fc