### PR TITLE
Improve cashflow chart formatting

### DIFF
--- a/components/dashboard/CashflowLineChart.tsx
+++ b/components/dashboard/CashflowLineChart.tsx
@@ -1,6 +1,6 @@
 import { ResponsiveContainer, LineChart, Line, Tooltip, Legend, XAxis, YAxis, CartesianGrid } from 'recharts';
 import type { TimeSeriesPoint } from '../../types/dashboard';
-import { formatDate, formatMoney } from '../../lib/format';
+import { formatMoney, formatChartDate } from '../../lib/format';
 
 interface Props {
   data: TimeSeriesPoint[];
@@ -10,11 +10,23 @@ export default function CashflowLineChart({ data }: Props) {
   return (
     <div className="p-4 rounded-2xl card">
       <ResponsiveContainer width="100%" height={300}>
-        <LineChart data={data}>
+        <LineChart data={data} margin={{ top: 16, right: 24, bottom: 0, left: 56 }}>
           <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
-          <XAxis dataKey="date" tickFormatter={(d) => formatDate(d)} tick={{ fill: 'var(--text-secondary)' }} />
-          <YAxis tickFormatter={(v) => formatMoney(v)} tick={{ fill: 'var(--text-secondary)' }} />
-          <Tooltip formatter={(v: number) => formatMoney(v)} labelFormatter={(l) => formatDate(l)} />
+          <XAxis
+            dataKey="date"
+            tickFormatter={(d) => formatChartDate(d)}
+            tick={{ fill: 'var(--text-secondary)' }}
+            tickLine={false}
+            axisLine={{ stroke: 'var(--border)' }}
+          />
+          <YAxis
+            tickFormatter={(v) => formatMoney(v)}
+            tick={{ fill: 'var(--text-secondary)' }}
+            width={88}
+            tickLine={false}
+            axisLine={{ stroke: 'var(--border)' }}
+          />
+          <Tooltip formatter={(v: number) => formatMoney(v)} labelFormatter={(l) => formatChartDate(l)} />
           <Legend />
           <Line type="monotone" dataKey="cashInCents" name="Cash In" stroke="#22c55e" />
           <Line type="monotone" dataKey="cashOutCents" name="Cash Out" stroke="#ef4444" />

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -12,6 +12,18 @@ export const formatDate = (d?: string | Date) => {
   }).format(date);
 };
 
+export const formatChartDate = (d?: string | Date) => {
+  if (!d) return '';
+  const date = new Date(d);
+  if (isNaN(date.getTime())) return '';
+  const formatted = new Intl.DateTimeFormat('en-AU', {
+    day: '2-digit',
+    month: 'short',
+    year: '2-digit',
+  }).format(date);
+  return `${formatted}'`;
+};
+
 export const formatMoney = (cents: number) => formatCurrency(cents / 100);
 
 export const statusToBadgeColor = (status: string) => {


### PR DESCRIPTION
## Summary
- add chart margins and axis styling so the y-axis is visible on the dashboard cashflow graph
- introduce a dedicated short date formatter and apply it to the cashflow chart ticks and tooltip

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68ca37906370832c8e0477b984925191