### PR TITLE
feat: dynamically update page titles

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import './globals.css';
 import type { ReactNode } from 'react';
 import Providers from './providers';
 import Sidebar from '../components/Sidebar';
+import TitleUpdater from '../components/TitleUpdater';
 
 export const metadata = { title: 'PropTech' };
 
@@ -10,6 +11,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <html lang="en">
       <body className="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-200">
         <Providers>
+          <TitleUpdater />
           <div className="flex h-screen overflow-hidden">
             <Sidebar />
             <main className="flex-1 overflow-y-auto">{children}</main>

--- a/components/TitleUpdater.tsx
+++ b/components/TitleUpdater.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
+
+const titleMap: Record<string, string> = {
+  "/dashboard": "Dashboard",
+  "/analytics": "Analytics",
+  "/tasks": "Tasks",
+  "/tasks/archive": "Tasks Archive",
+  "/properties": "Properties",
+  "/documents": "Documents",
+  "/reminders": "Reminders",
+  "/settings": "Settings",
+  "/settings/notifications": "Notification Settings",
+  "/finance/pnl": "Profit & Loss",
+  "/finance/expenses": "Expenses",
+  "/finance/scan": "Scan Receipt",
+};
+
+export default function TitleUpdater() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    let title = "PropTech";
+
+    if (pathname) {
+      if (titleMap[pathname]) {
+        title = `PropTech | ${titleMap[pathname]}`;
+      } else if (pathname.startsWith("/properties/")) {
+        const parts = pathname.split("/");
+        if (parts.length === 3) {
+          title = "PropTech | Property";
+        } else {
+          const sub = parts[3];
+          const propertyMap: Record<string, string> = {
+            applications: "Applications",
+            listing: "Listing",
+            edit: "Edit Property",
+            inspections: "Inspections",
+          };
+          title = `PropTech | ${propertyMap[sub] ?? "Property"}`;
+        }
+      }
+    }
+
+    document.title = title;
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add `TitleUpdater` client component to map routes to page titles
- wire TitleUpdater into root layout to update document title on navigation

## Testing
- `npm test` (fails: playwright not found)
- `npm run test:unit` (fails: vitest not found)


------
https://chatgpt.com/codex/tasks/task_e_68c37fa319e0832c959332bc9b43bb63