### PR TITLE
feat: add mock dashboard page

### DIFF
--- a/app/dashboard-lite/page.tsx
+++ b/app/dashboard-lite/page.tsx
@@ -1,0 +1,5 @@
+import DashboardPage from '../../components/dashboard/DashboardPage';
+
+export default function Page() {
+  return <DashboardPage />;
+}

--- a/components/dashboard/CashflowLineChart.tsx
+++ b/components/dashboard/CashflowLineChart.tsx
@@ -1,0 +1,26 @@
+import { ResponsiveContainer, LineChart, Line, Tooltip, Legend, XAxis, YAxis, CartesianGrid } from 'recharts';
+import type { TimeSeriesPoint } from '../../types/dashboard';
+import { formatDate, formatMoney } from '../../lib/format';
+
+interface Props {
+  data: TimeSeriesPoint[];
+}
+
+export default function CashflowLineChart({ data }: Props) {
+  return (
+    <div className="p-4 rounded-2xl shadow bg-white">
+      <ResponsiveContainer width="100%" height={300}>
+        <LineChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="date" tickFormatter={(d) => formatDate(d)} />
+          <YAxis tickFormatter={(v) => formatMoney(v)} />
+          <Tooltip formatter={(v: number) => formatMoney(v)} labelFormatter={(l) => formatDate(l)} />
+          <Legend />
+          <Line type="monotone" dataKey="cashInCents" name="Cash In" stroke="#22c55e" />
+          <Line type="monotone" dataKey="cashOutCents" name="Cash Out" stroke="#ef4444" />
+          <Line type="monotone" dataKey="netCents" name="Net" stroke="#3b82f6" />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/components/dashboard/DashboardPage.tsx
+++ b/components/dashboard/DashboardPage.tsx
@@ -1,0 +1,48 @@
+'use client';
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { startOfMonth, formatISO } from 'date-fns';
+import MetricCard from './MetricCard';
+import CashflowLineChart from './CashflowLineChart';
+import PieCard from './PieCard';
+import PropertyCard from './PropertyCard';
+import { getDashboard } from '../../lib/dashboard';
+import { formatMoney } from '../../lib/format';
+import Header from './Header';
+
+export default function DashboardPage() {
+  const [from] = useState(() => startOfMonth(new Date()));
+  const [to] = useState(() => new Date());
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['dashboard', from, to],
+    queryFn: () => getDashboard(formatISO(from, { representation: 'date' }), formatISO(to, { representation: 'date' })),
+  });
+
+  if (isLoading) return <div className="p-6">Loading...</div>;
+  if (error || !data) return <div className="p-6">Failed to load dashboard</div>;
+
+  return (
+    <div className="p-6 space-y-6">
+      <Header from={from} to={to} />
+      <div className="grid gap-6 lg:grid-cols-12">
+        <div className="lg:col-span-8 space-y-6">
+          <div className="grid gap-4 md:grid-cols-2">
+            <MetricCard title="YTD Cashflow" value={formatMoney(data.cashflow.ytdNet.amountCents)} hint="Year to Date" />
+            <MetricCard title="MTD Cashflow" value={formatMoney(data.cashflow.mtdNet.amountCents)} hint="Month to Date" />
+          </div>
+          <CashflowLineChart data={data.lineSeries.points} />
+          <div className="grid gap-4 md:grid-cols-2">
+            <PieCard title="Income by Property" data={data.incomeByProperty} labelKey="propertyName" valueKey="incomeCents" />
+            <PieCard title="Expenses by Category" data={data.expensesByCategory} labelKey="category" valueKey="amountCents" />
+          </div>
+        </div>
+        <div className="lg:col-span-4 space-y-4">
+          {data.properties.map((p) => (
+            <PropertyCard key={p.propertyId} data={p} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/Header.tsx
+++ b/components/dashboard/Header.tsx
@@ -1,0 +1,17 @@
+import { format } from 'date-fns';
+
+interface Props {
+  from: Date;
+  to: Date;
+}
+
+export default function Header({ from, to }: Props) {
+  return (
+    <div className="flex flex-col md:flex-row md:items-center md:justify-between p-4">
+      <h1 className="text-2xl font-bold">Dashboard</h1>
+      <div className="text-sm text-gray-500 mt-2 md:mt-0">
+        {format(from, 'dd MMM yyyy')} – {format(to, 'dd MMM yyyy')}
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/MetricCard.tsx
+++ b/components/dashboard/MetricCard.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+
+interface MetricCardProps {
+  title: string;
+  value: ReactNode;
+  hint?: string;
+}
+
+export default function MetricCard({ title, value, hint }: MetricCardProps) {
+  return (
+    <div className="p-4 rounded-2xl shadow bg-white">
+      <div className="text-sm text-gray-500">{title}</div>
+      <div className="mt-2 text-2xl font-bold">{value}</div>
+      {hint && <div className="text-xs text-gray-400">{hint}</div>}
+    </div>
+  );
+}

--- a/components/dashboard/PieCard.tsx
+++ b/components/dashboard/PieCard.tsx
@@ -1,0 +1,30 @@
+import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip, Legend } from 'recharts';
+import { formatMoney } from '../../lib/format';
+
+interface PieCardProps<T> {
+  title: string;
+  data: T[];
+  labelKey: keyof T;
+  valueKey: keyof T;
+}
+
+const COLORS = ['#3b82f6', '#10b981', '#f97316', '#e11d48', '#8b5cf6', '#14b8a6'];
+
+export default function PieCard<T extends Record<string, any>>({ title, data, labelKey, valueKey }: PieCardProps<T>) {
+  return (
+    <div className="p-4 rounded-2xl shadow bg-white">
+      <div className="mb-4 text-sm text-gray-500">{title}</div>
+      <ResponsiveContainer width="100%" height={300}>
+        <PieChart>
+          <Pie data={data} dataKey={valueKey as string} nameKey={labelKey as string} label>
+            {data.map((_, idx) => (
+              <Cell key={idx} fill={COLORS[idx % COLORS.length]} />
+            ))}
+          </Pie>
+          <Tooltip formatter={(v: number) => formatMoney(v)} />
+          <Legend />
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/components/dashboard/PropertyCard.tsx
+++ b/components/dashboard/PropertyCard.tsx
@@ -1,0 +1,49 @@
+import { formatMoney, formatDate, statusToBadgeColor } from '../../lib/format';
+import type { PropertyCardData } from '../../types/dashboard';
+
+interface Props {
+  data: PropertyCardData;
+}
+
+export default function PropertyCard({ data }: Props) {
+  return (
+    <div className="p-4 rounded-2xl shadow bg-white space-y-4">
+      <div className="flex justify-between items-center">
+        <h3 className="font-semibold">{data.name}</h3>
+      </div>
+      <div className="p-3 rounded-lg bg-gray-50">
+        <div className="flex justify-between items-center">
+          <div>
+            <div className="text-sm text-gray-500">Next Rent Due</div>
+            <div className="text-lg font-bold">{formatMoney(data.rentDue.amountCents)}</div>
+            <div className="text-xs text-gray-500">{formatDate(data.rentDue.nextDueDate)}</div>
+          </div>
+          <span className={`px-2 py-1 text-xs rounded ${statusToBadgeColor(data.rentDue.status)}`}>
+            {data.rentDue.status}
+          </span>
+        </div>
+      </div>
+      <div>
+        <div className="text-sm font-semibold mb-1">Key Dates/Alerts</div>
+        <ul className="space-y-1">
+          {data.alerts.slice(0, 3).map((a) => (
+            <li key={a.id} className="text-sm">
+              <span className={`inline-block w-2 h-2 rounded-full mr-2 ${statusToBadgeColor(a.severity)}`}></span>
+              {a.label}
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div>
+        <div className="text-sm font-semibold mb-1">Current Tasks</div>
+        <ul className="space-y-1">
+          {data.tasks.slice(0, 3).map((t) => (
+            <li key={t.id} className="text-sm">
+              {t.title}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/lib/dashboard.ts
+++ b/lib/dashboard.ts
@@ -1,0 +1,10 @@
+import type { DashboardDTO } from '../types/dashboard';
+
+// TODO: replace with real API call
+export async function getDashboard(from: string, to: string): Promise<DashboardDTO> {
+  const res = await fetch('/mock/mockDashboard.json');
+  if (!res.ok) {
+    throw new Error('Failed to load dashboard');
+  }
+  return (await res.json()) as DashboardDTO;
+}

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -3,3 +3,23 @@ export const formatCurrency = (n: number) =>
 
 export const formatDate = (d: string | Date) =>
   new Intl.DateTimeFormat('en-AU').format(new Date(d));
+
+export const formatMoney = (cents: number) => formatCurrency(cents / 100);
+
+export const statusToBadgeColor = (status: string) => {
+  switch (status) {
+    case 'Overdue':
+    case 'high':
+      return 'bg-red-100 text-red-800';
+    case 'Due':
+    case 'med':
+      return 'bg-orange-100 text-orange-800';
+    case 'Upcoming':
+    case 'low':
+      return 'bg-yellow-100 text-yellow-800';
+    case 'Paid':
+      return 'bg-green-100 text-green-800';
+    default:
+      return 'bg-gray-100 text-gray-800';
+  }
+};

--- a/public/mock/mockDashboard.json
+++ b/public/mock/mockDashboard.json
@@ -1,0 +1,33 @@
+{
+  "portfolio": { "propertiesCount": 3, "occupiedCount": 3, "vacancyCount": 0 },
+  "cashflow": { "ytdNet": { "amountCents": 1823400, "currency": "AUD" }, "mtdNet": { "amountCents": 154200, "currency": "AUD" } },
+  "lineSeries": {
+    "points": [
+      { "date": "2025-09-01", "cashInCents": 420000, "cashOutCents": 120000, "netCents": 300000 },
+      { "date": "2025-09-02", "cashInCents": 0, "cashOutCents": 15000, "netCents": -15000 }
+    ]
+  },
+  "incomeByProperty": [
+    { "propertyId": "p1", "propertyName": "12 Smith St", "incomeCents": 280000 },
+    { "propertyId": "p2", "propertyName": "8 Brown Ave", "incomeCents": 270000 },
+    { "propertyId": "p3", "propertyName": "3/61 Park Rd", "incomeCents": 250000 }
+  ],
+  "expensesByCategory": [
+    { "category": "Maintenance", "amountCents": 42000 },
+    { "category": "Insurance", "amountCents": 18000 },
+    { "category": "Rates", "amountCents": 36000 }
+  ],
+  "properties": [
+    {
+      "propertyId": "p1",
+      "name": "12 Smith St, Chatswood NSW",
+      "rentDue": { "nextDueDate": "2025-09-15", "amountCents": 70000, "status": "Upcoming" },
+      "alerts": [
+        { "id": "a1", "label": "Smoke alarm check due", "date": "2025-09-20", "severity": "med" }
+      ],
+      "tasks": [
+        { "id": "t1", "title": "Approve plumber quote", "status": "in_progress", "dueDate": "2025-09-16", "priority": "high" }
+      ]
+    }
+  ]
+}

--- a/types/dashboard.ts
+++ b/types/dashboard.ts
@@ -1,0 +1,85 @@
+export type Currency = number; // store cents as number; format on render
+
+export interface Money {
+  amountCents: number;
+  currency: 'AUD';
+}
+
+export interface PortfolioSummary {
+  propertiesCount: number;
+  occupiedCount: number;
+  vacancyCount: number;
+}
+
+export interface CashflowSnapshot {
+  ytdNet: Money;
+  mtdNet: Money;
+}
+
+export interface TimeSeriesPoint {
+  date: string;           // ISO date
+  cashInCents: number;    // inflow
+  cashOutCents: number;   // outflow
+  netCents: number;       // inflow - outflow
+}
+
+export interface ChartSeries {
+  points: TimeSeriesPoint[];
+}
+
+export interface IncomeByPropertySlice {
+  propertyId: string;
+  propertyName: string;
+  incomeCents: number; // over selected range
+}
+
+export interface ExpenseByCategorySlice {
+  category:
+    | 'Maintenance'
+    | 'Utilities'
+    | 'Insurance'
+    | 'Rates'
+    | 'Strata'
+    | 'Mortgage Interest'
+    | 'Property Mgmt'
+    | 'Other';
+  amountCents: number;
+}
+
+export interface RentDue {
+  nextDueDate: string;       // ISO
+  amountCents: number;
+  status: 'Due' | 'Paid' | 'Overdue' | 'Upcoming';
+}
+
+export interface AlertItem {
+  id: string;
+  label: string;             // e.g., “Smoke alarm due”, “Lease expires in 30d”
+  date?: string;             // if relevant
+  severity: 'low' | 'med' | 'high';
+}
+
+export interface TaskItem {
+  id: string;
+  title: string;
+  status: 'todo' | 'in_progress' | 'blocked' | 'done';
+  dueDate?: string;
+  priority?: 'low' | 'med' | 'high';
+}
+
+export interface PropertyCardData {
+  propertyId: string;
+  name: string;              // e.g., “12 Smith St, Chatswood”
+  rentDue: RentDue;
+  alerts: AlertItem[];
+  tasks: TaskItem[];
+}
+
+export interface DashboardDTO {
+  portfolio: PortfolioSummary;
+  cashflow: CashflowSnapshot;
+  lineSeries: ChartSeries;
+  incomeByProperty: IncomeByPropertySlice[];
+  expensesByCategory: ExpenseByCategorySlice[];
+  properties: PropertyCardData[]; // 1..N
+}


### PR DESCRIPTION
## Summary
- add dashboard DTO types and mock data
- provide format helpers and dashboard fetcher
- scaffold dashboard page with metrics, charts and property cards

## Testing
- `npm run test:unit` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@hello-pangea%2fdnd)*

------
https://chatgpt.com/codex/tasks/task_e_68c7913fe020832cbe4e5f5edc183e9b