### PR TITLE
feat: add icons for dark mode toggle

### DIFF
--- a/app/(app)/settings/layout.tsx
+++ b/app/(app)/settings/layout.tsx
@@ -9,7 +9,7 @@ export default function SettingsLayout({ children }: { children: React.ReactNode
       <aside className="w-64 border-r p-6 space-y-4">
         <PageHeader title="Settings" />
         <label className="flex items-center justify-between">
-          <span>Dark Mode</span>
+          <span className="sr-only">Dark Mode</span>
           <DarkModeToggle />
         </label>
         <ul className="list-disc pl-6 space-y-1">

--- a/components/DarkModeToggle.tsx
+++ b/components/DarkModeToggle.tsx
@@ -5,5 +5,45 @@ import { Switch } from './ui/switch';
 
 export default function DarkModeToggle() {
   const { theme, toggleTheme } = useContext(ThemeContext);
-  return <Switch checked={theme === 'dark'} onCheckedChange={toggleTheme} />;
+  const isDark = theme === 'dark';
+  return (
+    <div className="flex items-center gap-2">
+      {isDark ? (
+        <svg
+          className="w-5 h-5 text-yellow-500"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <circle cx="12" cy="12" r="5" />
+          <line x1="12" y1="1" x2="12" y2="3" />
+          <line x1="12" y1="21" x2="12" y2="23" />
+          <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+          <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+          <line x1="1" y1="12" x2="3" y2="12" />
+          <line x1="21" y1="12" x2="23" y2="12" />
+          <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+          <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+        </svg>
+      ) : (
+        <svg
+          className="w-5 h-5"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+        </svg>
+      )}
+      <Switch checked={isDark} onCheckedChange={toggleTheme} />
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- show a moon icon beside the dark mode toggle when in light mode
- show a yellow sun icon beside the toggle when in dark mode
- keep accessible label hidden to allow the switch to remain screen-reader friendly

## Testing
- `npm test` *(fails: playwright not found)*
- `npm run test:unit` *(fails: vitest not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c788e9795c832c92eeebbd5a5fa4d7