### PR TITLE
Ensure dashboard uses listTasks for property tasks

### DIFF
--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -13,7 +13,7 @@ import {
   incomes,
   rentLedger,
   reminders,
-  tasks,
+  listTasks,
   isActiveProperty,
   seedIfEmpty,
 } from '../store';
@@ -180,11 +180,8 @@ export async function GET(req: Request) {
         severity: r.severity,
       }));
 
-    const taskItems = tasks
-      .filter(
-        (t) =>
-          t.properties.some((pr) => pr.id === p.id) && t.status !== 'done'
-      )
+    const taskItems = listTasks({ propertyId: p.id })
+      .filter((t) => t.status !== 'done')
       .map((t) => ({
         id: t.id,
         title: t.title,


### PR DESCRIPTION
## Summary
- use the shared listTasks helper when constructing dashboard property card task lists so the dashboard shows the same task data as the task endpoints

## Testing
- npm run test:unit *(fails: vitest not installed because dependencies cannot be downloaded in this environment)*


------
https://chatgpt.com/codex/tasks/task_e_68c937971e10832c9f57ee3f4553061b