### PR TITLE
feat: redesign property detail layout

### DIFF
--- a/app/(app)/properties/[id]/components/ActionButtons.tsx
+++ b/app/(app)/properties/[id]/components/ActionButtons.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import type { ButtonHTMLAttributes } from "react";
+import { Button } from "../../../../../components/ui/button";
+
+interface ActionButtonsProps {
+  onAddIncome: () => void;
+  onAddExpense: () => void;
+  onUploadDocument: () => void;
+}
+
+function ActionButton({
+  children,
+  className = "",
+  ...props
+}: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <Button
+      type="button"
+      className={`whitespace-nowrap px-3 py-1 text-sm font-medium ${className}`}
+      {...props}
+    >
+      {children}
+    </Button>
+  );
+}
+
+export default function ActionButtons({
+  onAddIncome,
+  onAddExpense,
+  onUploadDocument,
+}: ActionButtonsProps) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      <ActionButton
+        onClick={onAddIncome}
+        aria-label="Add Income"
+        className="bg-green-600 text-white hover:bg-green-700"
+      >
+        +Add Income
+      </ActionButton>
+      <ActionButton
+        onClick={onAddExpense}
+        aria-label="Add Expense"
+        className="bg-blue-600 text-white hover:bg-blue-700"
+      >
+        +Add Expense
+      </ActionButton>
+      <ActionButton
+        onClick={onUploadDocument}
+        aria-label="Upload Document"
+        className="bg-purple-600 text-white hover:bg-purple-700"
+      >
+        +Upload Document
+      </ActionButton>
+    </div>
+  );
+}

--- a/app/(app)/properties/[id]/components/PropertyHero.tsx
+++ b/app/(app)/properties/[id]/components/PropertyHero.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import Link from "next/link";
+import type { PropertySummary } from "../../../../../types/property";
+import { Button } from "../../../../../components/ui/button";
+
+interface PropertyHeroProps {
+  property: PropertySummary;
+  onEdit: () => void;
+}
+
+export default function PropertyHero({ property, onEdit }: PropertyHeroProps) {
+  const imageSrc = property.imageUrl || "/default-house.svg";
+
+  return (
+    <section className="overflow-hidden rounded-lg border bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900">
+      <div className="relative h-48 w-full bg-gray-200 dark:bg-gray-700">
+        <img
+          src={imageSrc}
+          alt={`Photo of ${property.address}`}
+          className="h-full w-full object-cover"
+        />
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={onEdit}
+          className="absolute right-4 top-4 bg-white/90 text-sm font-medium text-gray-900 hover:bg-white"
+        >
+          Edit Property
+        </Button>
+      </div>
+      <div className="flex flex-col gap-4 p-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-1">
+          <Link
+            href={`/properties/${property.id}`}
+            className="text-lg font-semibold text-blue-600 underline"
+          >
+            {property.address}
+          </Link>
+          <div className="text-sm text-gray-600 dark:text-gray-300">
+            Tenant: {property.tenant}
+          </div>
+        </div>
+        <div className="text-right">
+          <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            Rent / week
+          </p>
+          <p className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+            ${property.rent}/week
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/(app)/properties/[id]/components/ScrollableSectionBar.tsx
+++ b/app/(app)/properties/[id]/components/ScrollableSectionBar.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
+import { Button } from "../../../../../components/ui/button";
+
+export interface SectionTab {
+  id: string;
+  label: string;
+}
+
+interface ScrollableSectionBarProps {
+  tabs: SectionTab[];
+  activeTab: string;
+  onTabSelect: (tab: string) => void;
+}
+
+export default function ScrollableSectionBar({
+  tabs,
+  activeTab,
+  onTabSelect,
+}: ScrollableSectionBarProps) {
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  const tabRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const orderedTabs = useMemo(() => tabs, [tabs]);
+
+  const updateScrollButtons = () => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    const { scrollLeft, scrollWidth, clientWidth } = container;
+    setCanScrollLeft(scrollLeft > 0);
+    setCanScrollRight(scrollLeft + clientWidth < scrollWidth - 1);
+  };
+
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    updateScrollButtons();
+    container.addEventListener("scroll", updateScrollButtons);
+    window.addEventListener("resize", updateScrollButtons);
+    return () => {
+      container.removeEventListener("scroll", updateScrollButtons);
+      window.removeEventListener("resize", updateScrollButtons);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [orderedTabs.length]);
+
+  useEffect(() => {
+    updateScrollButtons();
+  }, [activeTab]);
+
+  useEffect(() => {
+    const current = tabRefs.current[activeTab];
+    const container = scrollContainerRef.current;
+    if (current && container) {
+      const currentRect = current.getBoundingClientRect();
+      const containerRect = container.getBoundingClientRect();
+      if (currentRect.left < containerRect.left || currentRect.right > containerRect.right) {
+        current.scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" });
+      }
+    }
+  }, [activeTab]);
+
+  const handleArrowClick = (direction: "left" | "right") => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    const scrollAmount = direction === "left" ? -240 : 240;
+    container.scrollBy({ left: scrollAmount, behavior: "smooth" });
+  };
+
+  const focusTab = (tabId: string) => {
+    const el = tabRefs.current[tabId];
+    el?.focus();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      const next = orderedTabs[(index + 1) % orderedTabs.length];
+      onTabSelect(next.id);
+      focusTab(next.id);
+    }
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      const prev =
+        orderedTabs[(index - 1 + orderedTabs.length) % orderedTabs.length];
+      onTabSelect(prev.id);
+      focusTab(prev.id);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button
+        type="button"
+        variant="secondary"
+        aria-label="Scroll left"
+        onClick={() => handleArrowClick("left")}
+        disabled={!canScrollLeft}
+        className="h-9 w-9 p-0"
+      >
+        <span aria-hidden>&lsaquo;</span>
+      </Button>
+      <div className="relative flex-1 overflow-hidden">
+        <div
+          ref={scrollContainerRef}
+          className="flex overflow-x-auto whitespace-nowrap"
+          role="tablist"
+          aria-orientation="horizontal"
+        >
+          {orderedTabs.map((tab, index) => {
+            const isActive = tab.id === activeTab;
+            return (
+              <button
+                key={tab.id}
+                ref={(el) => {
+                  tabRefs.current[tab.id] = el;
+                }}
+                id={`tab-${tab.id}`}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                aria-controls={`panel-${tab.id}`}
+                tabIndex={isActive ? 0 : -1}
+                onClick={() => onTabSelect(tab.id)}
+                onKeyDown={(event) => handleKeyDown(event, index)}
+                className={`relative mx-1 flex-shrink-0 rounded px-4 py-2 text-sm font-medium transition-colors ${
+                  isActive
+                    ? "bg-blue-600 text-white"
+                    : "text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
+                }`}
+              >
+                {tab.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      <Button
+        type="button"
+        variant="secondary"
+        aria-label="Scroll right"
+        onClick={() => handleArrowClick("right")}
+        disabled={!canScrollRight}
+        className="h-9 w-9 p-0"
+      >
+        <span aria-hidden>&rsaquo;</span>
+      </Button>
+    </div>
+  );
+}

--- a/app/(app)/properties/[id]/page.tsx
+++ b/app/(app)/properties/[id]/page.tsx
@@ -1,45 +1,128 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
-import QuickActionsBar from "../../../../components/QuickActionsBar";
+
+import IncomeForm from "../../../../components/IncomeForm";
 import ExpenseForm from "../../../../components/ExpenseForm";
 import DocumentUploadModal from "../../../../components/DocumentUploadModal";
-import MessageTenantModal from "../../../../components/MessageTenantModal";
-import PropertyOverviewCard from "../../../../components/PropertyOverviewCard";
-import PropertyDetailTabs from "../../../../components/PropertyDetailTabs";
 import PropertyEditModal from "../../../../components/PropertyEditModal";
 import { getProperty } from "../../../../lib/api";
 import type { PropertySummary } from "../../../../types/property";
+import { useURLState } from "../../../../lib/useURLState";
+import ActionButtons from "./components/ActionButtons";
+import PropertyHero from "./components/PropertyHero";
+import ScrollableSectionBar, { type SectionTab } from "./components/ScrollableSectionBar";
+import RentLedger from "./sections/RentLedger";
+import Expenses from "./sections/Expenses";
+import Documents from "./sections/Documents";
+import RentReview from "./sections/RentReview";
+import KeyDates from "./sections/KeyDates";
+import TenantCRM from "./sections/TenantCRM";
+import Inspections from "./sections/Inspections";
+import CreateListing from "./sections/CreateListing";
+import Vendors from "./sections/Vendors";
+
+const TABS = [
+  { id: "rent-ledger", label: "Rent Ledger" },
+  { id: "expenses", label: "Expenses" },
+  { id: "documents", label: "Documents" },
+  { id: "rent-review", label: "Rent Review" },
+  { id: "key-dates", label: "Key Dates" },
+  { id: "tenant-crm", label: "Tenant CRM" },
+  { id: "inspections", label: "Inspections" },
+  { id: "create-listing", label: "Create Listing" },
+  { id: "vendors", label: "Vendors" },
+] as const satisfies SectionTab[];
+
+type TabId = (typeof TABS)[number]["id"];
+const DEFAULT_TAB: TabId = "rent-ledger";
 
 export default function PropertyPage() {
-  const [expenseOpen, setExpenseOpen] = useState(false);
-  const [docOpen, setDocOpen] = useState(false);
-  const [messageOpen, setMessageOpen] = useState(false);
-  const [editOpen, setEditOpen] = useState(false);
   const { id } = useParams<{ id: string }>();
+  const [activeTab, setActiveTab] = useURLState<TabId>({
+    key: "tab",
+    defaultValue: DEFAULT_TAB,
+  });
+  const [incomeOpen, setIncomeOpen] = useState(false);
+  const [expenseOpen, setExpenseOpen] = useState(false);
+  const [documentOpen, setDocumentOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
 
-  const { data: property } = useQuery<PropertySummary>({
+  const { data: property, isPending } = useQuery<PropertySummary>({
     queryKey: ["property", id],
     queryFn: () => getProperty(id),
   });
 
-  if (!property) return <div className="p-6">Loading...</div>;
+  const resolvedTab = useMemo<TabId>(() => {
+    return TABS.some((tab) => tab.id === activeTab) ? activeTab : DEFAULT_TAB;
+  }, [activeTab]);
+
+  if (isPending || !property) {
+    return <div className="p-6">Loading...</div>;
+  }
+
+  const handleTabSelect = (tab: string) => {
+    const match = TABS.find((item) => item.id === tab);
+    if (match) {
+      setActiveTab(match.id);
+    }
+  };
+
+  const renderSection = (tabId: TabId) => {
+    switch (tabId) {
+      case "rent-ledger":
+        return <RentLedger propertyId={id} />;
+      case "expenses":
+        return <Expenses propertyId={id} />;
+      case "documents":
+        return <Documents propertyId={id} />;
+      case "rent-review":
+        return <RentReview propertyId={id} />;
+      case "key-dates":
+        return <KeyDates propertyId={id} />;
+      case "tenant-crm":
+        return <TenantCRM propertyId={id} />;
+      case "inspections":
+        return <Inspections propertyId={id} />;
+      case "create-listing":
+        return <CreateListing property={property} />;
+      case "vendors":
+        return <Vendors propertyId={id} />;
+      default:
+        return <RentLedger propertyId={id} />;
+    }
+  };
 
   return (
-    <div className="p-6 space-y-4">
-      <QuickActionsBar
-        onLogExpense={() => setExpenseOpen(true)}
-        onUploadDocument={() => setDocOpen(true)}
-        onMessageTenant={() => setMessageOpen(true)}
+    <div className="space-y-4 p-6">
+      <ActionButtons
+        onAddIncome={() => setIncomeOpen(true)}
+        onAddExpense={() => setExpenseOpen(true)}
+        onUploadDocument={() => setDocumentOpen(true)}
       />
-      <button
-        onClick={() => setEditOpen(true)}
-        className="inline-block px-2 py-1 border rounded dark:border-gray-700"
+      <PropertyHero property={property} onEdit={() => setEditOpen(true)} />
+      <ScrollableSectionBar
+        tabs={TABS}
+        activeTab={resolvedTab}
+        onTabSelect={handleTabSelect}
+      />
+      <div
+        role="tabpanel"
+        id={`panel-${resolvedTab}`}
+        aria-labelledby={`tab-${resolvedTab}`}
+        tabIndex={0}
+        className="pt-2"
       >
-        Edit Property
-      </button>
+        {renderSection(resolvedTab)}
+      </div>
+      <IncomeForm
+        propertyId={id}
+        open={incomeOpen}
+        onOpenChange={setIncomeOpen}
+        showTrigger={false}
+      />
       <ExpenseForm
         propertyId={id}
         open={expenseOpen}
@@ -48,18 +131,14 @@ export default function PropertyPage() {
       />
       <DocumentUploadModal
         propertyId={id}
-        open={docOpen}
-        onClose={() => setDocOpen(false)}
+        open={documentOpen}
+        onClose={() => setDocumentOpen(false)}
       />
-      <MessageTenantModal open={messageOpen} onClose={() => setMessageOpen(false)} />
       <PropertyEditModal
         property={property}
         open={editOpen}
         onClose={() => setEditOpen(false)}
       />
-      <h1 className="text-2xl font-semibold">Property Details</h1>
-      <PropertyOverviewCard property={property} />
-      <PropertyDetailTabs propertyId={id} />
     </div>
   );
 }

--- a/app/(app)/properties/[id]/sections/CreateListing.tsx
+++ b/app/(app)/properties/[id]/sections/CreateListing.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import ListingWizard from "../../../../../components/ListingWizard";
+import type { PropertySummary } from "../../../../../types/property";
+
+interface CreateListingProps {
+  property: PropertySummary;
+}
+
+export default function CreateListing({ property }: CreateListingProps) {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold">
+        Create Listing for {property.address}
+      </h2>
+      <ListingWizard />
+    </div>
+  );
+}

--- a/app/(app)/properties/[id]/sections/Documents.tsx
+++ b/app/(app)/properties/[id]/sections/Documents.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import PropertyDocumentsTable from "../../../../../components/PropertyDocumentsTable";
+
+interface DocumentsProps {
+  propertyId: string;
+}
+
+export default function Documents({ propertyId }: DocumentsProps) {
+  return (
+    <div className="space-y-4">
+      <PropertyDocumentsTable propertyId={propertyId} />
+    </div>
+  );
+}

--- a/app/(app)/properties/[id]/sections/Expenses.tsx
+++ b/app/(app)/properties/[id]/sections/Expenses.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import ExpensesTable from "../../../../../components/ExpensesTable";
+
+interface ExpensesProps {
+  propertyId: string;
+}
+
+export default function Expenses({ propertyId }: ExpensesProps) {
+  return (
+    <div className="space-y-4">
+      <ExpensesTable propertyId={propertyId} />
+    </div>
+  );
+}

--- a/app/(app)/properties/[id]/sections/Inspections.tsx
+++ b/app/(app)/properties/[id]/sections/Inspections.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Button } from "../../../../../components/ui/button";
+import { createInspection, getInspections, type Inspection } from "../../../../../lib/api";
+
+interface InspectionsProps {
+  propertyId: string;
+}
+
+export default function Inspections({ propertyId }: InspectionsProps) {
+  const queryClient = useQueryClient();
+  const { data = [], isPending } = useQuery<Inspection[]>({
+    queryKey: ["inspections", propertyId],
+    queryFn: () => getInspections({ propertyId }),
+  });
+
+  const createInspectionMutation = useMutation({
+    mutationFn: () =>
+      createInspection({
+        propertyId,
+        type: "Routine",
+        status: "Scheduled",
+        date: new Date().toISOString(),
+      }),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["inspections", propertyId] }),
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <h2 className="text-xl font-semibold">Inspections</h2>
+        <Button
+          type="button"
+          onClick={() => createInspectionMutation.mutate()}
+          disabled={createInspectionMutation.isPending}
+        >
+          Start Inspection
+        </Button>
+      </div>
+      {isPending ? (
+        <div>Loading inspections...</div>
+      ) : data.length === 0 ? (
+        <div className="rounded border border-dashed p-6 text-center text-gray-500">
+          No inspections scheduled
+        </div>
+      ) : (
+        <ul className="space-y-3">
+          {data.map((inspection) => (
+            <li
+              key={inspection.id}
+              className="rounded border bg-white p-4 shadow-sm dark:border-gray-800 dark:bg-gray-900"
+            >
+              <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                <div className="font-medium">{inspection.type}</div>
+                <span className="text-sm text-gray-500 dark:text-gray-400">
+                  {new Date(inspection.date).toLocaleString()}
+                </span>
+              </div>
+              <div className="text-sm text-gray-600 dark:text-gray-300">
+                Status: {inspection.status}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/app/(app)/properties/[id]/sections/KeyDates.tsx
+++ b/app/(app)/properties/[id]/sections/KeyDates.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import UpcomingReminders from "../../../../../components/UpcomingReminders";
+
+interface KeyDatesProps {
+  propertyId: string;
+}
+
+export default function KeyDates({ propertyId }: KeyDatesProps) {
+  return (
+    <div className="space-y-4">
+      <UpcomingReminders propertyId={propertyId} />
+    </div>
+  );
+}

--- a/app/(app)/properties/[id]/sections/RentLedger.tsx
+++ b/app/(app)/properties/[id]/sections/RentLedger.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import RentLedgerTable from "../../../../../components/RentLedgerTable";
+
+interface RentLedgerProps {
+  propertyId: string;
+}
+
+export default function RentLedger({ propertyId }: RentLedgerProps) {
+  return (
+    <div className="space-y-4">
+      <RentLedgerTable propertyId={propertyId} />
+    </div>
+  );
+}

--- a/app/(app)/properties/[id]/sections/RentReview.tsx
+++ b/app/(app)/properties/[id]/sections/RentReview.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import PropertyRentReview from "../../../../../components/PropertyRentReview";
+
+interface RentReviewProps {
+  propertyId: string;
+}
+
+export default function RentReview({ propertyId }: RentReviewProps) {
+  return (
+    <div className="space-y-4">
+      <PropertyRentReview propertyId={propertyId} />
+    </div>
+  );
+}

--- a/app/(app)/properties/[id]/sections/TenantCRM.tsx
+++ b/app/(app)/properties/[id]/sections/TenantCRM.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import TenantCRMModule from "../../../../../components/TenantCRM";
+
+interface TenantCRMProps {
+  propertyId: string;
+}
+
+export default function TenantCRM({ propertyId }: TenantCRMProps) {
+  return (
+    <div className="space-y-4">
+      <TenantCRMModule propertyId={propertyId} />
+    </div>
+  );
+}

--- a/app/(app)/properties/[id]/sections/Vendors.tsx
+++ b/app/(app)/properties/[id]/sections/Vendors.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { listVendors, type Vendor } from "../../../../../lib/api";
+
+interface VendorsProps {
+  propertyId: string;
+}
+
+export default function Vendors({ propertyId: _propertyId }: VendorsProps) {
+  const { data = [], isPending } = useQuery<Vendor[]>({
+    queryKey: ["vendors"],
+    queryFn: listVendors,
+  });
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold">Preferred Vendors</h2>
+      {isPending ? (
+        <div>Loading vendors...</div>
+      ) : data.length === 0 ? (
+        <div className="rounded border border-dashed p-6 text-center text-gray-500">
+          No vendors available
+        </div>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2">
+          {data.map((vendor) => (
+            <div
+              key={vendor.id ?? vendor.name}
+              className="space-y-2 rounded border bg-white p-4 shadow-sm dark:border-gray-800 dark:bg-gray-900"
+            >
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold">{vendor.name}</h3>
+                {vendor.favourite && <span aria-label="Favourite vendor">★</span>}
+              </div>
+              {vendor.tags && vendor.tags.length > 0 && (
+                <div className="flex flex-wrap gap-2 text-xs">
+                  {vendor.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="rounded-full bg-gray-100 px-2 py-1 text-gray-700 dark:bg-gray-800 dark:text-gray-200"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              )}
+              <div className="flex flex-wrap gap-2 text-xs text-gray-600 dark:text-gray-300">
+                <span
+                  className={`rounded-full px-2 py-1 ${
+                    vendor.insured ? "bg-green-100 text-green-700" : "bg-red-100 text-red-700"
+                  }`}
+                >
+                  {vendor.insured ? "Insured" : "Not insured"}
+                </span>
+                <span
+                  className={`rounded-full px-2 py-1 ${
+                    vendor.licensed ? "bg-green-100 text-green-700" : "bg-red-100 text-red-700"
+                  }`}
+                >
+                  {vendor.licensed ? "Licensed" : "No licence"}
+                </span>
+              </div>
+              {vendor.avgResponseTime !== undefined && (
+                <div className="text-sm text-gray-500 dark:text-gray-400">
+                  Avg response: {vendor.avgResponseTime}h
+                </div>
+              )}
+              {vendor.documents && vendor.documents.length > 0 && (
+                <div className="flex flex-wrap gap-2 text-xs text-blue-600">
+                  {vendor.documents.map((doc) => (
+                    <span key={doc} className="rounded bg-blue-100 px-2 py-1">
+                      {doc}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/useURLState.ts
+++ b/lib/useURLState.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+interface UseURLStateOptions<T extends string> {
+  key: string;
+  defaultValue: T;
+}
+
+export function useURLState<T extends string>({
+  key,
+  defaultValue,
+}: UseURLStateOptions<T>) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const searchString = useMemo(() => searchParams?.toString() ?? "", [searchParams]);
+
+  const readValue = useCallback(() => {
+    const params = new URLSearchParams(searchString);
+    return (params.get(key) as T | null) ?? defaultValue;
+  }, [defaultValue, key, searchString]);
+
+  const [value, setValue] = useState<T>(readValue);
+
+  useEffect(() => {
+    const next = readValue();
+    setValue((current) => (current === next ? current : next));
+  }, [readValue, searchString]);
+
+  const updateValue = useCallback(
+    (next: T) => {
+      setValue(next);
+      const params = new URLSearchParams(searchString);
+      if (next === defaultValue) {
+        params.delete(key);
+      } else {
+        params.set(key, next);
+      }
+      const query = params.toString();
+      const url = query ? `${pathname}?${query}` : pathname;
+      router.replace(url, { scroll: false });
+    },
+    [defaultValue, key, pathname, router, searchString]
+  );
+
+  return [value, updateValue] as const;
+}


### PR DESCRIPTION
## Summary
- redesign the property detail page to use the new hero card, action buttons, and scrollable tab navigation synced to the URL
- add section components for rent ledger, expenses, documents, rent review, key dates, tenant CRM, inspections, create listing, and vendors
- introduce a reusable useURLState hook for query parameter driven state

## Testing
- npm run lint *(fails: ESLint config missing in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68ca355034a0832cae79908386e6953e