### PR TITLE
feat: separate analytics builder containers

### DIFF
--- a/app/(app)/analytics/builder/page.tsx
+++ b/app/(app)/analytics/builder/page.tsx
@@ -58,20 +58,24 @@ export default function AnalyticsBuilderPage() {
         <div ref={exportRef} className="space-y-2">
           <div data-testid="viz-section">
             {state.viz === 'line' && (
-              <>
-                <VizLine
-                  data={lineData}
-                  showIncome={showIncome}
-                  showExpenses={showExpenses}
-                  showNet={showNet}
-                />
-                <VizSpreadsheet
-                  data={lineData}
-                  showIncome={showIncome}
-                  showExpenses={showExpenses}
-                  showNet={showNet}
-                />
-              </>
+              <div className="space-y-4">
+                <div className="border rounded-lg bg-white/10 dark:bg-gray-900/20 backdrop-blur shadow-lg p-4">
+                  <VizLine
+                    data={lineData}
+                    showIncome={showIncome}
+                    showExpenses={showExpenses}
+                    showNet={showNet}
+                  />
+                </div>
+                <div className="border rounded-lg bg-white/10 dark:bg-gray-900/20 backdrop-blur shadow-lg p-4">
+                  <VizSpreadsheet
+                    data={lineData}
+                    showIncome={showIncome}
+                    showExpenses={showExpenses}
+                    showNet={showNet}
+                  />
+                </div>
+              </div>
             )}
             {state.viz === 'pie' && <VizPie data={pieData} />}
             {state.viz === 'custom' && <CustomGraphBuilder onRun={() => {}} />}

--- a/app/(app)/analytics/components/VizSpreadsheet.tsx
+++ b/app/(app)/analytics/components/VizSpreadsheet.tsx
@@ -39,7 +39,7 @@ export default function VizSpreadsheet({ data, showIncome = true, showExpenses =
   const both = showIncome && showExpenses;
   const colClass = both ? 'w-1/2' : 'w-full';
   return (
-    <div className="overflow-x-auto mt-4" data-testid="viz-spreadsheet">
+    <div className="overflow-x-auto" data-testid="viz-spreadsheet">
       <table className="w-full text-sm">
         <thead>
           <tr>


### PR DESCRIPTION
## Summary
- separate analytics builder graph and spreadsheet into individual rounded containers

## Testing
- `npm test` *(fails: playwright not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@hello-pangea%2fdnd)*

------
https://chatgpt.com/codex/tasks/task_e_68c78bcbb424832c91a5d66245a135e4