### PR TITLE
Enable drag-and-drop reordering of analytics filter cards

### DIFF
--- a/app/(app)/analytics/components/SearchExpensesPanel.tsx
+++ b/app/(app)/analytics/components/SearchExpensesPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, type DragEvent } from 'react';
 import { EXPENSE_CATEGORIES } from '../../../../lib/categories';
 
 interface Props {
@@ -8,8 +8,41 @@ interface Props {
 export default function SearchExpensesPanel({ onAdd }: Props) {
   const [q, setQ] = useState('');
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  // track the order of expense groups and currently dragged index for manual reordering
+  const [order, setOrder] = useState<string[]>(Object.keys(EXPENSE_CATEGORIES));
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+
+  const handleDragStart = (
+    e: DragEvent<HTMLDivElement>,
+    value: string,
+    index?: number
+  ) => {
+    e.dataTransfer.setData(
+      'application/json',
+      JSON.stringify({ type: 'expenseTypes', value })
+    );
+    e.dataTransfer.effectAllowed = 'copy';
+    if (typeof index === 'number') setDragIndex(index);
+  };
+
+  const handleDragOver = (
+    e: DragEvent<HTMLDivElement>,
+    index: number
+  ) => {
+    e.preventDefault();
+    if (dragIndex === null || dragIndex === index) return;
+    setOrder(prev => {
+      const newOrder = Array.from(prev);
+      const [removed] = newOrder.splice(dragIndex, 1);
+      newOrder.splice(index, 0, removed);
+      return newOrder;
+    });
+    setDragIndex(index);
+  };
+
   const qLower = q.toLowerCase();
-  const entries = Object.entries(EXPENSE_CATEGORIES).filter(([group, items]) => {
+  const entries = order.filter(group => {
+    const items = EXPENSE_CATEGORIES[group as keyof typeof EXPENSE_CATEGORIES];
     const label = group.replace(/([A-Z])/g, ' $1').trim();
     return (
       label.toLowerCase().includes(qLower) ||
@@ -47,56 +80,63 @@ export default function SearchExpensesPanel({ onAdd }: Props) {
         className="w-full border rounded p-1 text-sm bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100"
       />
       <div className="space-y-1 max-h-40 overflow-y-auto">
-        {entries.map(([group, items]) => {
+        {entries.map((group, index) => {
+          const items = EXPENSE_CATEGORIES[group as keyof typeof EXPENSE_CATEGORIES];
           const label = group.replace(/([A-Z])/g, ' $1').trim();
           const showItems = expanded[group] || qLower.length > 0;
-          const filteredItems = items.filter(i =>
-            i.toLowerCase().includes(qLower)
-          );
+          const filteredItems = items.filter(i => i.toLowerCase().includes(qLower));
           return (
-            <div key={group} className="space-y-1">
-              <div
-                className="p-1 text-sm bg-gray-100 dark:bg-gray-700 rounded flex items-center justify-between text-gray-900 dark:text-gray-100"
-              >
-                <span>{label}</span>
-                <div className="flex items-center gap-1">
-                  <button
-                    aria-label={`${expanded[group] ? 'Collapse' : 'Expand'} ${label}`}
-                    onClick={() =>
-                      setExpanded(prev => ({
-                        ...prev,
-                        [group]: !prev[group],
-                      }))
-                    }
-                    className="text-xs"
-                  >
-                    {expanded[group] || qLower.length > 0 ? '▾' : '▸'}
-                  </button>
-                  <button
-                    aria-label={`Add ${label}`}
-                    onClick={() => onAdd(label)}
-                    className="text-xs"
-                  >
-                    +
-                  </button>
-                </div>
-              </div>
-              {showItems &&
-                filteredItems.map(item => (
-                  <div
-                    key={item}
-                    className="ml-4 p-1 text-sm bg-gray-100 dark:bg-gray-700 rounded text-gray-900 dark:text-gray-100"
-                  >
-                    <span>{item}</span>
+            <div
+              key={group}
+              draggable
+              onDragStart={e => handleDragStart(e, label, index)}
+              onDragOver={e => handleDragOver(e, index)}
+              onDragEnd={() => setDragIndex(null)}
+            >
+              <div className="space-y-1">
+                <div className="p-1 text-sm bg-gray-100 dark:bg-gray-700 rounded flex items-center justify-between text-gray-900 dark:text-gray-100">
+                  <span>{label}</span>
+                  <div className="flex items-center gap-1">
                     <button
-                      aria-label={`Add ${item}`}
-                      onClick={() => onAdd(item)}
+                      aria-label={`${expanded[group] ? 'Collapse' : 'Expand'} ${label}`}
+                      onClick={() =>
+                        setExpanded(prev => ({
+                          ...prev,
+                          [group]: !prev[group],
+                        }))
+                      }
+                      className="text-xs"
+                    >
+                      {expanded[group] || qLower.length > 0 ? '▾' : '▸'}
+                    </button>
+                    <button
+                      aria-label={`Add ${label}`}
+                      onClick={() => onAdd(label)}
                       className="text-xs"
                     >
                       +
                     </button>
                   </div>
-                ))}
+                </div>
+                {showItems &&
+                  filteredItems.map(item => (
+                    <div
+                      key={item}
+                      draggable
+                      onDragStart={e => handleDragStart(e, item)}
+                      className="ml-4 p-1 text-sm bg-gray-100 dark:bg-gray-700 rounded text-gray-900 dark:text-gray-100"
+                    >
+                      <span>{item}</span>
+                      <button
+                        aria-label={`Add ${item}`}
+                        onClick={() => onAdd(item)}
+                        className="text-xs"
+                      >
+                        +
+                      </button>
+                    </div>
+                  ))}
+              </div>
             </div>
           );
         })}

--- a/app/(app)/analytics/components/SearchIncomePanel.tsx
+++ b/app/(app)/analytics/components/SearchIncomePanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, type DragEvent } from 'react';
 import { INCOME_CATEGORIES } from '../../../../lib/categories';
 
 interface Props {
@@ -8,8 +8,41 @@ interface Props {
 export default function SearchIncomePanel({ onAdd }: Props) {
   const [q, setQ] = useState('');
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  // keep track of category order and currently dragged index for manual reordering
+  const [order, setOrder] = useState<string[]>(Object.keys(INCOME_CATEGORIES));
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+
+  const handleDragStart = (
+    e: DragEvent<HTMLDivElement>,
+    value: string,
+    index?: number
+  ) => {
+    e.dataTransfer.setData(
+      'application/json',
+      JSON.stringify({ type: 'incomeTypes', value })
+    );
+    e.dataTransfer.effectAllowed = 'copy';
+    if (typeof index === 'number') setDragIndex(index);
+  };
+
+  const handleDragOver = (
+    e: DragEvent<HTMLDivElement>,
+    index: number
+  ) => {
+    e.preventDefault();
+    if (dragIndex === null || dragIndex === index) return;
+    setOrder(prev => {
+      const newOrder = Array.from(prev);
+      const [removed] = newOrder.splice(dragIndex, 1);
+      newOrder.splice(index, 0, removed);
+      return newOrder;
+    });
+    setDragIndex(index);
+  };
+
   const qLower = q.toLowerCase();
-  const entries = Object.entries(INCOME_CATEGORIES).filter(([group, items]) => {
+  const entries = order.filter(group => {
+    const items = INCOME_CATEGORIES[group as keyof typeof INCOME_CATEGORIES];
     const label = group.replace(/([A-Z])/g, ' $1').trim();
     return (
       label.toLowerCase().includes(qLower) ||
@@ -47,56 +80,63 @@ export default function SearchIncomePanel({ onAdd }: Props) {
         className="w-full border rounded p-1 text-sm bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100"
       />
       <div className="space-y-1 max-h-40 overflow-y-auto">
-        {entries.map(([group, items]) => {
+        {entries.map((group, index) => {
+          const items = INCOME_CATEGORIES[group as keyof typeof INCOME_CATEGORIES];
           const label = group.replace(/([A-Z])/g, ' $1').trim();
           const showItems = expanded[group] || qLower.length > 0;
-          const filteredItems = items.filter(i =>
-            i.toLowerCase().includes(qLower)
-          );
+          const filteredItems = items.filter(i => i.toLowerCase().includes(qLower));
           return (
-            <div key={group} className="space-y-1">
-              <div
-                className="p-1 text-sm bg-gray-100 dark:bg-gray-700 rounded flex items-center justify-between text-gray-900 dark:text-gray-100"
-              >
-                <span>{label}</span>
-                <div className="flex items-center gap-1">
-                  <button
-                    aria-label={`${expanded[group] ? 'Collapse' : 'Expand'} ${label}`}
-                    onClick={() =>
-                      setExpanded(prev => ({
-                        ...prev,
-                        [group]: !prev[group],
-                      }))
-                    }
-                    className="text-xs"
-                  >
-                    {expanded[group] || qLower.length > 0 ? '▾' : '▸'}
-                  </button>
-                  <button
-                    aria-label={`Add ${label}`}
-                    onClick={() => onAdd(label)}
-                    className="text-xs"
-                  >
-                    +
-                  </button>
-                </div>
-              </div>
-              {showItems &&
-                filteredItems.map(item => (
-                  <div
-                    key={item}
-                    className="ml-4 p-1 text-sm bg-gray-100 dark:bg-gray-700 rounded flex items-center justify-between text-gray-900 dark:text-gray-100"
-                  >
-                    <span>{item}</span>
+            <div
+              key={group}
+              draggable
+              onDragStart={e => handleDragStart(e, label, index)}
+              onDragOver={e => handleDragOver(e, index)}
+              onDragEnd={() => setDragIndex(null)}
+            >
+              <div className="space-y-1">
+                <div className="p-1 text-sm bg-gray-100 dark:bg-gray-700 rounded flex items-center justify-between text-gray-900 dark:text-gray-100">
+                  <span>{label}</span>
+                  <div className="flex items-center gap-1">
                     <button
-                      aria-label={`Add ${item}`}
-                      onClick={() => onAdd(item)}
+                      aria-label={`${expanded[group] ? 'Collapse' : 'Expand'} ${label}`}
+                      onClick={() =>
+                        setExpanded(prev => ({
+                          ...prev,
+                          [group]: !prev[group],
+                        }))
+                      }
+                      className="text-xs"
+                    >
+                      {expanded[group] || qLower.length > 0 ? '▾' : '▸'}
+                    </button>
+                    <button
+                      aria-label={`Add ${label}`}
+                      onClick={() => onAdd(label)}
                       className="text-xs"
                     >
                       +
                     </button>
                   </div>
-                ))}
+                </div>
+                {showItems &&
+                  filteredItems.map(item => (
+                    <div
+                      key={item}
+                      draggable
+                      onDragStart={e => handleDragStart(e, item)}
+                      className="ml-4 p-1 text-sm bg-gray-100 dark:bg-gray-700 rounded flex items-center justify-between text-gray-900 dark:text-gray-100"
+                    >
+                      <span>{item}</span>
+                      <button
+                        aria-label={`Add ${item}`}
+                        onClick={() => onAdd(item)}
+                        className="text-xs"
+                      >
+                        +
+                      </button>
+                    </div>
+                  ))}
+              </div>
             </div>
           );
         })}


### PR DESCRIPTION
## Summary
- add @hello-pangea/dnd to income and expense filter panels
- allow dragging categories and drilled items into the applied filters section
- allow dragging to reorder filter cards while keeping existing add/expand behavior
- fix dragging of top-level income and expense categories by switching to native drag events with manual reordering

## Testing
- `npm test` *(fails: playwright not found)*
- `npm run test:unit` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68c784cbd680832cb31f122fb3cfa414