### PR TITLE
Add sidebar layout for settings

### DIFF
--- a/app/(app)/settings/layout.tsx
+++ b/app/(app)/settings/layout.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+import PageHeader from "../../../components/PageHeader";
+import DarkModeToggle from "../../../components/DarkModeToggle";
+import React from "react";
+
+export default function SettingsLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex h-full">
+      <aside className="w-64 border-r p-6 space-y-4">
+        <PageHeader title="Settings" />
+        <label className="flex items-center justify-between">
+          <span>Dark Mode</span>
+          <DarkModeToggle />
+        </label>
+        <ul className="list-disc pl-6 space-y-1">
+          <li>
+            <Link href="/settings/notifications">Notification Preferences</Link>
+          </li>
+        </ul>
+      </aside>
+      <div className="flex-1 p-6">{children}</div>
+    </div>
+  );
+}

--- a/app/(app)/settings/notifications/page.tsx
+++ b/app/(app)/settings/notifications/page.tsx
@@ -2,9 +2,9 @@ import NotificationPrefsForm from '../../../../components/NotificationPrefsForm'
 
 export default function NotificationSettingsPage() {
   return (
-    <div className="p-6">
+    <>
       <h1 className="text-2xl font-semibold mb-4">Notification Settings</h1>
       <NotificationPrefsForm />
-    </div>
+    </>
   );
 }

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -1,20 +1,7 @@
-import Link from "next/link";
-import PageHeader from "../../../components/PageHeader";
-import DarkModeToggle from "../../../components/DarkModeToggle";
-
 export default function SettingsPage() {
   return (
-      <div className="p-6 space-y-4">
-        <PageHeader title="Settings" />
-        <label className="flex items-center justify-between">
-          <span>Dark Mode</span>
-          <DarkModeToggle />
-        </label>
-        <ul className="list-disc pl-6 space-y-1">
-          <li>
-            <Link href="/settings/notifications">Notification Preferences</Link>
-          </li>
-        </ul>
-      </div>
+    <div className="text-sm text-muted-foreground">
+      Select a setting to view details.
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- create two-pane settings layout with sidebar categories and detail area
- simplify base settings page and embed notification settings in layout

## Testing
- `npm test` *(fails: playwright not found)*
- `npm run test:unit` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b2453608832c8c229c9a369e9f1b