### PR TITLE
Expand dashboard date range to two months

### DIFF
--- a/components/dashboard/DashboardPage.tsx
+++ b/components/dashboard/DashboardPage.tsx
@@ -9,11 +9,12 @@ import { getDashboard } from '../../lib/dashboard';
 import { formatMoney } from '../../lib/format';
 import Header from './Header';
 
-const startOfMonth = (d: Date) => new Date(d.getFullYear(), d.getMonth(), 1);
+// Use the first day of the previous month to show a two-month window ending today.
+const startOfPreviousMonth = (d: Date) => new Date(d.getFullYear(), d.getMonth() - 1, 1);
 const formatISODate = (d: Date) => d.toISOString().split('T')[0];
 
 export default function DashboardPage() {
-  const [from] = useState(() => startOfMonth(new Date()));
+  const [from] = useState(() => startOfPreviousMonth(new Date()));
   const [to] = useState(() => new Date());
 
   const { data, isLoading, error } = useQuery({


### PR DESCRIPTION
## Summary
- update the dashboard query range to begin on the first day of the previous month so the view covers two months to date
- document the new range calculation for easier maintenance

## Testing
- npm run test:unit *(fails: local vitest binary is unavailable in this environment)*
- npm run lint *(fails: repository still uses .eslintrc and ESLint 9 requires eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c936b0ba4c832c83cafc5afb46c731