### PR TITLE
Replace analytics builder back link with icon

### DIFF
--- a/app/(app)/analytics/builder/page.tsx
+++ b/app/(app)/analytics/builder/page.tsx
@@ -49,10 +49,13 @@ export default function AnalyticsBuilderPage() {
   return (
     <div className="flex">
       <div className="flex-1 p-6 space-y-4">
-        <Link href="/analytics" className="text-sm text-blue-600 hover:underline">
-          &larr; Back to Analytics
-        </Link>
-        <h1 className="text-2xl font-semibold mb-4 mt-2">Analytics</h1>
+        <div className="flex items-center gap-2 mb-4 mt-2">
+          <Link href="/analytics" className="text-blue-600 hover:underline">
+            <span aria-hidden>&larr;</span>
+            <span className="sr-only">Back to Analytics</span>
+          </Link>
+          <h1 className="text-2xl font-semibold">Analytics Builder</h1>
+        </div>
         <div ref={exportRef} className="space-y-2">
           <div data-testid="viz-section">
             {state.viz === 'line' && (


### PR DESCRIPTION
## Summary
- replace "Back to Analytics" link with clickable icon placed next to the heading
- rename page heading to "Analytics Builder"

## Testing
- `npm run test:unit` *(fails: vitest: not found)*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@hello-pangea%2fdnd)*

------
https://chatgpt.com/codex/tasks/task_e_68c402e919f0832c97301b4b6cac39c7