### PR TITLE
feat: scaffold analytics sections

### DIFF
--- a/app/(app)/analytics/builder/page.tsx
+++ b/app/(app)/analytics/builder/page.tsx
@@ -1,0 +1,114 @@
+'use client';
+import { useState, useRef } from 'react';
+import DateRangeFilter from '../components/DateRangeFilter';
+import AppliedFiltersPanel from '../components/AppliedFiltersPanel';
+import SearchIncomePanel from '../components/SearchIncomePanel';
+import SearchExpensesPanel from '../components/SearchExpensesPanel';
+import VizLine from '../components/VizLine';
+import VizPie from '../components/VizPie';
+import CustomGraphBuilder from '../components/CustomGraphBuilder';
+import ExportButtons from '../components/ExportButtons';
+import PresetMenu from '../components/PresetMenu';
+import VizSpreadsheet from '../components/VizSpreadsheet';
+import { AnalyticsState, AnalyticsStateType } from '../../../../lib/schemas';
+import { useUrlState } from '../../../../lib/urlState';
+import { useSeries } from '../../../../hooks/useAnalytics';
+
+const now = new Date();
+const defaultState = AnalyticsState.parse({
+  from: new Date(now.getFullYear(), now.getMonth() - 1, now.getDate()).toISOString(),
+  to: now.toISOString(),
+});
+
+export default function AnalyticsBuilderPage() {
+  const [state, setState] = useState<AnalyticsStateType>(defaultState);
+  useUrlState(state, setState);
+  const { data } = useSeries(state);
+  const exportRef = useRef<HTMLDivElement>(null);
+
+  const filtersApplied = Object.values(state.filters).some(arr => (arr || []).length > 0);
+  const hasIncomeFilters = (state.filters.incomeTypes || []).length > 0;
+  const hasExpenseFilters = (state.filters.expenseTypes || []).length > 0;
+
+  const lineData = filtersApplied ? data?.buckets || [] : [];
+  const pieData = (filtersApplied ? data?.buckets || [] : []).map(b => ({ label: b.label, value: b[state.metric] }));
+
+  let showIncome = filtersApplied;
+  let showExpenses = filtersApplied;
+  let showNet = filtersApplied;
+
+  if (hasIncomeFilters && !hasExpenseFilters) {
+    showExpenses = false;
+    showNet = false;
+  } else if (hasExpenseFilters && !hasIncomeFilters) {
+    showIncome = false;
+    showNet = false;
+  }
+
+  return (
+    <div className="flex">
+      <div className="flex-1 p-6 space-y-4">
+        <h1 className="text-2xl font-semibold mb-4">Analytics</h1>
+        <div ref={exportRef} className="space-y-2">
+          <div data-testid="viz-section">
+            {state.viz === 'line' && (
+              <>
+                <VizLine
+                  data={lineData}
+                  showIncome={showIncome}
+                  showExpenses={showExpenses}
+                  showNet={showNet}
+                />
+                <VizSpreadsheet data={lineData} />
+              </>
+            )}
+            {state.viz === 'pie' && <VizPie data={pieData} />}
+            {state.viz === 'custom' && <CustomGraphBuilder onRun={() => {}} />}
+          </div>
+          <div className="text-sm text-gray-700 dark:text-gray-300">
+            <div>
+              Date range: {new Date(state.from).toLocaleDateString()} - {new Date(state.to).toLocaleDateString()}
+            </div>
+            {filtersApplied && (
+              <div>
+                Filters:{' '}
+                {Object.entries(state.filters)
+                  .filter(([, arr]) => (arr || []).length > 0)
+                  .map(([key, arr]) => `${key}: ${(arr || []).join(', ')}`)
+                  .join('; ')}
+              </div>
+            )}
+          </div>
+        </div>
+        <ExportButtons csvData={JSON.stringify(lineData)} targetRef={exportRef} />
+      </div>
+      <div className="w-80 p-4 space-y-4 hidden lg:block">
+        <DateRangeFilter state={state} onChange={(s) => setState(prev => ({ ...prev, ...s }))} />
+        <AppliedFiltersPanel
+          state={state}
+          onAdd={(key, value) =>
+            setState(prev => ({
+              ...prev,
+              filters: {
+                ...prev.filters,
+                [key]: Array.from(new Set([...(prev.filters[key] || []), value])),
+              },
+            }))
+          }
+          onRemove={(key, value) =>
+            setState(prev => ({
+              ...prev,
+              filters: {
+                ...prev.filters,
+                [key]: (prev.filters[key] || []).filter(v => v !== value),
+              },
+            }))
+          }
+        />
+        <SearchIncomePanel />
+        <SearchExpensesPanel />
+        <PresetMenu />
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/analytics/custom/page.tsx
+++ b/app/(app)/analytics/custom/page.tsx
@@ -1,0 +1,8 @@
+export default function CustomAnalytics() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-semibold mb-4">Custom Analytics</h1>
+      <p>Saved analytics will be accessible here.</p>
+    </div>
+  );
+}

--- a/app/(app)/analytics/overview/page.tsx
+++ b/app/(app)/analytics/overview/page.tsx
@@ -1,0 +1,8 @@
+export default function AnalyticsOverview() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-semibold mb-4">Analytics Overview</h1>
+      <p>Standardised visualisations will appear here.</p>
+    </div>
+  );
+}

--- a/app/(app)/analytics/page.tsx
+++ b/app/(app)/analytics/page.tsx
@@ -1,113 +1,24 @@
-'use client';
-import { useState, useRef } from 'react';
-import DateRangeFilter from './components/DateRangeFilter';
-import AppliedFiltersPanel from './components/AppliedFiltersPanel';
-import SearchIncomePanel from './components/SearchIncomePanel';
-import SearchExpensesPanel from './components/SearchExpensesPanel';
-import VizLine from './components/VizLine';
-import VizPie from './components/VizPie';
-import CustomGraphBuilder from './components/CustomGraphBuilder';
-import ExportButtons from './components/ExportButtons';
-import PresetMenu from './components/PresetMenu';
-import VizSpreadsheet from './components/VizSpreadsheet';
-import { AnalyticsState, AnalyticsStateType } from '../../../lib/schemas';
-import { useUrlState } from '../../../lib/urlState';
-import { useSeries } from '../../../hooks/useAnalytics';
+import Link from 'next/link';
 
-const now = new Date();
-const defaultState = AnalyticsState.parse({
-  from: new Date(now.getFullYear(), now.getMonth() - 1, now.getDate()).toISOString(),
-  to: now.toISOString(),
-});
-
-export default function AnalyticsPage() {
-  const [state, setState] = useState<AnalyticsStateType>(defaultState);
-  useUrlState(state, setState);
-  const { data } = useSeries(state);
-  const exportRef = useRef<HTMLDivElement>(null);
-
-  const filtersApplied = Object.values(state.filters).some(arr => (arr || []).length > 0);
-  const hasIncomeFilters = (state.filters.incomeTypes || []).length > 0;
-  const hasExpenseFilters = (state.filters.expenseTypes || []).length > 0;
-
-  const lineData = filtersApplied ? data?.buckets || [] : [];
-  const pieData = (filtersApplied ? data?.buckets || [] : []).map(b => ({ label: b.label, value: b[state.metric] }));
-
-  let showIncome = filtersApplied;
-  let showExpenses = filtersApplied;
-  let showNet = filtersApplied;
-
-  if (hasIncomeFilters && !hasExpenseFilters) {
-    showExpenses = false;
-    showNet = false;
-  } else if (hasExpenseFilters && !hasIncomeFilters) {
-    showIncome = false;
-    showNet = false;
-  }
-
+export default function AnalyticsHome() {
   return (
-    <div className="flex">
-      <div className="flex-1 p-6 space-y-4">
-        <h1 className="text-2xl font-semibold mb-4">Analytics</h1>
-        <div ref={exportRef} className="space-y-2">
-          <div data-testid="viz-section">
-            {state.viz === 'line' && (
-              <>
-                <VizLine
-                  data={lineData}
-                  showIncome={showIncome}
-                  showExpenses={showExpenses}
-                  showNet={showNet}
-                />
-                <VizSpreadsheet data={lineData} />
-              </>
-            )}
-            {state.viz === 'pie' && <VizPie data={pieData} />}
-            {state.viz === 'custom' && <CustomGraphBuilder onRun={() => {}} />}
-          </div>
-          <div className="text-sm text-gray-700 dark:text-gray-300">
-            <div>
-              Date range: {new Date(state.from).toLocaleDateString()} - {new Date(state.to).toLocaleDateString()}
-            </div>
-            {filtersApplied && (
-              <div>
-                Filters:{' '}
-                {Object.entries(state.filters)
-                  .filter(([, arr]) => (arr || []).length > 0)
-                  .map(([key, arr]) => `${key}: ${(arr || []).join(', ')}`)
-                  .join('; ')}
-              </div>
-            )}
-          </div>
-        </div>
-        <ExportButtons csvData={JSON.stringify(lineData)} targetRef={exportRef} />
-      </div>
-      <div className="w-80 p-4 space-y-4 hidden lg:block">
-        <DateRangeFilter state={state} onChange={(s) => setState(prev => ({ ...prev, ...s }))} />
-        <AppliedFiltersPanel
-          state={state}
-          onAdd={(key, value) =>
-            setState(prev => ({
-              ...prev,
-              filters: {
-                ...prev.filters,
-                [key]: Array.from(new Set([...(prev.filters[key] || []), value])),
-              },
-            }))
-          }
-          onRemove={(key, value) =>
-            setState(prev => ({
-              ...prev,
-              filters: {
-                ...prev.filters,
-                [key]: (prev.filters[key] || []).filter(v => v !== value),
-              },
-            }))
-          }
-        />
-        <SearchIncomePanel />
-        <SearchExpensesPanel />
-        <PresetMenu />
+    <div className="p-6 h-full">
+      <div className="grid grid-cols-3 grid-rows-2 gap-4 h-full">
+        <Link
+          href="/analytics/overview"
+          className="col-span-2 row-span-2 flex items-center justify-center border rounded bg-gray-100 dark:bg-gray-800">
+          Overview
+        </Link>
+        <Link
+          href="/analytics/custom"
+          className="col-start-3 row-start-1 flex items-center justify-center border rounded bg-gray-100 dark:bg-gray-800">
+          Custom Analytics
+        </Link>
+        <Link
+          href="/analytics/builder"
+          className="col-start-3 row-start-2 flex items-center justify-center border rounded bg-gray-100 dark:bg-gray-800">
+          Analytics Builder
+        </Link>
       </div>
     </div>
   );

--- a/components/TitleUpdater.tsx
+++ b/components/TitleUpdater.tsx
@@ -6,6 +6,9 @@ import { useEffect } from "react";
 const titleMap: Record<string, string> = {
   "/dashboard": "Dashboard",
   "/analytics": "Analytics",
+  "/analytics/overview": "Analytics Overview",
+  "/analytics/custom": "Custom Analytics",
+  "/analytics/builder": "Analytics Builder",
   "/tasks": "Tasks",
   "/tasks/archive": "Tasks Archive",
   "/properties": "Properties",

--- a/tests/analytics.spec.ts
+++ b/tests/analytics.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
-test('analytics page loads', async ({ page }) => {
-  await page.goto('/analytics');
+test('analytics builder page loads', async ({ page }) => {
+  await page.goto('/analytics/builder');
   await expect(page.getByTestId('date-range-filter')).toBeVisible();
   await expect(page.getByTestId('viz-section')).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- add analytics landing page linking to overview, custom, and builder sections
- move existing analytics page to /analytics/builder and update titles
- cover builder route in tests

## Testing
- `npm test` *(fails: playwright not found)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3832b7638832cab03e42c7bc28678