### PR TITLE
feat: scaffold analytics sections

### DIFF
--- a/app/(app)/analytics/builder/page.tsx
+++ b/app/(app)/analytics/builder/page.tsx
@@ -1,0 +1,118 @@
+'use client';
+import { useState, useRef } from 'react';
+import Link from 'next/link';
+import DateRangeFilter from '../components/DateRangeFilter';
+import AppliedFiltersPanel from '../components/AppliedFiltersPanel';
+import SearchIncomePanel from '../components/SearchIncomePanel';
+import SearchExpensesPanel from '../components/SearchExpensesPanel';
+import VizLine from '../components/VizLine';
+import VizPie from '../components/VizPie';
+import CustomGraphBuilder from '../components/CustomGraphBuilder';
+import ExportButtons from '../components/ExportButtons';
+import PresetMenu from '../components/PresetMenu';
+import VizSpreadsheet from '../components/VizSpreadsheet';
+import { AnalyticsState, AnalyticsStateType } from '../../../../lib/schemas';
+import { useUrlState } from '../../../../lib/urlState';
+import { useSeries } from '../../../../hooks/useAnalytics';
+
+const now = new Date();
+const defaultState = AnalyticsState.parse({
+  from: new Date(now.getFullYear(), now.getMonth() - 1, now.getDate()).toISOString(),
+  to: now.toISOString(),
+});
+
+export default function AnalyticsBuilderPage() {
+  const [state, setState] = useState<AnalyticsStateType>(defaultState);
+  useUrlState(state, setState);
+  const { data } = useSeries(state);
+  const exportRef = useRef<HTMLDivElement>(null);
+
+  const filtersApplied = Object.values(state.filters).some(arr => (arr || []).length > 0);
+  const hasIncomeFilters = (state.filters.incomeTypes || []).length > 0;
+  const hasExpenseFilters = (state.filters.expenseTypes || []).length > 0;
+
+  const lineData = filtersApplied ? data?.buckets || [] : [];
+  const pieData = (filtersApplied ? data?.buckets || [] : []).map(b => ({ label: b.label, value: b[state.metric] }));
+
+  let showIncome = filtersApplied;
+  let showExpenses = filtersApplied;
+  let showNet = filtersApplied;
+
+  if (hasIncomeFilters && !hasExpenseFilters) {
+    showExpenses = false;
+    showNet = false;
+  } else if (hasExpenseFilters && !hasIncomeFilters) {
+    showIncome = false;
+    showNet = false;
+  }
+
+  return (
+    <div className="flex">
+      <div className="flex-1 p-6 space-y-4">
+        <Link href="/analytics" className="text-sm text-blue-600 hover:underline">
+          &larr; Back to Analytics
+        </Link>
+        <h1 className="text-2xl font-semibold mb-4 mt-2">Analytics</h1>
+        <div ref={exportRef} className="space-y-2">
+          <div data-testid="viz-section">
+            {state.viz === 'line' && (
+              <>
+                <VizLine
+                  data={lineData}
+                  showIncome={showIncome}
+                  showExpenses={showExpenses}
+                  showNet={showNet}
+                />
+                <VizSpreadsheet data={lineData} />
+              </>
+            )}
+            {state.viz === 'pie' && <VizPie data={pieData} />}
+            {state.viz === 'custom' && <CustomGraphBuilder onRun={() => {}} />}
+          </div>
+          <div className="text-sm text-gray-700 dark:text-gray-300">
+            <div>
+              Date range: {new Date(state.from).toLocaleDateString()} - {new Date(state.to).toLocaleDateString()}
+            </div>
+            {filtersApplied && (
+              <div>
+                Filters:{' '}
+                {Object.entries(state.filters)
+                  .filter(([, arr]) => (arr || []).length > 0)
+                  .map(([key, arr]) => `${key}: ${(arr || []).join(', ')}`)
+                  .join('; ')}
+              </div>
+            )}
+          </div>
+        </div>
+        <ExportButtons csvData={JSON.stringify(lineData)} targetRef={exportRef} />
+      </div>
+      <div className="w-80 p-4 space-y-4 hidden lg:block">
+        <DateRangeFilter state={state} onChange={(s) => setState(prev => ({ ...prev, ...s }))} />
+        <AppliedFiltersPanel
+          state={state}
+          onAdd={(key, value) =>
+            setState(prev => ({
+              ...prev,
+              filters: {
+                ...prev.filters,
+                [key]: Array.from(new Set([...(prev.filters[key] || []), value])),
+              },
+            }))
+          }
+          onRemove={(key, value) =>
+            setState(prev => ({
+              ...prev,
+              filters: {
+                ...prev.filters,
+                [key]: (prev.filters[key] || []).filter(v => v !== value),
+              },
+            }))
+          }
+        />
+        <SearchIncomePanel />
+        <SearchExpensesPanel />
+        <PresetMenu />
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/analytics/custom/page.tsx
+++ b/app/(app)/analytics/custom/page.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link';
+
+export default function CustomAnalytics() {
+  return (
+    <div className="p-6">
+      <Link href="/analytics" className="text-sm text-blue-600 hover:underline">
+        &larr; Back to Analytics
+      </Link>
+      <h1 className="text-2xl font-semibold mb-4 mt-2">Custom Analytics</h1>
+      <p>Saved analytics will be accessible here.</p>
+    </div>
+  );
+}

--- a/app/(app)/analytics/overview/page.tsx
+++ b/app/(app)/analytics/overview/page.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link';
+
+export default function AnalyticsOverview() {
+  return (
+    <div className="p-6">
+      <Link href="/analytics" className="text-sm text-blue-600 hover:underline">
+        &larr; Back to Analytics
+      </Link>
+      <h1 className="text-2xl font-semibold mb-4 mt-2">Analytics Overview</h1>
+      <p>Standardised visualisations will appear here.</p>
+    </div>
+  );
+}

--- a/app/(app)/analytics/page.tsx
+++ b/app/(app)/analytics/page.tsx
@@ -1,114 +1,59 @@
 'use client';
-import { useState, useRef } from 'react';
-import DateRangeFilter from './components/DateRangeFilter';
-import AppliedFiltersPanel from './components/AppliedFiltersPanel';
-import SearchIncomePanel from './components/SearchIncomePanel';
-import SearchExpensesPanel from './components/SearchExpensesPanel';
-import VizLine from './components/VizLine';
-import VizPie from './components/VizPie';
-import CustomGraphBuilder from './components/CustomGraphBuilder';
-import ExportButtons from './components/ExportButtons';
-import PresetMenu from './components/PresetMenu';
-import VizSpreadsheet from './components/VizSpreadsheet';
-import { AnalyticsState, AnalyticsStateType } from '../../../lib/schemas';
-import { useUrlState } from '../../../lib/urlState';
-import { useSeries } from '../../../hooks/useAnalytics';
 
-const now = new Date();
-const defaultState = AnalyticsState.parse({
-  from: new Date(now.getFullYear(), now.getMonth() - 1, now.getDate()).toISOString(),
-  to: now.toISOString(),
-});
+import Link from 'next/link';
+import { useState } from 'react';
 
+// Landing page for the analytics section. Provides quick links to the
+// overview, custom analytics and builder areas, along with a placeholder for
+// the planned AI-powered search feature.
 export default function AnalyticsPage() {
-  const [state, setState] = useState<AnalyticsStateType>(defaultState);
-  useUrlState(state, setState);
-  const { data } = useSeries(state);
-  const exportRef = useRef<HTMLDivElement>(null);
-
-  const filtersApplied = Object.values(state.filters).some(arr => (arr || []).length > 0);
-  const hasIncomeFilters = (state.filters.incomeTypes || []).length > 0;
-  const hasExpenseFilters = (state.filters.expenseTypes || []).length > 0;
-
-  const lineData = filtersApplied ? data?.buckets || [] : [];
-  const pieData = (filtersApplied ? data?.buckets || [] : []).map(b => ({ label: b.label, value: b[state.metric] }));
-
-  let showIncome = filtersApplied;
-  let showExpenses = filtersApplied;
-  let showNet = filtersApplied;
-
-  if (hasIncomeFilters && !hasExpenseFilters) {
-    showExpenses = false;
-    showNet = false;
-  } else if (hasExpenseFilters && !hasIncomeFilters) {
-    showIncome = false;
-    showNet = false;
-  }
+  const [query, setQuery] = useState('');
 
   return (
-    <div className="flex">
-      <div className="flex-1 p-6 space-y-4">
-        <h1 className="text-2xl font-semibold mb-4">Analytics</h1>
-        <div ref={exportRef} className="space-y-2">
-          <div data-testid="viz-section">
-            {state.viz === 'line' && (
-              <>
-                <VizLine
-                  data={lineData}
-                  showIncome={showIncome}
-                  showExpenses={showExpenses}
-                  showNet={showNet}
-                />
-                <VizSpreadsheet data={lineData} />
-              </>
-            )}
-            {state.viz === 'pie' && <VizPie data={pieData} />}
-            {state.viz === 'custom' && <CustomGraphBuilder onRun={() => {}} />}
+    <div className="p-6 h-full">
+      <h1 className="text-2xl font-semibold mb-6">Analytics</h1>
+      <div className="grid grid-cols-3 grid-rows-2 gap-4 h-full">
+        <div className="relative col-span-2 row-span-2 flex flex-col border rounded-lg bg-white/10 dark:bg-gray-900/20 backdrop-blur shadow-lg p-4">
+          <Link
+            href="/analytics/overview"
+            className="absolute inset-0"
+            aria-label="Go to overview"
+          />
+          <div className="flex-1 flex items-center justify-center pointer-events-none">
+            <span>Overview</span>
           </div>
-          <div className="text-sm text-gray-700 dark:text-gray-300">
-            <div>
-              Date range: {new Date(state.from).toLocaleDateString()} - {new Date(state.to).toLocaleDateString()}
-            </div>
-            {filtersApplied && (
-              <div>
-                Filters:{' '}
-                {Object.entries(state.filters)
-                  .filter(([, arr]) => (arr || []).length > 0)
-                  .map(([key, arr]) => `${key}: ${(arr || []).join(', ')}`)
-                  .join('; ')}
+          <div
+            className="mt-4 relative z-10"
+            onClick={e => e.stopPropagation()}
+          >
+            <input
+              type="text"
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              placeholder="What do you want to see?"
+              className="w-full p-2 border rounded bg-white/70 dark:bg-gray-800/70 text-sm"
+            />
+            {query && (
+              <div className="mt-2 text-sm">
+                Showing results for: <strong>{query}</strong>
               </div>
             )}
           </div>
         </div>
-        <ExportButtons csvData={JSON.stringify(lineData)} targetRef={exportRef} />
-      </div>
-      <div className="w-80 p-4 space-y-4 hidden lg:block">
-        <DateRangeFilter state={state} onChange={(s) => setState(prev => ({ ...prev, ...s }))} />
-        <AppliedFiltersPanel
-          state={state}
-          onAdd={(key, value) =>
-            setState(prev => ({
-              ...prev,
-              filters: {
-                ...prev.filters,
-                [key]: Array.from(new Set([...(prev.filters[key] || []), value])),
-              },
-            }))
-          }
-          onRemove={(key, value) =>
-            setState(prev => ({
-              ...prev,
-              filters: {
-                ...prev.filters,
-                [key]: (prev.filters[key] || []).filter(v => v !== value),
-              },
-            }))
-          }
-        />
-        <SearchIncomePanel />
-        <SearchExpensesPanel />
-        <PresetMenu />
+        <Link
+          href="/analytics/custom"
+          className="col-start-3 row-start-1 flex items-center justify-center border rounded-lg bg-white/10 dark:bg-gray-900/20 backdrop-blur shadow-lg"
+        >
+          Custom Analytics
+        </Link>
+        <Link
+          href="/analytics/builder"
+          className="col-start-3 row-start-2 flex items-center justify-center border rounded-lg bg-white/10 dark:bg-gray-900/20 backdrop-blur shadow-lg"
+        >
+          Analytics Builder
+        </Link>
       </div>
     </div>
   );
 }
+

--- a/components/TitleUpdater.tsx
+++ b/components/TitleUpdater.tsx
@@ -6,6 +6,9 @@ import { useEffect } from "react";
 const titleMap: Record<string, string> = {
   "/dashboard": "Dashboard",
   "/analytics": "Analytics",
+  "/analytics/overview": "Analytics Overview",
+  "/analytics/custom": "Custom Analytics",
+  "/analytics/builder": "Analytics Builder",
   "/tasks": "Tasks",
   "/tasks/archive": "Tasks Archive",
   "/properties": "Properties",

--- a/tests/analytics.spec.ts
+++ b/tests/analytics.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
-test('analytics page loads', async ({ page }) => {
-  await page.goto('/analytics');
+test('analytics builder page loads', async ({ page }) => {
+  await page.goto('/analytics/builder');
   await expect(page.getByTestId('date-range-filter')).toBeVisible();
   await expect(page.getByTestId('viz-section')).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- add "Analytics" title, glass-style tiles, and AI search placeholder to analytics landing page
- add back navigation links for overview, custom analytics, and builder pages
- mark analytics landing page as a client component to resolve build error
- fix analytics landing page export so the page compiles correctly

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/@hello-pangea%2fdnd)
- `npm test` (fails: playwright not found)
- `npm run test:unit` (fails: vitest not found)
- `npm run build` (fails: next not found)


------
https://chatgpt.com/codex/tasks/task_e_68c3832b7638832cab03e42c7bc28678