### PR TITLE
Persist rent ledger edits

### DIFF
--- a/app/api/rent-ledger/[id]/route.ts
+++ b/app/api/rent-ledger/[id]/route.ts
@@ -1,0 +1,29 @@
+import { prisma } from '../../../../lib/prisma';
+import { z } from 'zod';
+
+const zPatch = z.object({
+  amount: z.number().optional(),
+  date: z.string().optional(),
+});
+
+export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+  try {
+    const body = zPatch.parse(await req.json());
+    const rec = await prisma.mockData.findUnique({ where: { id: params.id } });
+    if (!rec) return new Response('Not found', { status: 404 });
+    const data: any = rec.data;
+    if (body.amount !== undefined) {
+      data.amount = body.amount;
+    }
+    if (body.date) {
+      data.dueDate = body.date;
+      if (data.status === 'paid') {
+        data.paidDate = body.date;
+      }
+    }
+    await prisma.mockData.update({ where: { id: params.id }, data: { data } });
+    return Response.json({ id: params.id });
+  } catch (err: any) {
+    return new Response(err.message, { status: 400 });
+  }
+}

--- a/components/EditLedgerEntryModal.tsx
+++ b/components/EditLedgerEntryModal.tsx
@@ -5,7 +5,7 @@ import type { LedgerEntry } from "../types/property";
 
 interface Props {
   entry: LedgerEntry;
-  onSave: (entry: LedgerEntry) => void;
+  onSave: (entry: LedgerEntry) => void | Promise<void>;
   onClose: () => void;
 }
 
@@ -26,8 +26,8 @@ export default function EditLedgerEntryModal({ entry, onSave, onClose }: Props) 
     )
   );
 
-  const handleSave = () => {
-    onSave({ ...entry, date: datePaid, amount: parseFloat(amount) || 0 });
+  const handleSave = async () => {
+    await onSave({ ...entry, date: datePaid, amount: parseFloat(amount) || 0 });
   };
 
   const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {

--- a/components/RentLedgerTable.tsx
+++ b/components/RentLedgerTable.tsx
@@ -3,7 +3,7 @@
 import { useParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
-import { listLedger } from "../lib/api";
+import { listLedger, updateLedgerEntry } from "../lib/api";
 import type { LedgerEntry } from "../types/property";
 import EditLedgerEntryModal from "./EditLedgerEntryModal";
 
@@ -34,8 +34,14 @@ export default function RentLedgerTable({
     setEntries(calculateBalances(data));
   }, [data]);
 
-  const handleSave = (entry: LedgerEntry) => {
-    const updated = entries.map((e) => (e.id === entry.id ? entry : e));
+  const handleSave = async (entry: LedgerEntry) => {
+    await updateLedgerEntry(entry.id, {
+      amount: entry.amount,
+      date: entry.date,
+    });
+    const updated = entries
+      .map((e) => (e.id === entry.id ? entry : e))
+      .sort((a, b) => a.date.localeCompare(b.date));
     setEntries(calculateBalances(updated));
     setSelected(null);
   };

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -111,6 +111,14 @@ export const deleteProperty = (id: string) =>
   api(`/properties/${id}`, { method: 'DELETE' });
 export const listLedger = (propertyId: string) =>
   api<LedgerEntry[]>(`/rent-ledger?propertyId=${propertyId}`);
+export const updateLedgerEntry = (
+  id: string,
+  payload: { amount?: number; date?: string }
+) =>
+  api(`/rent-ledger/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(payload),
+  });
 export const listTenantNotes = (propertyId: string) =>
   api<TenantNote[]>(`/tenant-crm?propertyId=${propertyId}`);
 export const addTenantNote = (propertyId: string, text: string) =>


### PR DESCRIPTION
## Summary
- allow updating rent ledger entries via new PATCH API
- call ledger update API from edit modal to persist changes
- support async save in modal

## Testing
- `npm test` *(fails: playwright not found)*
- `npm install` *(fails: 403 Forbidden fetching @hello-pangea/dnd)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c36229af10832ca4971cd8ce8b040f