### PR TITLE
fix: improve export button contrast in dark mode

### DIFF
--- a/app/(app)/analytics/components/ExportButtons.tsx
+++ b/app/(app)/analytics/components/ExportButtons.tsx
@@ -10,13 +10,13 @@ export default function ExportButtons({ csvData }: Props) {
   return (
     <div className="flex gap-2" data-testid="export-buttons" ref={ref}>
       <button
-        className="px-3 py-1 text-sm bg-gray-200 rounded"
+        className="px-3 py-1 text-sm rounded bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-gray-100"
         onClick={() => downloadCsv(csvData, 'analytics.csv')}
       >
         CSV
       </button>
       <button
-        className="px-3 py-1 text-sm bg-gray-200 rounded"
+        className="px-3 py-1 text-sm rounded bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-gray-100"
         onClick={() => {
           if (ref.current) downloadPng(ref.current, 'chart.png');
         }}


### PR DESCRIPTION
## Summary
- ensure export buttons display text clearly in dark mode by adding dark theme styles

## Testing
- `npm test` *(fails: playwright not found)*
- `npm run test:unit` *(fails: vitest not found)*
- `npm ci` *(fails: 403 Forbidden fetching @hello-pangea/dnd)*

------
https://chatgpt.com/codex/tasks/task_e_68c36442c41c832cba3717ea180924c4