### PR TITLE
Increase popup card border radius

### DIFF
--- a/app/(app)/analytics/components/VizSpreadsheet.tsx
+++ b/app/(app)/analytics/components/VizSpreadsheet.tsx
@@ -125,7 +125,7 @@ export default function VizSpreadsheet({ data, showIncome = true, showExpenses =
           onClick={() => setSelected(null)}
         >
           <div
-            className="bg-white dark:bg-gray-900 p-4 rounded shadow max-h-[80vh] overflow-auto"
+            className="bg-white dark:bg-gray-900 p-4 rounded-xl shadow max-h-[80vh] overflow-auto"
             onClick={(e) => e.stopPropagation()}
           >
             <h2 className="text-lg mb-2">{formatLabel(selected.label)} Details</h2>


### PR DESCRIPTION
## Summary
- use a larger border radius for the details popup

## Testing
- `npm test` *(fails: playwright: not found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e8f56fdc832c81620af2b6905ee2