### PR TITLE
Add actions menu for saved analytics with delete confirmation

### DIFF
--- a/app/(app)/analytics/custom/page.tsx
+++ b/app/(app)/analytics/custom/page.tsx
@@ -1,14 +1,38 @@
 'use client';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
-import { loadProjects } from '../../../../lib/savedAnalytics';
+import { useRouter } from 'next/navigation';
+import { loadProjects, deleteProject } from '../../../../lib/savedAnalytics';
+import ConfirmDeleteModal from '../../../../components/ConfirmDeleteModal';
 
 export default function CustomAnalytics() {
   const [projects, setProjects] = useState([] as ReturnType<typeof loadProjects>);
+  const [menuOpen, setMenuOpen] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState<string | null>(null);
+  const router = useRouter();
 
   useEffect(() => {
     setProjects(loadProjects());
   }, []);
+
+  const handleShare = (id: string) => {
+    const url = `${window.location.origin}/analytics/builder?saved=${id}`;
+    if (navigator.share) {
+      navigator.share({ url }).catch(() => {});
+    } else if (navigator.clipboard) {
+      navigator.clipboard.writeText(url);
+      alert('Link copied to clipboard');
+    }
+  };
+
+  const handleExport = (id: string) => {
+    router.push(`/analytics/builder?saved=${id}`);
+  };
+
+  const handleDelete = (id: string) => {
+    deleteProject(id);
+    setProjects(loadProjects());
+  };
 
   return (
     <div className="p-6">
@@ -21,19 +45,76 @@ export default function CustomAnalytics() {
       ) : (
         <ul className="space-y-2">
           {projects.map(p => (
-            <li key={p.id}>
+            <li key={p.id} className="relative">
               <Link
                 href={`/analytics/builder?saved=${p.id}`}
-                className="block p-4 border rounded-lg bg-white/10 dark:bg-gray-900/20 backdrop-blur hover:bg-white/20"
+                className="block p-4 pr-8 border rounded-lg bg-white/10 dark:bg-gray-900/20 backdrop-blur hover:bg-white/20"
               >
                 <div className="font-medium">{p.name}</div>
                 <div className="text-xs text-gray-500">
                   Created {new Date(p.createdAt).toLocaleString()}
                 </div>
               </Link>
+              <button
+                className="absolute top-2 right-2 p-1 rounded hover:bg-white/20"
+                onClick={() => setMenuOpen(menuOpen === p.id ? null : p.id)}
+              >
+                <svg
+                  className="w-5 h-5"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <circle cx="12" cy="5" r="1" />
+                  <circle cx="12" cy="12" r="1" />
+                  <circle cx="12" cy="19" r="1" />
+                </svg>
+                <span className="sr-only">Options</span>
+              </button>
+              {menuOpen === p.id && (
+                <div className="absolute right-2 z-10 mt-2 w-40 rounded border bg-white shadow-lg dark:bg-gray-800">
+                  <button
+                    onClick={() => {
+                      setMenuOpen(null);
+                      handleExport(p.id);
+                    }}
+                    className="block w-full px-3 py-2 text-left hover:bg-gray-100 dark:hover:bg-gray-700"
+                  >
+                    Export
+                  </button>
+                  <button
+                    onClick={() => {
+                      setMenuOpen(null);
+                      handleShare(p.id);
+                    }}
+                    className="block w-full px-3 py-2 text-left hover:bg-gray-100 dark:hover:bg-gray-700"
+                  >
+                    Share
+                  </button>
+                  <button
+                    onClick={() => {
+                      setMenuOpen(null);
+                      setDeleting(p.id);
+                    }}
+                    className="block w-full px-3 py-2 text-left text-red-600 hover:bg-gray-100 dark:text-red-400 dark:hover:bg-gray-700"
+                  >
+                    Delete
+                  </button>
+                </div>
+              )}
             </li>
           ))}
         </ul>
+      )}
+      {deleting && (
+        <ConfirmDeleteModal
+          onClose={() => setDeleting(null)}
+          onConfirm={() => handleDelete(deleting)}
+        />
       )}
     </div>
   );

--- a/components/ConfirmDeleteModal.tsx
+++ b/components/ConfirmDeleteModal.tsx
@@ -1,0 +1,59 @@
+"use client";
+import { useState, useEffect } from "react";
+
+export default function ConfirmDeleteModal({
+  onClose,
+  onConfirm,
+  word = "delete",
+}: {
+  onClose: () => void;
+  onConfirm: () => void;
+  word?: string;
+}) {
+  const [value, setValue] = useState("");
+
+  useEffect(() => {
+    setValue("");
+  }, [word]);
+
+  const canDelete = value === word;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
+      <div className="w-80 space-y-2 rounded bg-white p-4 dark:bg-gray-800 dark:text-white">
+        <h2 className="text-lg font-medium">Delete</h2>
+        <p className="text-sm dark:text-gray-300">
+          Type "{word}" to confirm deleting this item.
+        </p>
+        <input
+          className="w-full rounded border p-1 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+        />
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            className="px-2 py-1 bg-gray-100 dark:bg-gray-600 dark:text-white"
+            onClick={onClose}
+          >
+            Cancel
+          </button>
+          <button
+            disabled={!canDelete}
+            className={`px-2 py-1 text-white ${
+              canDelete
+                ? "bg-red-500 hover:bg-red-600 dark:bg-red-600 dark:hover:bg-red-700"
+                : "bg-red-300 dark:bg-red-300"
+            }`}
+            onClick={() => {
+              if (!canDelete) return;
+              onConfirm();
+              onClose();
+            }}
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/savedAnalytics.ts
+++ b/lib/savedAnalytics.ts
@@ -37,3 +37,10 @@ export function saveProject(name: string, state: AnalyticsStateType): SavedProje
 export function getProject(id: string): SavedProject | undefined {
   return loadProjects().find(p => p.id === id);
 }
+
+export function deleteProject(id: string) {
+  const projects = loadProjects().filter(p => p.id !== id);
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(KEY, JSON.stringify(projects));
+  }
+}


### PR DESCRIPTION
## Summary
- add deleteProject helper for saved analytics
- provide actions menu for each saved analytic with export/share/delete
- require typing 'delete' to confirm removal

## Testing
- `npm test` *(fails: playwright not found)*
- `npm run test:unit` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e85149e4832c881ed88ddd8f9894