### PR TITLE
Adjust scrollbars for theme awareness

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -7,6 +7,8 @@
   --bg-surface:#FFFFFF;
   --bg-elevated:#F3F6FB;
   --border:#D6DEE8;
+  --scrollbar-thumb:#CBD5E1;
+  --scrollbar-thumb-hover:#A8B6C9;
 
   --text-primary:#0B1220;
   --text-secondary:#3B475A;
@@ -40,6 +42,8 @@
   --bg-surface:#111826;
   --bg-elevated:#161E2E;
   --border:#2A3448;
+  --scrollbar-thumb:#2A3448;
+  --scrollbar-thumb-hover:#3A4761;
 
   --text-primary:#E6EAF2;
   --text-secondary:#B1B7C6;
@@ -88,21 +92,21 @@
 [data-theme="dark"] textarea{ background:var(--bg-surface); border:1px solid var(--border); color:var(--text-primary); }
 [data-theme="dark"] ::placeholder{ color:var(--placeholder); opacity:1; }
 
-[data-theme="dark"] *{
+[data-theme] *{
   scrollbar-width: thin;
-  scrollbar-color: var(--border) var(--bg-base);
+  scrollbar-color: var(--scrollbar-thumb) var(--bg-base);
 }
-[data-theme="dark"] *::-webkit-scrollbar{
+[data-theme] *::-webkit-scrollbar{
   width: 8px;
   height: 8px;
 }
-[data-theme="dark"] *::-webkit-scrollbar-track{
+[data-theme] *::-webkit-scrollbar-track{
   background: var(--bg-base);
 }
-[data-theme="dark"] *::-webkit-scrollbar-thumb{
-  background-color: var(--border);
+[data-theme] *::-webkit-scrollbar-thumb{
+  background-color: var(--scrollbar-thumb);
   border-radius: 4px;
 }
-[data-theme="dark"] *::-webkit-scrollbar-thumb:hover{
-  background-color: #3A4761;
+[data-theme] *::-webkit-scrollbar-thumb:hover{
+  background-color: var(--scrollbar-thumb-hover);
 }


### PR DESCRIPTION
## Summary
- add theme-specific scrollbar variables for both light and dark modes
- apply shared scrollbar styling that respects the active theme colors

## Testing
- npm install *(fails: registry access is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca37c16d90832c8ca52566ee754da9