### PR TITLE
feat: add dark theme tokens and demo

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,19 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  overrides: [
+    {
+      files: ['**/*.{ts,tsx,js,jsx}'],
+      rules: {
+        'no-restricted-syntax': [
+          'error',
+          {
+            selector: "Literal[value=/^#[0-9A-Fa-f]{3,6}$/]",
+            message: 'Avoid hard-coded hex colors; use design tokens.',
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/README.md
+++ b/README.md
@@ -134,3 +134,27 @@ Retrieve profit and loss figures for a single property over a specific date rang
 
 The response contains total `income`, `expenses`, `net` amount and a `buckets` array of monthly breakdowns.
 
+
+## Dark theme tokens
+
+The dark theme is driven by CSS variables defined in `app/globals.css`:
+
+```
+--bg-base: #0B0F1A;
+--bg-surface: #111826;
+--bg-elevated: #161E2E;
+--border: #2A3448;
+--text-primary: #E6EAF2;
+--text-secondary: #B1B7C6;
+--text-muted: #8A93A5;
+--text-disabled: #5C667A;
+--primary: #4EA8FF;
+--success: #10B981;
+--warning: #F59E0B;
+--danger: #EF4444;
+```
+
+### Usage
+
+- **Do:** `className="bg-bg-surface text-text-primary"`
+- **Don't:** `className="bg-slate-900 text-gray-300"`

--- a/app/(app)/analytics/components/VizLine.tsx
+++ b/app/(app)/analytics/components/VizLine.tsx
@@ -1,4 +1,4 @@
-import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from 'recharts';
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend, CartesianGrid } from 'recharts';
 
 interface Props {
   data: { label: string; income: number; expenses: number; net: number }[];
@@ -21,21 +21,23 @@ export default function VizLine({ data, showIncome = true, showExpenses = true, 
     <div data-testid="viz-line" className="h-64">
       <ResponsiveContainer width="100%" height="100%">
         <LineChart data={chartData}>
-          <XAxis dataKey="label" tickFormatter={formatLabel} />
-          <YAxis />
+          <CartesianGrid stroke="rgba(255,255,255,0.06)" />
+          <XAxis dataKey="label" tickFormatter={formatLabel} stroke="var(--text-secondary)" />
+          <YAxis stroke="var(--text-secondary)" />
           <Tooltip
             labelFormatter={formatLabel}
             formatter={(value: number, name: string) => [value, name.charAt(0).toUpperCase() + name.slice(1)]}
+            contentStyle={{ backgroundColor: 'var(--bg-elevated)', borderColor: 'var(--border)', color: 'var(--text-primary)' }}
           />
           <Legend />
           {showNet && hasData && (
-            <Line type="monotone" dataKey="net" stroke="#10b981" name="Net" dot={false} />
+            <Line type="monotone" dataKey="net" stroke="var(--chart-1)" name="Net" dot={false} />
           )}
           {showIncome && hasData && (
-            <Line type="monotone" dataKey="income" stroke="#3b82f6" name="Income" dot={false} />
+            <Line type="monotone" dataKey="income" stroke="var(--chart-2)" name="Income" dot={false} />
           )}
           {showExpenses && hasData && (
-            <Line type="monotone" dataKey="expenses" stroke="#ef4444" name="Expenses" dot={false} />
+            <Line type="monotone" dataKey="expenses" stroke="var(--chart-5)" name="Expenses" dot={false} />
           )}
         </LineChart>
       </ResponsiveContainer>

--- a/app/(app)/analytics/components/VizPie.tsx
+++ b/app/(app)/analytics/components/VizPie.tsx
@@ -4,7 +4,16 @@ interface Props {
   data: { label: string; value: number }[];
 }
 
-const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042'];
+const COLORS = [
+  'var(--chart-1)',
+  'var(--chart-2)',
+  'var(--chart-3)',
+  'var(--chart-4)',
+  'var(--chart-5)',
+  'var(--chart-6)',
+  'var(--chart-7)',
+  'var(--chart-8)',
+];
 
 export default function VizPie({ data }: Props) {
   return (
@@ -16,7 +25,7 @@ export default function VizPie({ data }: Props) {
               <Cell key={i} fill={COLORS[i % COLORS.length]} />
             ))}
           </Pie>
-          <Tooltip />
+          <Tooltip contentStyle={{ backgroundColor: 'var(--bg-elevated)', borderColor: 'var(--border)', color: 'var(--text-primary)' }} />
         </PieChart>
       </ResponsiveContainer>
     </div>

--- a/app/dark-demo/page.tsx
+++ b/app/dark-demo/page.tsx
@@ -1,0 +1,33 @@
+import DarkModeToggle from "../../components/DarkModeToggle";
+import { Button } from "../../components/ui/button";
+import { Input } from "../../components/ui/input";
+import ApplicationsTable from "../../components/ApplicationsTable";
+
+export default function Page() {
+  const rows = [
+    { id: "1", applicant: "Jane Doe", property: "123 Main", status: "New" },
+  ];
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex justify-end">
+        <DarkModeToggle />
+      </div>
+      <div className="p-4 bg-bg-surface border border-[var(--border)] rounded shadow-sm space-y-2">
+        <h2 className="font-semibold">Buttons</h2>
+        <div className="space-x-2">
+          <Button>Primary</Button>
+          <Button variant="secondary">Secondary</Button>
+          <Button variant="destructive">Destructive</Button>
+        </div>
+      </div>
+      <div className="p-4 bg-bg-surface border border-[var(--border)] rounded shadow-sm space-y-2">
+        <h2 className="font-semibold">Input</h2>
+        <Input placeholder="Placeholder" />
+      </div>
+      <div className="p-4 bg-bg-surface border border-[var(--border)] rounded shadow-sm space-y-2">
+        <h2 className="font-semibold">Table</h2>
+        <ApplicationsTable rows={rows} />
+      </div>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,30 +2,60 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Global scrollbar styling for light and dark modes */
-* {
+:root[data-theme="dark"]{
+  --bg-base:#0B0F1A;
+  --bg-surface:#111826;
+  --bg-elevated:#161E2E;
+  --border:#2A3448;
+
+  --text-primary:#E6EAF2;
+  --text-secondary:#B1B7C6;
+  --text-muted:#8A93A5;
+  --text-disabled:#5C667A;
+  --placeholder:#6B7280;
+
+  --primary:#4EA8FF;
+  --primary-hover:#79BFFF;
+  --primary-active:#2D7ECD;
+  --focus:#93C5FD;
+
+  --success:#10B981;
+  --warning:#F59E0B;
+  --danger:#EF4444;
+  --info:#60A5FA;
+
+  --shadow-1:0 1px 0 rgba(255,255,255,0.03),0 4px 16px rgba(0,0,0,0.6);
+  --zebra:rgba(255,255,255,0.02);
+  --hover:rgba(255,255,255,0.04);
+
+  --chart-1:#60A5FA; --chart-2:#34D399; --chart-3:#F59E0B; --chart-4:#A78BFA;
+  --chart-5:#F87171; --chart-6:#22D3EE; --chart-7:#F472B6; --chart-8:#94A3B8;
+}
+@media (prefers-color-scheme: dark){
+  html{ color-scheme: dark; }
+}
+
+[data-theme="dark"] body{ background:var(--bg-base); color:var(--text-primary); }
+[data-theme="dark"] input,
+[data-theme="dark"] select,
+[data-theme="dark"] textarea{ background:var(--bg-surface); border:1px solid var(--border); color:var(--text-primary); }
+[data-theme="dark"] ::placeholder{ color:var(--placeholder); opacity:1; }
+
+[data-theme="dark"] *{
   scrollbar-width: thin;
-  scrollbar-color: #9ca3af transparent; /* gray-400 */
+  scrollbar-color: var(--border) var(--bg-base);
 }
-
-.dark * {
-  scrollbar-color: #4b5563 transparent; /* gray-600 */
-}
-
-*::-webkit-scrollbar {
+[data-theme="dark"] *::-webkit-scrollbar{
   width: 8px;
   height: 8px;
 }
-
-*::-webkit-scrollbar-track {
-  background: transparent;
+[data-theme="dark"] *::-webkit-scrollbar-track{
+  background: var(--bg-base);
 }
-
-*::-webkit-scrollbar-thumb {
-  background-color: #9ca3af; /* gray-400 */
+[data-theme="dark"] *::-webkit-scrollbar-thumb{
+  background-color: var(--border);
   border-radius: 4px;
 }
-
-.dark *::-webkit-scrollbar-thumb {
-  background-color: #4b5563; /* gray-600 */
+[data-theme="dark"] *::-webkit-scrollbar-thumb:hover{
+  background-color: #3A4761;
 }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -21,25 +21,17 @@ export default function Providers({ children }: { children: ReactNode }) {
   const [theme, setTheme] = useState<Theme>('light');
 
   useEffect(() => {
-    const applySystemTheme = () => {
-      if (!localStorage.getItem('theme')) {
-        const hour = new Date().getHours();
-        const isDark = hour >= 18 || hour < 6;
-        setTheme(isDark ? 'dark' : 'light');
-      }
-    };
     const stored = localStorage.getItem('theme') as Theme | null;
     if (stored) {
       setTheme(stored);
     } else {
-      applySystemTheme();
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      setTheme(prefersDark ? 'dark' : 'light');
     }
-    const id = setInterval(applySystemTheme, 60_000);
-    return () => clearInterval(id);
   }, []);
 
   useEffect(() => {
-    document.documentElement.classList.toggle('dark', theme === 'dark');
+    document.documentElement.setAttribute('data-theme', theme);
   }, [theme]);
 
   const toggleTheme = () =>

--- a/components/ApplicationsTable.tsx
+++ b/components/ApplicationsTable.tsx
@@ -14,9 +14,9 @@ export default function ApplicationsTable({ rows }: { rows: ApplicationRow[] }) 
   const openDetails = (id: string) => router.push(`/applications/${id}`);
 
   return (
-    <table className="min-w-full border dark:border-gray-700">
+    <table className="min-w-full border border-[var(--border)]">
       <thead>
-        <tr className="bg-gray-100 dark:bg-gray-800">
+        <tr className="bg-bg-elevated">
           <th className="p-2 text-left">Applicant</th>
           <th className="p-2 text-left">Property</th>
           <th className="p-2 text-left">Status</th>
@@ -26,7 +26,7 @@ export default function ApplicationsTable({ rows }: { rows: ApplicationRow[] }) 
         {rows.map((r) => (
           <tr
             key={r.id}
-            className="border-t cursor-pointer hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700"
+            className="border-t border-[var(--border)] cursor-pointer even:bg-[var(--zebra)] hover:bg-[var(--hover)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] ring-offset-2 ring-offset-[var(--bg-base)]"
             role="button"
             tabIndex={0}
             onClick={() => openDetails(r.id)}

--- a/components/DashboardPnlMiniChart.tsx
+++ b/components/DashboardPnlMiniChart.tsx
@@ -28,7 +28,7 @@ export default function DashboardPnlMiniChart() {
 
   if (!data || data.series.length === 0) {
     return (
-      <div className="p-4 border rounded">
+      <div className="p-4 bg-bg-surface border border-[var(--border)] rounded shadow-sm">
         <h2 className="font-semibold mb-2">P&L Trend (Last 6 months)</h2>
         <EmptyState message="Not enough data yet" />
       </div>
@@ -39,7 +39,7 @@ export default function DashboardPnlMiniChart() {
 
   return (
     <div
-      className="p-4 border rounded group cursor-pointer"
+      className="p-4 bg-bg-surface border border-[var(--border)] rounded shadow-sm group cursor-pointer"
       data-testid="pnl-mini"
       onClick={() => router.push("/analytics")}
       role="link"
@@ -50,23 +50,23 @@ export default function DashboardPnlMiniChart() {
           <AreaChart data={series}>
             <Tooltip
               contentStyle={{
-                backgroundColor: "var(--tooltip-bg, #ffffff)",
-                borderColor: "var(--tooltip-border, #e5e7eb)",
-                color: "var(--tooltip-text, #000000)",
+                backgroundColor: "var(--bg-elevated)",
+                borderColor: "var(--border)",
+                color: "var(--text-primary)",
               }}
               formatter={(_, __, props) => [props.payload.net, props.payload.month]}
             />
             <Area
               type="monotone"
               dataKey="net"
-              stroke="currentColor"
-              fill="currentColor"
+              stroke="var(--chart-1)"
+              fill="var(--chart-1)"
               fillOpacity={0.3}
             />
           </AreaChart>
         </ResponsiveContainer>
       </div>
-      <div className="flex justify-between text-xs mt-2 opacity-0 group-hover:opacity-100 transition-opacity">
+      <div className="flex justify-between text-xs mt-2 opacity-0 group-hover:opacity-100 transition-opacity text-text-secondary">
         <div>Income: {totals.income}</div>
         <div>Expenses: {totals.expenses}</div>
         <div>Net: {totals.net}</div>

--- a/components/PnLChart.tsx
+++ b/components/PnLChart.tsx
@@ -7,6 +7,7 @@ import {
   YAxis,
   Tooltip,
   ResponsiveContainer,
+  CartesianGrid,
 } from "recharts";
 
 interface MonthlyNet {
@@ -21,20 +22,21 @@ export default function PnLChart({ data }: { data: MonthlyNet[] }) {
     <div className="h-64">
       <ResponsiveContainer width="100%" height="100%">
         <LineChart data={data}>
-          <XAxis dataKey="month" stroke="currentColor" />
-          <YAxis stroke="currentColor" />
+          <CartesianGrid stroke="rgba(255,255,255,0.06)" />
+          <XAxis dataKey="month" stroke="var(--text-secondary)" />
+          <YAxis stroke="var(--text-secondary)" />
           <Tooltip
             contentStyle={{
-              backgroundColor: "var(--tooltip-bg, #ffffff)",
-              borderColor: "var(--tooltip-border, #e5e7eb)",
-              color: "var(--tooltip-text, #000000)",
+              backgroundColor: "var(--bg-elevated)",
+              borderColor: "var(--border)",
+              color: "var(--text-primary)",
             }}
           />
           {data.some((d) => d.income !== undefined) && (
             <Line
               type="monotone"
               dataKey="income"
-              stroke="var(--color-income, rgb(34,197,94))"
+              stroke="var(--chart-2)"
               strokeWidth={2}
               dot={false}
             />
@@ -43,7 +45,7 @@ export default function PnLChart({ data }: { data: MonthlyNet[] }) {
             <Line
               type="monotone"
               dataKey="expenses"
-              stroke="var(--color-expenses, rgb(239,68,68))"
+              stroke="var(--chart-5)"
               strokeWidth={2}
               dot={false}
             />
@@ -51,7 +53,7 @@ export default function PnLChart({ data }: { data: MonthlyNet[] }) {
           <Line
             type="monotone"
             dataKey="net"
-            stroke="var(--color-net, rgb(75,192,192))"
+            stroke="var(--chart-1)"
             strokeWidth={2}
             dot={false}
           />
@@ -60,4 +62,3 @@ export default function PnLChart({ data }: { data: MonthlyNet[] }) {
     </div>
   );
 }
-

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -5,9 +5,11 @@ import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
 import { listProperties } from "../lib/api";
 import type { PropertySummary } from "../types/property";
+import { usePathname } from "next/navigation";
 
 export default function Sidebar() {
   const [open, setOpen] = useState(false);
+  const pathname = usePathname();
   const { data: propertyList = [] } = useQuery<PropertySummary[]>({
     queryKey: ["properties"],
     queryFn: listProperties,
@@ -99,43 +101,49 @@ export default function Sidebar() {
     <div
       onMouseEnter={() => setOpen(true)}
       onMouseLeave={() => setOpen(false)}
-      className={`relative h-screen bg-white dark:bg-gray-800 border-r dark:border-gray-700 transition-all ${
+      className={`relative h-screen bg-bg-base border-r border-[var(--border)] transition-all ${
         open ? "w-64" : "w-16"
       }`}
     >
       <div className="flex flex-col h-full justify-between">
         <nav className="mt-12 space-y-1">
-          {links.map((link) => (
-            <div key={link.href}>
-              <Link
-                href={link.href}
-                className={`flex items-center px-4 py-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700 ${
-                  open ? "" : "justify-center"
-                }`}
-              >
-                <span className="h-6 w-6">{link.icon}</span>
-                {open && <span className="ml-3">{link.label}</span>}
-              </Link>
-              {open && link.children && (
-                <div className="ml-8 mt-1 space-y-1">
-                  {link.children.map((child) => (
-                    <Link
-                      key={child.href}
-                      href={child.href}
-                      className="block px-2 py-1 text-sm rounded hover:bg-gray-100 dark:hover:bg-gray-700"
-                    >
-                      {child.label}
-                    </Link>
-                  ))}
-                </div>
-              )}
-            </div>
-          ))}
+          {links.map((link) => {
+            const active = pathname === link.href;
+            return (
+              <div key={link.href}>
+                <Link
+                  href={link.href}
+                  className={`relative flex items-center px-4 py-2 rounded hover:bg-[var(--hover)] text-text-primary ${
+                    open ? "" : "justify-center"
+                  } ${active ? "bg-bg-elevated" : ""}`}
+                >
+                  {active && (
+                    <span className="absolute left-0 top-0 h-full w-1 bg-[var(--primary)]" />
+                  )}
+                  <span className="h-6 w-6">{link.icon}</span>
+                  {open && <span className="ml-3">{link.label}</span>}
+                </Link>
+                {open && link.children && (
+                  <div className="ml-8 mt-1 space-y-1">
+                    {link.children.map((child) => (
+                      <Link
+                        key={child.href}
+                        href={child.href}
+                        className="block px-2 py-1 text-sm rounded hover:bg-[var(--hover)]"
+                      >
+                        {child.label}
+                      </Link>
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })}
         </nav>
-        <div className="p-4 border-t dark:border-gray-700 flex justify-center">
+        <div className="p-4 border-t border-[var(--border)] flex justify-center">
           <Link
             href="/settings"
-            className="p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
+            className="p-2 rounded hover:bg-[var(--hover)]"
             aria-label="Settings"
           >
             <svg
@@ -164,4 +172,3 @@ export default function Sidebar() {
     </div>
   );
 }
-

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,12 +1,17 @@
 import * as React from "react";
 
-export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: "primary" | "secondary" | "destructive";
+}
 
-export function Button({ className = "", ...props }: ButtonProps) {
-  return (
-    <button
-      className={"px-3 py-1 rounded bg-blue-600 text-white disabled:opacity-50 " + className}
-      {...props}
-    />
-  );
+export function Button({ className = "", variant = "primary", ...props }: ButtonProps) {
+  const base =
+    "px-3 py-1 rounded disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] ring-offset-2 ring-offset-[var(--bg-base)] transition-colors";
+  const variants: Record<string, string> = {
+    primary:
+      "bg-[var(--primary)] hover:bg-[var(--primary-hover)] active:bg-[var(--primary-active)] text-black",
+    secondary: "bg-bg-elevated border border-[var(--border)] hover:bg-[var(--hover)]",
+    destructive: "bg-[var(--danger)] hover:brightness-110 text-black",
+  };
+  return <button className={`${base} ${variants[variant]} ${className}`} {...props} />;
 }

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 
-export const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>( 
+export const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
   ({ className = "", ...props }, ref) => (
     <input
       ref={ref}
-      className={"border rounded px-2 py-1 w-full " + className}
+      className={`bg-bg-surface border border-[var(--border)] rounded px-2 py-1 w-full text-[var(--text-primary)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] ring-offset-2 ring-offset-[var(--bg-base)] ${className}`}
       {...props}
     />
   )

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -10,7 +10,7 @@ export function Switch({ checked, onCheckedChange, className = "" }: SwitchProps
   return (
     <input
       type="checkbox"
-      className={"w-10 h-6 " + className}
+      className={`w-10 h-6 rounded bg-bg-elevated border border-[var(--border)] checked:bg-[var(--primary)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] ring-offset-2 ring-offset-[var(--bg-base)] ${className}`}
       checked={checked}
       onChange={(e) => onCheckedChange?.(e.target.checked)}
     />

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "start": "next start",
     "deploy": "bash -ac 'source .env && npx prisma migrate deploy && npx prisma db seed && next start'",
     "test": "playwright test",
-    "test:unit": "vitest run"
+    "test:unit": "vitest run",
+    "lint": "eslint . --ext .ts,.tsx"
   },
   "dependencies": {
     "@prisma/client": "^5.13.0",
@@ -34,6 +35,8 @@
     "@playwright/test": "^1.44.0",
     "vitest": "^1.4.0",
     "@testing-library/react": "^14.0.0",
-    "@testing-library/jest-dom": "^6.1.3"
+    "@testing-library/jest-dom": "^6.1.3",
+    "eslint": "^8.57.0",
+    "@typescript-eslint/parser": "^7.0.0"
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,10 +1,30 @@
 import type { Config } from 'tailwindcss';
 
+const withVar = (v: string) => ({ DEFAULT: `var(${v})` });
+
 const config: Config = {
-  darkMode: 'class',
+  darkMode: ['class', '[data-theme="dark"]'],
   content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        bg: { base: 'var(--bg-base)', surface: 'var(--bg-surface)', elevated: 'var(--bg-elevated)' },
+        border: withVar('--border'),
+        text: {
+          primary: 'var(--text-primary)',
+          secondary: 'var(--text-secondary)',
+          muted: 'var(--text-muted)',
+          disabled: 'var(--text-disabled)',
+        },
+        primary: withVar('--primary'),
+        success: withVar('--success'),
+        warning: withVar('--warning'),
+        danger: withVar('--danger'),
+        info: withVar('--info'),
+      },
+      boxShadow: { sm: 'var(--shadow-1)', md: 'var(--shadow-1)' },
+      transitionDuration: { 120: '120ms', 160: '160ms', 200: '200ms' },
+    },
   },
   plugins: [],
 };

--- a/tests/VizLine.test.tsx
+++ b/tests/VizLine.test.tsx
@@ -17,18 +17,18 @@ describe('VizLine', () => {
     const { container } = render(
       <VizLine data={sample} showIncome showExpenses={false} showNet={false} />
     );
-    expect(container.querySelector('path[stroke="#3b82f6"]')).not.toBeNull();
-    expect(container.querySelector('path[stroke="#ef4444"]')).toBeNull();
-    expect(container.querySelector('path[stroke="#10b981"]')).toBeNull();
+    expect(container.querySelector('path[stroke="var(--chart-2)"]')).not.toBeNull();
+    expect(container.querySelector('path[stroke="var(--chart-5)"]')).toBeNull();
+    expect(container.querySelector('path[stroke="var(--chart-1)"]')).toBeNull();
   });
 
   it('renders axes without data', () => {
     const { container } = render(
       <VizLine data={[]} showIncome={false} showExpenses={false} showNet={false} />
     );
-    expect(container.querySelector('path[stroke="#3b82f6"]')).toBeNull();
-    expect(container.querySelector('path[stroke="#ef4444"]')).toBeNull();
-    expect(container.querySelector('path[stroke="#10b981"]')).toBeNull();
+    expect(container.querySelector('path[stroke="var(--chart-2)"]')).toBeNull();
+    expect(container.querySelector('path[stroke="var(--chart-5)"]')).toBeNull();
+    expect(container.querySelector('path[stroke="var(--chart-1)"]')).toBeNull();
     expect(container.querySelectorAll('.recharts-cartesian-axis').length).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary
- add dark mode design tokens and map Tailwind utilities
- provide theme toggle using `data-theme` with local storage and system default
- refactor sample components and add dark mode demo page

## Testing
- `npm install` *(failed: 403 Forbidden - GET https://registry.npmjs.org/@hello-pangea%2fdnd)*
- `npm run lint` *(failed: ESLint couldn't find a config file)*
- `npm run test:unit` *(failed: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c401adc83c832cbd51b59d949c6e12