### PR TITLE
Rename custom analytics page

### DIFF
--- a/app/(app)/analytics/custom/page.tsx
+++ b/app/(app)/analytics/custom/page.tsx
@@ -6,7 +6,7 @@ export default function CustomAnalytics() {
       <Link href="/analytics" className="text-sm text-blue-600 hover:underline">
         &larr; Back to Analytics
       </Link>
-      <h1 className="text-2xl font-semibold mb-4 mt-2">Custom Analytics</h1>
+      <h1 className="text-2xl font-semibold mb-4 mt-2">My Custom Analytics</h1>
       <p>Saved analytics will be accessible here.</p>
     </div>
   );

--- a/app/(app)/analytics/page.tsx
+++ b/app/(app)/analytics/page.tsx
@@ -44,7 +44,7 @@ export default function AnalyticsPage() {
           href="/analytics/custom"
           className="col-start-3 row-start-1 flex items-center justify-center border rounded-lg bg-white/10 dark:bg-gray-900/20 backdrop-blur shadow-lg text-3xl font-bold"
         >
-          Custom Analytics
+          My Custom Analytics
         </Link>
         <Link
           href="/analytics/builder"

--- a/components/TitleUpdater.tsx
+++ b/components/TitleUpdater.tsx
@@ -7,7 +7,7 @@ const titleMap: Record<string, string> = {
   "/dashboard": "Dashboard",
   "/analytics": "Analytics",
   "/analytics/overview": "Analytics Overview",
-  "/analytics/custom": "Custom Analytics",
+  "/analytics/custom": "My Custom Analytics",
   "/analytics/builder": "Analytics Builder",
   "/tasks": "Tasks",
   "/tasks/archive": "Tasks Archive",


### PR DESCRIPTION
## Summary
- rename custom analytics page to "My Custom Analytics"
- update page title mapping

## Testing
- `npm test` *(fails: playwright: not found)*
- `npm run test:unit` *(fails: vitest: not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68c78a792518832c9288a72dbb7d381f