### PR TITLE
Align dashboard date range typography

### DIFF
--- a/components/dashboard/Header.tsx
+++ b/components/dashboard/Header.tsx
@@ -9,7 +9,7 @@ export default function Header({ from, to }: Props) {
   return (
     <div className="flex flex-col md:flex-row md:items-center md:justify-between p-4">
       <h1 className="text-2xl font-bold">Dashboard</h1>
-      <div className="text-sm text-text-secondary mt-2 md:mt-0">
+      <div className="text-2xl font-bold mt-2 md:mt-0">
         {formatDate(from)} – {formatDate(to)}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- match the dashboard date range styling to the main title by using the same font size and weight

## Testing
- npm run lint (fails: ESLint couldn't find an eslint.config file)


------
https://chatgpt.com/codex/tasks/task_e_68ca3743e0fc832ca3d7e8908ccec06c