### PR TITLE
Revamp income and expense filter panels

### DIFF
--- a/app/(app)/analytics/builder/page.tsx
+++ b/app/(app)/analytics/builder/page.tsx
@@ -109,8 +109,32 @@ export default function AnalyticsBuilderPage() {
             }))
           }
         />
-        <SearchIncomePanel />
-        <SearchExpensesPanel />
+        <SearchIncomePanel
+          onAdd={value =>
+            setState(prev => ({
+              ...prev,
+              filters: {
+                ...prev.filters,
+                incomeTypes: Array.from(
+                  new Set([...(prev.filters.incomeTypes || []), value])
+                ),
+              },
+            }))
+          }
+        />
+        <SearchExpensesPanel
+          onAdd={value =>
+            setState(prev => ({
+              ...prev,
+              filters: {
+                ...prev.filters,
+                expenseTypes: Array.from(
+                  new Set([...(prev.filters.expenseTypes || []), value])
+                ),
+              },
+            }))
+          }
+        />
         <PresetMenu />
       </div>
     </div>

--- a/app/(app)/analytics/components/SearchExpensesPanel.tsx
+++ b/app/(app)/analytics/components/SearchExpensesPanel.tsx
@@ -1,10 +1,12 @@
 import { useState } from 'react';
-import ExpenseForm from '../../../../components/ExpenseForm';
 import { EXPENSE_CATEGORIES } from '../../../../lib/categories';
 
-export default function SearchExpensesPanel() {
+interface Props {
+  onAdd: (value: string) => void;
+}
+
+export default function SearchExpensesPanel({ onAdd }: Props) {
   const [q, setQ] = useState('');
-  const [open, setOpen] = useState(false);
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
   const qLower = q.toLowerCase();
   const entries = Object.entries(EXPENSE_CATEGORIES).filter(([group, items]) => {
@@ -14,16 +16,24 @@ export default function SearchExpensesPanel() {
       items.some(i => i.toLowerCase().includes(qLower))
     );
   });
+
+  const handleAddAll = () => {
+    Object.keys(EXPENSE_CATEGORIES).forEach(group => {
+      const label = group.replace(/([A-Z])/g, ' $1').trim();
+      onAdd(label);
+    });
+  };
+
   return (
     <div
       data-testid="search-expenses"
       className="p-4 border rounded-2xl shadow-sm space-y-2 bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700"
     >
       <div className="flex items-center justify-between">
-        <div className="font-semibold">Search Expenses</div>
+        <div className="font-semibold">Expenses</div>
         <button
-          aria-label="Add custom expense"
-          onClick={() => setOpen(true)}
+          aria-label="Add all expenses"
+          onClick={handleAddAll}
           className="text-xl leading-none text-blue-600 dark:text-blue-400"
         >
           +
@@ -46,46 +56,45 @@ export default function SearchExpensesPanel() {
           return (
             <div key={group} className="space-y-1">
               <div
-                draggable
-                onDragStart={e =>
-                  e.dataTransfer.setData(
-                    'application/json',
-                    JSON.stringify({ type: 'expenseTypes', value: label })
-                  )
-                }
-                className="p-1 text-sm bg-gray-100 dark:bg-gray-700 rounded cursor-grab flex items-center justify-between text-gray-900 dark:text-gray-100"
+                className="p-1 text-sm bg-gray-100 dark:bg-gray-700 rounded flex items-center justify-between text-gray-900 dark:text-gray-100"
               >
                 <span>{label}</span>
-                <button
-                  aria-label={`Toggle ${label}`}
-                  onClick={() =>
-                    setExpanded(prev => ({
-                      ...prev,
-                      [group]: !prev[group],
-                    }))
-                  }
-                  className="ml-2 text-xs"
-                >
-                  {expanded[group] || qLower.length > 0 ? '-' : '+'}
-                </button>
+                <div className="flex items-center gap-1">
+                  <button
+                    aria-label={`${expanded[group] ? 'Collapse' : 'Expand'} ${label}`}
+                    onClick={() =>
+                      setExpanded(prev => ({
+                        ...prev,
+                        [group]: !prev[group],
+                      }))
+                    }
+                    className="text-xs"
+                  >
+                    {expanded[group] || qLower.length > 0 ? '▾' : '▸'}
+                  </button>
+                  <button
+                    aria-label={`Add ${label}`}
+                    onClick={() => onAdd(label)}
+                    className="text-xs"
+                  >
+                    +
+                  </button>
+                </div>
               </div>
               {showItems &&
                 filteredItems.map(item => (
                   <div
                     key={item}
-                    draggable
-                    onDragStart={e =>
-                      e.dataTransfer.setData(
-                        'application/json',
-                        JSON.stringify({
-                          type: 'expenseTypes',
-                          value: item,
-                        })
-                      )
-                    }
-                    className="ml-4 p-1 text-sm bg-gray-100 dark:bg-gray-700 rounded cursor-grab text-gray-900 dark:text-gray-100"
+                    className="ml-4 p-1 text-sm bg-gray-100 dark:bg-gray-700 rounded flex items-center justify-between text-gray-900 dark:text-gray-100"
                   >
-                    {item}
+                    <span>{item}</span>
+                    <button
+                      aria-label={`Add ${item}`}
+                      onClick={() => onAdd(item)}
+                      className="text-xs"
+                    >
+                      +
+                    </button>
                   </div>
                 ))}
             </div>
@@ -95,7 +104,6 @@ export default function SearchExpensesPanel() {
           <div className="text-sm text-gray-500 dark:text-gray-400">No results</div>
         )}
       </div>
-      <ExpenseForm open={open} onOpenChange={setOpen} showTrigger={false} />
     </div>
   );
 }

--- a/app/(app)/analytics/components/SearchIncomePanel.tsx
+++ b/app/(app)/analytics/components/SearchIncomePanel.tsx
@@ -1,10 +1,12 @@
 import { useState } from 'react';
-import IncomeForm from '../../../../components/IncomeForm';
 import { INCOME_CATEGORIES } from '../../../../lib/categories';
 
-export default function SearchIncomePanel() {
+interface Props {
+  onAdd: (value: string) => void;
+}
+
+export default function SearchIncomePanel({ onAdd }: Props) {
   const [q, setQ] = useState('');
-  const [open, setOpen] = useState(false);
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
   const qLower = q.toLowerCase();
   const entries = Object.entries(INCOME_CATEGORIES).filter(([group, items]) => {
@@ -14,16 +16,24 @@ export default function SearchIncomePanel() {
       items.some(i => i.toLowerCase().includes(qLower))
     );
   });
+
+  const handleAddAll = () => {
+    Object.keys(INCOME_CATEGORIES).forEach(group => {
+      const label = group.replace(/([A-Z])/g, ' $1').trim();
+      onAdd(label);
+    });
+  };
+
   return (
     <div
       data-testid="search-income"
       className="p-4 border rounded-2xl shadow-sm space-y-2 bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700"
     >
       <div className="flex items-center justify-between">
-        <div className="font-semibold">Search Income</div>
+        <div className="font-semibold">Income</div>
         <button
-          aria-label="Add custom income"
-          onClick={() => setOpen(true)}
+          aria-label="Add all income"
+          onClick={handleAddAll}
           className="text-xl leading-none text-blue-600 dark:text-blue-400"
         >
           +
@@ -46,46 +56,45 @@ export default function SearchIncomePanel() {
           return (
             <div key={group} className="space-y-1">
               <div
-                draggable
-                onDragStart={e =>
-                  e.dataTransfer.setData(
-                    'application/json',
-                    JSON.stringify({ type: 'incomeTypes', value: label })
-                  )
-                }
-                className="p-1 text-sm bg-gray-100 dark:bg-gray-700 rounded cursor-grab flex items-center justify-between text-gray-900 dark:text-gray-100"
+                className="p-1 text-sm bg-gray-100 dark:bg-gray-700 rounded flex items-center justify-between text-gray-900 dark:text-gray-100"
               >
                 <span>{label}</span>
-                <button
-                  aria-label={`Toggle ${label}`}
-                  onClick={() =>
-                    setExpanded(prev => ({
-                      ...prev,
-                      [group]: !prev[group],
-                    }))
-                  }
-                  className="ml-2 text-xs"
-                >
-                  {expanded[group] || qLower.length > 0 ? '-' : '+'}
-                </button>
+                <div className="flex items-center gap-1">
+                  <button
+                    aria-label={`${expanded[group] ? 'Collapse' : 'Expand'} ${label}`}
+                    onClick={() =>
+                      setExpanded(prev => ({
+                        ...prev,
+                        [group]: !prev[group],
+                      }))
+                    }
+                    className="text-xs"
+                  >
+                    {expanded[group] || qLower.length > 0 ? '▾' : '▸'}
+                  </button>
+                  <button
+                    aria-label={`Add ${label}`}
+                    onClick={() => onAdd(label)}
+                    className="text-xs"
+                  >
+                    +
+                  </button>
+                </div>
               </div>
               {showItems &&
                 filteredItems.map(item => (
                   <div
                     key={item}
-                    draggable
-                    onDragStart={e =>
-                      e.dataTransfer.setData(
-                        'application/json',
-                        JSON.stringify({
-                          type: 'incomeTypes',
-                          value: item,
-                        })
-                      )
-                    }
-                    className="ml-4 p-1 text-sm bg-gray-100 dark:bg-gray-700 rounded cursor-grab text-gray-900 dark:text-gray-100"
+                    className="ml-4 p-1 text-sm bg-gray-100 dark:bg-gray-700 rounded flex items-center justify-between text-gray-900 dark:text-gray-100"
                   >
-                    {item}
+                    <span>{item}</span>
+                    <button
+                      aria-label={`Add ${item}`}
+                      onClick={() => onAdd(item)}
+                      className="text-xs"
+                    >
+                      +
+                    </button>
                   </div>
                 ))}
             </div>
@@ -95,7 +104,6 @@ export default function SearchIncomePanel() {
           <div className="text-sm text-gray-500 dark:text-gray-400">No results</div>
         )}
       </div>
-      <IncomeForm open={open} onOpenChange={setOpen} showTrigger={false} />
     </div>
   );
 }

--- a/tests/SearchPanels.test.tsx
+++ b/tests/SearchPanels.test.tsx
@@ -3,30 +3,29 @@ import { describe, it, expect, vi } from 'vitest';
 import SearchExpensesPanel from '../app/(app)/analytics/components/SearchExpensesPanel';
 import SearchIncomePanel from '../app/(app)/analytics/components/SearchIncomePanel';
 
-vi.mock('../components/ExpenseForm', () => ({ __esModule: true, default: () => null }));
-vi.mock('../components/IncomeForm', () => ({ __esModule: true, default: () => null }));
-
 describe('SearchExpensesPanel', () => {
-  it('shows categories and allows expanding to items', () => {
-    render(<SearchExpensesPanel />);
+  it('shows categories, expands, and adds items', () => {
+    const onAdd = vi.fn();
+    render(<SearchExpensesPanel onAdd={onAdd} />);
     const category = screen.getByText('Finance Holding');
     expect(category).toBeInTheDocument();
-    fireEvent.click(screen.getByLabelText('Toggle Finance Holding'));
+    fireEvent.click(screen.getByLabelText('Expand Finance Holding'));
     expect(screen.getByText('Mortgage interest')).toBeInTheDocument();
-    expect(category).toHaveAttribute('draggable', 'true');
-    expect(screen.getByText('Mortgage interest')).toHaveAttribute('draggable', 'true');
+    fireEvent.click(screen.getByLabelText('Add Mortgage interest'));
+    expect(onAdd).toHaveBeenCalledWith('Mortgage interest');
   });
 });
 
 describe('SearchIncomePanel', () => {
-  it('shows categories and allows expanding to items', () => {
-    render(<SearchIncomePanel />);
+  it('shows categories, expands, and adds items', () => {
+    const onAdd = vi.fn();
+    render(<SearchIncomePanel onAdd={onAdd} />);
     const category = screen.getByText('Core Rent');
     expect(category).toBeInTheDocument();
-    fireEvent.click(screen.getByLabelText('Toggle Core Rent'));
+    fireEvent.click(screen.getByLabelText('Expand Core Rent'));
     expect(screen.getByText('Base rent')).toBeInTheDocument();
-    expect(category).toHaveAttribute('draggable', 'true');
-    expect(screen.getByText('Base rent')).toHaveAttribute('draggable', 'true');
+    fireEvent.click(screen.getByLabelText('Add Base rent'));
+    expect(onAdd).toHaveBeenCalledWith('Base rent');
   });
 });
 


### PR DESCRIPTION
## Summary
- Replace search panel titles with simplified "Income" and "Expenses" headers
- Use chevrons and plus icons to expand categories and add them to applied filters
- Wire filter panels to update analytics state and adjust tests

## Testing
- `npm run test:unit` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@hello-pangea%2fdnd)*

------
https://chatgpt.com/codex/tasks/task_e_68c3fdeb8f04832c8a418136373b6f4e