### PR TITLE
Increase popup card border radius

### DIFF
--- a/app/(app)/analytics/builder/page.tsx
+++ b/app/(app)/analytics/builder/page.tsx
@@ -124,12 +124,26 @@ export default function AnalyticsBuilderPage() {
               Date range: {new Date(state.from).toLocaleDateString()} - {new Date(state.to).toLocaleDateString()}
             </div>
             {filtersApplied && (
-              <div>
-                Filters:{' '}
+              <div className="flex flex-wrap items-center gap-2">
+                <span>Filters:</span>
                 {Object.entries(state.filters)
                   .filter(([, arr]) => (arr || []).length > 0)
-                  .map(([key, arr]) => `${key}: ${(arr || []).join(', ')}`)
-                  .join('; ')}
+                  .map(([key, arr]) =>
+                    (arr || []).map(value => (
+                      <span
+                        key={`${key}-${value}`}
+                        className={`px-2 py-0.5 rounded-full text-sm cursor-default ${
+                          key === 'incomeTypes'
+                            ? 'bg-green-100 text-green-800 hover:bg-green-200 dark:bg-green-800 dark:text-green-100 dark:hover:bg-green-700'
+                            : key === 'expenseTypes'
+                              ? 'bg-red-100 text-red-800 hover:bg-red-200 dark:bg-red-800 dark:text-red-100 dark:hover:bg-red-700'
+                              : 'bg-gray-100 text-gray-800 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700'
+                        }`}
+                      >
+                        {value}
+                      </span>
+                    ))
+                  )}
               </div>
             )}
           </div>

--- a/app/(app)/analytics/components/VizSpreadsheet.tsx
+++ b/app/(app)/analytics/components/VizSpreadsheet.tsx
@@ -125,7 +125,7 @@ export default function VizSpreadsheet({ data, showIncome = true, showExpenses =
           onClick={() => setSelected(null)}
         >
           <div
-            className="bg-white dark:bg-gray-900 p-4 rounded shadow max-h-[80vh] overflow-auto"
+            className="bg-white dark:bg-gray-900 p-4 rounded-xl shadow max-h-[80vh] overflow-auto"
             onClick={(e) => e.stopPropagation()}
           >
             <h2 className="text-lg mb-2">{formatLabel(selected.label)} Details</h2>


### PR DESCRIPTION
## Summary
- use a larger border radius for the details popup
- display applied filters as read-only tags with income in green and expenses in red

## Testing
- `npm test` *(fails: playwright: not found)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e8f56fdc832c81620af2b6905ee2