### PR TITLE
refactor: fix analytics page default export

### DIFF
--- a/app/(app)/analytics/page.tsx
+++ b/app/(app)/analytics/page.tsx
@@ -9,7 +9,6 @@ import { useState } from 'react';
 export default function AnalyticsPage() {
   const [query, setQuery] = useState('');
 
-export default function AnalyticsHome() {
   return (
     <div className="p-6 h-full">
       <h1 className="text-2xl font-semibold mb-6">Analytics</h1>


### PR DESCRIPTION
## Summary
- ensure only a single default export in analytics page

## Testing
- `npm run test:unit` *(fails: vitest not found)*
- `npm run dev` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3930ce930832cacccf4f60f59e22d