### PR TITLE
Remove duplicate GET handler stub

### DIFF
--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -73,7 +73,6 @@ const listDashboardTasks = (propertyId: string) =>
 export async function GET(req: Request) {
   seedIfEmpty();
 
-export async function GET(req: Request) {
   const url = new URL(req.url);
   const from = url.searchParams.get('from') ?? '1970-01-01';
   const to = url.searchParams.get('to') ?? new Date().toISOString().split('T')[0];


### PR DESCRIPTION
## Summary
- remove the stray GET handler stub from the dashboard route
- ensure the remaining handler seeds the mock store before generating the response

## Testing
- npm run dev *(fails: next binary not available because dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca268024a8832cb4807f2a88fb7de2