### PR TITLE
chore: remove presets card from analytics builder

### DIFF
--- a/app/(app)/analytics/builder/page.tsx
+++ b/app/(app)/analytics/builder/page.tsx
@@ -9,7 +9,6 @@ import VizLine from '../components/VizLine';
 import VizPie from '../components/VizPie';
 import CustomGraphBuilder from '../components/CustomGraphBuilder';
 import ExportButtons from '../components/ExportButtons';
-import PresetMenu from '../components/PresetMenu';
 import VizSpreadsheet from '../components/VizSpreadsheet';
 import { AnalyticsState, AnalyticsStateType } from '../../../../lib/schemas';
 import { useUrlState } from '../../../../lib/urlState';
@@ -143,7 +142,6 @@ export default function AnalyticsBuilderPage() {
             }))
           }
         />
-        <PresetMenu />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- remove presets menu from analytics builder right rail

## Testing
- `npm test` *(fails: playwright not found)*
- `npm install` *(fails: 403 Forbidden fetching @hello-pangea/dnd)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c786e06084832cbb4cc195f0b7a4ea