### PR TITLE
Add Australian financial year metrics to dashboard

### DIFF
--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -20,6 +20,14 @@ import {
 
 const toCents = (value: number) => Math.round(value * 100);
 
+const getAustralianFinancialYearStart = (isoDate: string) => {
+  const [yearStr, monthStr] = isoDate.split('-');
+  const year = Number(yearStr);
+  const month = Number(monthStr);
+  const fyStartYear = month >= 7 ? year : year - 1;
+  return `${fyStartYear.toString().padStart(4, '0')}-07-01`;
+};
+
 export async function GET(req: Request) {
   seedIfEmpty();
 
@@ -54,6 +62,7 @@ export async function GET(req: Request) {
 
   const yearStart = to.slice(0, 4) + '-01-01';
   const monthStart = to.slice(0, 7) + '-01';
+  const fyStart = getAustralianFinancialYearStart(to);
 
   const sumIncome = (start: string, end: string) =>
     incomeEntries
@@ -68,6 +77,8 @@ export async function GET(req: Request) {
   const ytdExpense = sumExpense(yearStart, to);
   const mtdIncome = sumIncome(monthStart, to);
   const mtdExpense = sumExpense(monthStart, to);
+  const fyIncome = sumIncome(fyStart, to);
+  const fyExpense = sumExpense(fyStart, to);
 
   const points: TimeSeriesPoint[] = [];
   for (
@@ -214,6 +225,8 @@ export async function GET(req: Request) {
     cashflow: {
       ytdNet: { amountCents: ytdIncome - ytdExpense, currency: 'AUD' },
       mtdNet: { amountCents: mtdIncome - mtdExpense, currency: 'AUD' },
+      fyIncome: { amountCents: fyIncome, currency: 'AUD' },
+      fyExpense: { amountCents: fyExpense, currency: 'AUD' },
     },
     lineSeries: { points },
     incomeByProperty,

--- a/components/dashboard/DashboardPage.tsx
+++ b/components/dashboard/DashboardPage.tsx
@@ -12,10 +12,19 @@ import Header from './Header';
 // Use the first day of the previous month to show a two-month window ending today.
 const startOfPreviousMonth = (d: Date) => new Date(d.getFullYear(), d.getMonth() - 1, 1);
 const formatISODate = (d: Date) => d.toISOString().split('T')[0];
+const getAustralianFinancialYearBounds = (date: Date) => {
+  const month = date.getMonth();
+  const year = date.getFullYear();
+  const startYear = month >= 6 ? year : year - 1;
+  return { startYear, endYear: startYear + 1 };
+};
 
 export default function DashboardPage() {
   const [from] = useState(() => startOfPreviousMonth(new Date()));
   const [to] = useState(() => new Date());
+  const { startYear: fyStartYear, endYear: fyEndYear } = getAustralianFinancialYearBounds(to);
+  const fyLabel = `FY${String(fyEndYear).slice(-2)}`;
+  const fyHint = `Australian Financial Year (${fyStartYear}-${fyEndYear})`;
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['dashboard', from, to],
@@ -33,6 +42,16 @@ export default function DashboardPage() {
           <div className="grid gap-4 md:grid-cols-2">
             <MetricCard title="YTD Cashflow" value={formatMoney(data.cashflow.ytdNet.amountCents)} hint="Year to Date" />
             <MetricCard title="MTD Cashflow" value={formatMoney(data.cashflow.mtdNet.amountCents)} hint="Month to Date" />
+            <MetricCard
+              title={`${fyLabel} Income`}
+              value={formatMoney(data.cashflow.fyIncome.amountCents)}
+              hint={fyHint}
+            />
+            <MetricCard
+              title={`${fyLabel} Expenses`}
+              value={formatMoney(data.cashflow.fyExpense.amountCents)}
+              hint={fyHint}
+            />
           </div>
           <CashflowLineChart data={data.lineSeries.points} />
           <div className="grid gap-4 md:grid-cols-2">

--- a/public/mock/mockDashboard.json
+++ b/public/mock/mockDashboard.json
@@ -1,6 +1,11 @@
 {
   "portfolio": { "propertiesCount": 3, "occupiedCount": 3, "vacancyCount": 0 },
-  "cashflow": { "ytdNet": { "amountCents": 1823400, "currency": "AUD" }, "mtdNet": { "amountCents": 154200, "currency": "AUD" } },
+  "cashflow": {
+    "ytdNet": { "amountCents": 1823400, "currency": "AUD" },
+    "mtdNet": { "amountCents": 154200, "currency": "AUD" },
+    "fyIncome": { "amountCents": 5489000, "currency": "AUD" },
+    "fyExpense": { "amountCents": 3665600, "currency": "AUD" }
+  },
   "lineSeries": {
     "points": [
       { "date": "2025-09-01", "cashInCents": 420000, "cashOutCents": 120000, "netCents": 300000 },

--- a/types/dashboard.ts
+++ b/types/dashboard.ts
@@ -14,6 +14,8 @@ export interface PortfolioSummary {
 export interface CashflowSnapshot {
   ytdNet: Money;
   mtdNet: Money;
+  fyIncome: Money;
+  fyExpense: Money;
 }
 
 export interface TimeSeriesPoint {


### PR DESCRIPTION
## Summary
- extend the dashboard API and types to calculate income and expense totals for the Australian financial year
- surface the new metrics with additional cards on the dashboard and update the mock payload

## Testing
- npm install *(fails: npm ERR! 403 Forbidden - GET https://registry.npmjs.org/@tanstack%2freact-query)*

------
https://chatgpt.com/codex/tasks/task_e_68c93a2b612c832c90515f33d8d7350a