### PR TITLE
Fix dashboard API task lookup

### DIFF
--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -188,6 +188,15 @@ export async function GET(req: Request) {
     return 'low';
   };
 
+  const listDashboardTasks = (propertyId: string): PropertyCardData['tasks'] =>
+    listTasks({ propertyId }).map((task) => ({
+      id: task.id,
+      title: task.title,
+      status: normalizeTaskStatus(task.status),
+      dueDate: task.dueDate,
+      priority: normalizeTaskPriority(task.priority),
+    }));
+
   const today = new Date().toISOString().split('T')[0];
   const propertyCards: PropertyCardData[] = activeProperties.map((property) => {
     const rentEntries = rentLedger


### PR DESCRIPTION
## Summary
- define `listDashboardTasks` inside the dashboard API route so it uses the in-memory store
- normalize task status and priority while mapping property-specific tasks returned to the client

## Testing
- npm run lint *(fails: ESLint 9.x global binary runs without local config because dependencies cannot be installed in this environment)*
- npm run test:unit *(fails: vitest binary unavailable since npm install is blocked by registry access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68ca359f2810832cb73753d44c528ab0