### PR TITLE
feat: add light theme tokens and demo

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,39 @@
 @tailwind components;
 @tailwind utilities;
 
+:root[data-theme="light"]{
+  --bg-base:#F8FAFC;
+  --bg-surface:#FFFFFF;
+  --bg-elevated:#F3F6FB;
+  --border:#D6DEE8;
+
+  --text-primary:#0B1220;
+  --text-secondary:#3B475A;
+  --text-muted:#6A778D;
+  --text-disabled:#A4AEC0;
+  --placeholder:#9AA6B2;
+
+  --primary:#2563EB;
+  --primary-hover:#3B82F6;
+  --primary-active:#1D4ED8;
+  --focus:#93C5FD;
+
+  --success:#16A34A;
+  --warning:#D97706;
+  --danger:#DC2626;
+  --info:#2563EB;
+
+  --shadow-1:0 1px 2px rgba(16,24,40,.06), 0 8px 24px rgba(16,24,40,.06);
+  --zebra:rgba(2,6,23,.03);
+  --hover:rgba(2,6,23,.05);
+
+  --chart-1:#2563EB; --chart-2:#059669; --chart-3:#D97706; --chart-4:#7C3AED;
+  --chart-5:#DC2626; --chart-6:#0891B2; --chart-7:#DB2777; --chart-8:#475569;
+}
+@media (prefers-color-scheme: light){
+  html{ color-scheme: light; }
+}
+
 :root[data-theme="dark"]{
   --bg-base:#0B0F1A;
   --bg-surface:#111826;
@@ -35,7 +68,21 @@
   html{ color-scheme: dark; }
 }
 
+[data-theme="light"] body{ background:var(--bg-base); color:var(--text-primary); }
+[data-theme="light"] .card{ background:var(--bg-surface); border:1px solid var(--border); box-shadow:var(--shadow-1); }
+[data-theme="light"] input,
+[data-theme="light"] select,
+[data-theme="light"] textarea{
+  background:var(--bg-surface); border:1px solid var(--border); color:var(--text-primary);
+}
+[data-theme="light"] ::placeholder{ color:var(--placeholder); opacity:1; }
+
+[data-theme="light"] table thead{ background:var(--bg-elevated); }
+[data-theme="light"] table tbody tr:nth-child(even){ background:var(--zebra); }
+[data-theme="light"] table tbody tr:hover{ background:var(--hover); }
+
 [data-theme="dark"] body{ background:var(--bg-base); color:var(--text-primary); }
+[data-theme="dark"] .card{ background:var(--bg-surface); border:1px solid var(--border); box-shadow:var(--shadow-1); }
 [data-theme="dark"] input,
 [data-theme="dark"] select,
 [data-theme="dark"] textarea{ background:var(--bg-surface); border:1px solid var(--border); color:var(--text-primary); }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,7 +8,7 @@ export const metadata = { title: 'PropTech' };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" data-theme="dark">
+    <html lang="en" data-theme="light">
       <body className="min-h-screen">
         <Providers>
           <TitleUpdater />

--- a/app/listings/page.tsx
+++ b/app/listings/page.tsx
@@ -23,18 +23,18 @@ export default function ListingsPage() {
       ) : error ? (
         <ErrorState message={(error as Error).message} />
       ) : (
-        <table className="min-w-full bg-white">
+        <table className="min-w-full border rounded card">
           <thead>
             <tr>
-              <th className="border px-2 py-1 text-left">Property</th>
-              <th className="border px-2 py-1 text-left">Rent</th>
+              <th className="border-[var(--border)] px-2 py-1 text-left">Property</th>
+              <th className="border-[var(--border)] px-2 py-1 text-left">Rent</th>
             </tr>
           </thead>
           <tbody>
             {listings?.map((l) => (
               <tr key={l.id}>
-                <td className="border px-2 py-1">{l.property}</td>
-                <td className="border px-2 py-1">${l.rent}</td>
+                <td className="border-[var(--border)] px-2 py-1">{l.property}</td>
+                <td className="border-[var(--border)] px-2 py-1">${l.rent}</td>
               </tr>
             ))}
           </tbody>

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -12,13 +12,13 @@ interface ThemeContextValue {
 }
 
 export const ThemeContext = createContext<ThemeContextValue>({
-  theme: 'dark',
+  theme: 'light',
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   toggleTheme: () => {},
 });
 
 export default function Providers({ children }: { children: ReactNode }) {
-  const [theme, setTheme] = useState<Theme>('dark');
+  const [theme, setTheme] = useState<Theme>('light');
 
   useEffect(() => {
     const stored = localStorage.getItem('theme') as Theme | null;

--- a/app/theme-demo/page.tsx
+++ b/app/theme-demo/page.tsx
@@ -1,0 +1,19 @@
+import { Button } from "../../components/ui/button";
+
+export default function ThemeDemo() {
+  return (
+    <div className="grid grid-cols-2 gap-4 p-4">
+      <div data-theme="light" className="space-y-4 p-4 rounded card">
+        <h2 className="font-semibold">Light Theme</h2>
+        <Button>Primary</Button>
+        <Button variant="secondary">Secondary</Button>
+      </div>
+      <div data-theme="dark" className="space-y-4 p-4 rounded card">
+        <h2 className="font-semibold">Dark Theme</h2>
+        <Button>Primary</Button>
+        <Button variant="secondary">Secondary</Button>
+      </div>
+    </div>
+  );
+}
+

--- a/components/PropertyDocumentsTable.tsx
+++ b/components/PropertyDocumentsTable.tsx
@@ -18,8 +18,8 @@ export default function PropertyDocumentsTable({
   });
 
   return (
-    <table className="min-w-full border bg-white dark:bg-gray-800 dark:border-gray-700">
-      <thead className="bg-gray-100 dark:bg-gray-700">
+    <table className="min-w-full border rounded card">
+      <thead>
         <tr>
           <th className="p-2 text-left">Name</th>
           <th className="p-2 text-left">Uploaded</th>
@@ -28,7 +28,7 @@ export default function PropertyDocumentsTable({
       </thead>
       <tbody>
         {data.map((d) => (
-          <tr key={d.id} className="border-t dark:border-gray-700">
+          <tr key={d.id} className="border-t border-[var(--border)]">
             <td className="p-2">{d.name}</td>
             <td className="p-2">{d.uploaded}</td>
             <td className="p-2">
@@ -36,7 +36,7 @@ export default function PropertyDocumentsTable({
                 href={d.url}
                 target="_blank"
                 rel="noreferrer"
-                className="text-blue-600 underline dark:text-blue-400"
+                className="text-[var(--primary)] underline"
               >
                 View
               </a>

--- a/components/RentLedgerTable.tsx
+++ b/components/RentLedgerTable.tsx
@@ -48,8 +48,8 @@ export default function RentLedgerTable({
 
   return (
     <>
-      <table className="min-w-full border bg-white dark:bg-gray-800 dark:border-gray-700">
-        <thead className="bg-gray-100 dark:bg-gray-700">
+      <table className="min-w-full border rounded card">
+        <thead>
           <tr>
             <th className="p-2 text-left">Date</th>
             <th className="p-2 text-left">Description</th>
@@ -61,7 +61,7 @@ export default function RentLedgerTable({
           {entries.map((e) => (
             <tr
               key={e.id}
-              className="cursor-pointer border-t hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700"
+              className="cursor-pointer border-t border-[var(--border)] hover:bg-[var(--hover)]"
               onClick={() => setSelected(e)}
             >
               <td className="p-2">{e.date}</td>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -115,11 +115,12 @@ export default function Sidebar() {
                   href={link.href}
                   className={`relative flex items-center px-4 py-2 rounded hover:bg-[var(--hover)] text-text-primary ${
                     open ? "" : "justify-center"
-                  } ${active ? "bg-bg-elevated" : ""}`}
+                  } ${
+                    active
+                      ? "bg-[rgba(37,99,235,.08)] border-l-2 border-[var(--primary)]"
+                      : "border-l-2 border-transparent"
+                  }`}
                 >
-                  {active && (
-                    <span className="absolute left-0 top-0 h-full w-1 bg-[var(--primary)]" />
-                  )}
                   <span className="h-6 w-6">{link.icon}</span>
                   {open && <span className="ml-3">{link.label}</span>}
                 </Link>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -9,9 +9,10 @@ export function Button({ className = "", variant = "primary", ...props }: Button
     "px-3 py-1 rounded disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] ring-offset-2 ring-offset-[var(--bg-base)] transition-colors";
   const variants: Record<string, string> = {
     primary:
-      "bg-[var(--primary)] hover:bg-[var(--primary-hover)] active:bg-[var(--primary-active)] text-black",
-    secondary: "bg-bg-elevated border border-[var(--border)] hover:bg-[var(--hover)]",
-    destructive: "bg-[var(--danger)] hover:brightness-110 text-black",
+      "bg-[var(--primary)] hover:bg-[var(--primary-hover)] active:bg-[var(--primary-active)] text-white",
+    secondary:
+      "bg-[var(--bg-surface)] border border-[var(--border)] hover:bg-[var(--hover)] text-[var(--text-secondary)]",
+    destructive: "bg-[var(--danger)] hover:brightness-110 text-white",
   };
   return <button className={`${base} ${variants[variant]} ${className}`} {...props} />;
 }


### PR DESCRIPTION
## Summary
- add light-mode color tokens and element styles
- support theme toggling and sidebar/table styling
- showcase light and dark themes side-by-side

## Testing
- `npm test` *(fails: playwright not found)*
- `npm run test:unit` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c4096f2b64832c83d127c697aa7f72