### PR TITLE
Fix dashboard components for dark mode

### DIFF
--- a/components/dashboard/CashflowLineChart.tsx
+++ b/components/dashboard/CashflowLineChart.tsx
@@ -8,12 +8,12 @@ interface Props {
 
 export default function CashflowLineChart({ data }: Props) {
   return (
-    <div className="p-4 rounded-2xl shadow bg-white">
+    <div className="p-4 rounded-2xl card">
       <ResponsiveContainer width="100%" height={300}>
         <LineChart data={data}>
-          <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="date" tickFormatter={(d) => formatDate(d)} />
-          <YAxis tickFormatter={(v) => formatMoney(v)} />
+          <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+          <XAxis dataKey="date" tickFormatter={(d) => formatDate(d)} tick={{ fill: 'var(--text-secondary)' }} />
+          <YAxis tickFormatter={(v) => formatMoney(v)} tick={{ fill: 'var(--text-secondary)' }} />
           <Tooltip formatter={(v: number) => formatMoney(v)} labelFormatter={(l) => formatDate(l)} />
           <Legend />
           <Line type="monotone" dataKey="cashInCents" name="Cash In" stroke="#22c55e" />

--- a/components/dashboard/Header.tsx
+++ b/components/dashboard/Header.tsx
@@ -9,7 +9,7 @@ export default function Header({ from, to }: Props) {
   return (
     <div className="flex flex-col md:flex-row md:items-center md:justify-between p-4">
       <h1 className="text-2xl font-bold">Dashboard</h1>
-      <div className="text-sm text-gray-500 mt-2 md:mt-0">
+      <div className="text-sm text-text-secondary mt-2 md:mt-0">
         {formatDate(from)} – {formatDate(to)}
       </div>
     </div>

--- a/components/dashboard/MetricCard.tsx
+++ b/components/dashboard/MetricCard.tsx
@@ -8,10 +8,10 @@ interface MetricCardProps {
 
 export default function MetricCard({ title, value, hint }: MetricCardProps) {
   return (
-    <div className="p-4 rounded-2xl shadow bg-white">
-      <div className="text-sm text-gray-500">{title}</div>
-      <div className="mt-2 text-2xl font-bold">{value}</div>
-      {hint && <div className="text-xs text-gray-400">{hint}</div>}
+    <div className="p-4 rounded-2xl card">
+      <div className="text-sm text-text-secondary">{title}</div>
+      <div className="mt-2 text-2xl font-bold text-text-primary">{value}</div>
+      {hint && <div className="text-xs text-text-muted">{hint}</div>}
     </div>
   );
 }

--- a/components/dashboard/PieCard.tsx
+++ b/components/dashboard/PieCard.tsx
@@ -12,8 +12,8 @@ const COLORS = ['#3b82f6', '#10b981', '#f97316', '#e11d48', '#8b5cf6', '#14b8a6'
 
 export default function PieCard<T extends Record<string, any>>({ title, data, labelKey, valueKey }: PieCardProps<T>) {
   return (
-    <div className="p-4 rounded-2xl shadow bg-white">
-      <div className="mb-4 text-sm text-gray-500">{title}</div>
+    <div className="p-4 rounded-2xl card">
+      <div className="mb-4 text-sm text-text-secondary">{title}</div>
       <ResponsiveContainer width="100%" height={300}>
         <PieChart>
           <Pie data={data} dataKey={valueKey as string} nameKey={labelKey as string} label>

--- a/components/dashboard/PropertyCard.tsx
+++ b/components/dashboard/PropertyCard.tsx
@@ -7,16 +7,16 @@ interface Props {
 
 export default function PropertyCard({ data }: Props) {
   return (
-    <div className="p-4 rounded-2xl shadow bg-white space-y-4">
+    <div className="p-4 rounded-2xl card space-y-4">
       <div className="flex justify-between items-center">
         <h3 className="font-semibold">{data.name}</h3>
       </div>
-      <div className="p-3 rounded-lg bg-gray-50">
+      <div className="p-3 rounded-lg bg-bg-elevated">
         <div className="flex justify-between items-center">
           <div>
-            <div className="text-sm text-gray-500">Next Rent Due</div>
-            <div className="text-lg font-bold">{formatMoney(data.rentDue.amountCents)}</div>
-            <div className="text-xs text-gray-500">{formatDate(data.rentDue.nextDueDate)}</div>
+            <div className="text-sm text-text-secondary">Next Rent Due</div>
+            <div className="text-lg font-bold text-text-primary">{formatMoney(data.rentDue.amountCents)}</div>
+            <div className="text-xs text-text-muted">{formatDate(data.rentDue.nextDueDate)}</div>
           </div>
           <span className={`px-2 py-1 text-xs rounded ${statusToBadgeColor(data.rentDue.status)}`}>
             {data.rentDue.status}


### PR DESCRIPTION
## Summary
- update dashboard cards to use theme-aware colors
- adjust chart axes and header text for dark mode

## Testing
- `npm run test:unit` *(fails: vitest not found)*
- `npm test` *(fails: playwright not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e7286588832c9e91ccd732ab0526