### PR TITLE
feat: round analytics builder containers

### DIFF
--- a/app/(app)/analytics/builder/page.tsx
+++ b/app/(app)/analytics/builder/page.tsx
@@ -58,7 +58,7 @@ export default function AnalyticsBuilderPage() {
         <div ref={exportRef} className="space-y-2">
           <div data-testid="viz-section">
             {state.viz === 'line' && (
-              <>
+              <div className="border rounded-lg bg-white/10 dark:bg-gray-900/20 backdrop-blur shadow-lg p-4 space-y-4">
                 <VizLine
                   data={lineData}
                   showIncome={showIncome}
@@ -71,7 +71,7 @@ export default function AnalyticsBuilderPage() {
                   showExpenses={showExpenses}
                   showNet={showNet}
                 />
-              </>
+              </div>
             )}
             {state.viz === 'pie' && <VizPie data={pieData} />}
             {state.viz === 'custom' && <CustomGraphBuilder onRun={() => {}} />}

--- a/app/(app)/analytics/components/VizSpreadsheet.tsx
+++ b/app/(app)/analytics/components/VizSpreadsheet.tsx
@@ -39,7 +39,7 @@ export default function VizSpreadsheet({ data, showIncome = true, showExpenses =
   const both = showIncome && showExpenses;
   const colClass = both ? 'w-1/2' : 'w-full';
   return (
-    <div className="overflow-x-auto mt-4" data-testid="viz-spreadsheet">
+    <div className="overflow-x-auto" data-testid="viz-spreadsheet">
       <table className="w-full text-sm">
         <thead>
           <tr>


### PR DESCRIPTION
## Summary
- wrap analytics builder graph and spreadsheet in a rounded container
- remove excess margin from analytics spreadsheet component

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c78bcbb424832c91a5d66245a135e4