### PR TITLE
fix: export chart PNG from analytics page

### DIFF
--- a/app/(app)/analytics/components/ExportButtons.tsx
+++ b/app/(app)/analytics/components/ExportButtons.tsx
@@ -1,24 +1,24 @@
 import { downloadCsv, downloadPng } from '../../../../lib/download';
-import { useRef } from 'react';
+import { RefObject } from 'react';
 
 interface Props {
   csvData: string;
+  targetRef: RefObject<HTMLElement>;
 }
 
-export default function ExportButtons({ csvData }: Props) {
-  const ref = useRef<HTMLDivElement>(null);
+export default function ExportButtons({ csvData, targetRef }: Props) {
   return (
-    <div className="flex gap-2" data-testid="export-buttons" ref={ref}>
+    <div className="flex gap-2" data-testid="export-buttons">
       <button
-        className="px-3 py-1 text-sm bg-gray-200 rounded"
+        className="px-3 py-1 text-sm rounded bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-gray-100"
         onClick={() => downloadCsv(csvData, 'analytics.csv')}
       >
         CSV
       </button>
       <button
-        className="px-3 py-1 text-sm bg-gray-200 rounded"
+        className="px-3 py-1 text-sm rounded bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-gray-100"
         onClick={() => {
-          if (ref.current) downloadPng(ref.current, 'chart.png');
+          if (targetRef.current) downloadPng(targetRef.current, 'chart.png');
         }}
       >
         PNG

--- a/app/(app)/analytics/page.tsx
+++ b/app/(app)/analytics/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import DateRangeFilter from './components/DateRangeFilter';
 import AppliedFiltersPanel from './components/AppliedFiltersPanel';
 import SearchIncomePanel from './components/SearchIncomePanel';
@@ -23,6 +23,7 @@ export default function AnalyticsPage() {
   const [state, setState] = useState<AnalyticsStateType>(defaultState);
   useUrlState(state, setState);
   const { data } = useSeries(state);
+  const vizRef = useRef<HTMLDivElement>(null);
 
   const filtersApplied = Object.values(state.filters).some(arr => (arr || []).length > 0);
   const hasIncomeFilters = (state.filters.incomeTypes || []).length > 0;
@@ -47,7 +48,7 @@ export default function AnalyticsPage() {
     <div className="flex">
       <div className="flex-1 p-6 space-y-4">
         <h1 className="text-2xl font-semibold mb-4">Analytics</h1>
-        <div data-testid="viz-section">
+        <div data-testid="viz-section" ref={vizRef}>
           {state.viz === 'line' && (
             <VizLine
               data={lineData}
@@ -59,7 +60,7 @@ export default function AnalyticsPage() {
           {state.viz === 'pie' && <VizPie data={pieData} />}
           {state.viz === 'custom' && <CustomGraphBuilder onRun={() => {}} />}
         </div>
-        <ExportButtons csvData={JSON.stringify(lineData)} />
+        <ExportButtons csvData={JSON.stringify(lineData)} targetRef={vizRef} />
       </div>
       <div className="w-80 p-4 space-y-4 hidden lg:block">
         <DateRangeFilter state={state} onChange={(s) => setState(prev => ({ ...prev, ...s }))} />

--- a/lib/download.ts
+++ b/lib/download.ts
@@ -10,14 +10,29 @@ export function downloadCsv(data: string, filename: string) {
   URL.revokeObjectURL(url);
 }
 
-// Placeholder image export; real implementation may use html2canvas or similar
 export async function downloadPng(node: HTMLElement, filename: string) {
-  const canvas = document.createElement('canvas');
-  canvas.width = node.clientWidth;
-  canvas.height = node.clientHeight;
-  const url = canvas.toDataURL('image/png');
-  const link = document.createElement('a');
-  link.href = url;
-  link.download = filename;
-  link.click();
+  const svg = node.querySelector('svg');
+  if (!svg) return;
+
+  const serializer = new XMLSerializer();
+  const source = serializer.serializeToString(svg);
+  const svgBlob = new Blob([source], { type: 'image/svg+xml;charset=utf-8' });
+  const url = URL.createObjectURL(svgBlob);
+  const img = new Image();
+  img.onload = () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = svg.clientWidth;
+    canvas.height = svg.clientHeight;
+    const ctx = canvas.getContext('2d');
+    if (ctx) {
+      ctx.drawImage(img, 0, 0);
+      const png = canvas.toDataURL('image/png');
+      const link = document.createElement('a');
+      link.href = png;
+      link.download = filename;
+      link.click();
+    }
+    URL.revokeObjectURL(url);
+  };
+  img.src = url;
 }


### PR DESCRIPTION
## Summary
- convert chart SVG to PNG for download
- pass chart container ref to export buttons to capture the right element

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@hello-pangea%2fdnd)*
- `npm test` *(fails: playwright not found)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c36442c41c832cba3717ea180924c4