### PR TITLE
Add property-scoped task management

### DIFF
--- a/app/(app)/properties/[id]/page.tsx
+++ b/app/(app)/properties/[id]/page.tsx
@@ -19,6 +19,7 @@ import Expenses from "./sections/Expenses";
 import Documents from "./sections/Documents";
 import RentReview from "./sections/RentReview";
 import KeyDates from "./sections/KeyDates";
+import TasksSection from "./sections/Tasks";
 import TenantCRM from "./sections/TenantCRM";
 import Inspections from "./sections/Inspections";
 import CreateListing from "./sections/CreateListing";
@@ -30,6 +31,7 @@ const TABS = [
   { id: "documents", label: "Documents" },
   { id: "rent-review", label: "Rent Review" },
   { id: "key-dates", label: "Key Dates" },
+  { id: "tasks", label: "Tasks" },
   { id: "tenant-crm", label: "Tenant CRM" },
   { id: "inspections", label: "Inspections" },
   { id: "create-listing", label: "Create Listing" },
@@ -82,6 +84,10 @@ export default function PropertyPage() {
         return <RentReview propertyId={id} />;
       case "key-dates":
         return <KeyDates propertyId={id} />;
+      case "tasks":
+        return (
+          <TasksSection propertyId={id} propertyAddress={property.address} />
+        );
       case "tenant-crm":
         return <TenantCRM propertyId={id} />;
       case "inspections":

--- a/app/(app)/properties/[id]/sections/Tasks.tsx
+++ b/app/(app)/properties/[id]/sections/Tasks.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useState } from "react";
+import TasksKanban from "../../../../../components/tasks/TasksKanban";
+
+type PropertyContext = { id: string; address: string };
+
+interface TasksProps {
+  propertyId: string;
+  propertyAddress: string;
+}
+
+export default function Tasks({ propertyId, propertyAddress }: TasksProps) {
+  const [activeProperty, setActiveProperty] = useState<PropertyContext>({
+    id: propertyId,
+    address: propertyAddress,
+  });
+
+  return (
+    <div className="space-y-4">
+      <header className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold">
+          Tasks{activeProperty ? `: ${activeProperty.address}` : ""}
+        </h2>
+      </header>
+      <TasksKanban
+        initialPropertyId={propertyId}
+        allowPropertySwitching={false}
+        onContextChange={setActiveProperty}
+      />
+    </div>
+  );
+}

--- a/app/(app)/tasks/page.tsx
+++ b/app/(app)/tasks/page.tsx
@@ -1,17 +1,24 @@
 "use client";
 
+import { useState } from "react";
 import TasksKanban from "../../../components/tasks/TasksKanban";
 import Clock from "../../../components/Clock";
-import Link from "next/link";
+
+type PropertyContext = { id: string; address: string };
 
 export default function TasksPage() {
+  const [activeProperty, setActiveProperty] =
+    useState<PropertyContext | null>(null);
+
   return (
     <div className="p-6 space-y-4">
       <header className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold">Tasks</h1>
+        <h1 className="text-2xl font-semibold">
+          Tasks{activeProperty ? `: ${activeProperty.address}` : ""}
+        </h1>
         <Clock className="text-2xl font-semibold" />
       </header>
-      <TasksKanban />
+      <TasksKanban onContextChange={setActiveProperty} />
     </div>
   );
 }

--- a/components/tasks/TaskCard.tsx
+++ b/components/tasks/TaskCard.tsx
@@ -5,9 +5,11 @@ import type { TaskDto } from "../../types/tasks";
 export default function TaskCard({
   task,
   onClick,
+  showProperties = true,
 }: {
   task: TaskDto;
   onClick?: () => void;
+  showProperties?: boolean;
 }) {
   const REMINDER_DAYS = Number(
     process.env.NEXT_PUBLIC_TASK_REMINDER_DAYS ?? 1
@@ -43,9 +45,10 @@ export default function TaskCard({
       <div className="font-medium">{task.title}</div>
       <div className="mt-1 space-y-1 text-xs">
         {task.vendor && <div>Vendor: {task.vendor.name}</div>}
-        {task.properties.map((p) => (
-          <div key={p.id}>{p.address}</div>
-        ))}
+        {showProperties &&
+          task.properties.map((p) => (
+            <div key={p.id}>{p.address}</div>
+          ))}
         {task.attachments?.length ? (
           <div>📎 {task.attachments.length}</div>
         ) : null}

--- a/components/tasks/TaskQuickNew.tsx
+++ b/components/tasks/TaskQuickNew.tsx
@@ -4,9 +4,11 @@ import { useState } from "react";
 export default function TaskQuickNew({
   onCreate,
   className = "",
+  placeholder = "+ New task",
 }: {
   onCreate: (title: string) => void;
   className?: string;
+  placeholder?: string;
 }) {
   const [title, setTitle] = useState("");
   const handleKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -17,8 +19,8 @@ export default function TaskQuickNew({
   };
   return (
     <input
-      className="w-full border rounded p-2 mb-2 bg-white dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-      placeholder="+ New task"
+      className={`w-full border rounded p-2 mb-2 bg-white dark:border-gray-600 dark:bg-gray-700 dark:text-white ${className}`.trim()}
+      placeholder={placeholder}
       value={title}
       onChange={(e) => setTitle(e.target.value)}
       onKeyDown={handleKey}

--- a/components/tasks/TaskRow.tsx
+++ b/components/tasks/TaskRow.tsx
@@ -10,12 +10,14 @@ export default function TaskRow({
   onUpdate,
   onDelete,
   onToggle,
+  showProperties = true,
 }: {
   task: TaskDto;
   properties: PropertySummary[];
   onUpdate: (data: Partial<TaskDto>) => void;
   onDelete: () => void;
   onToggle: () => void;
+  showProperties?: boolean;
 }) {
   const [title, setTitle] = useState(task.title);
   const [editing, setEditing] = useState(false);
@@ -105,9 +107,10 @@ export default function TaskRow({
             onBlur={handleBlur}
           />
           <div className="flex flex-wrap gap-1 mt-1">
-            {task.properties.map((p) => (
-              <PropertyBadge key={p.id} address={p.address} />
-            ))}
+            {showProperties &&
+              task.properties.map((p) => (
+                <PropertyBadge key={p.id} address={p.address} />
+              ))}
             {task.dueDate && (
               <span
                 className={`text-xs ${


### PR DESCRIPTION
## Summary
- add a property-specific Tasks section to each property detail page
- enhance the kanban board with property filters, contextual titles, and scoped creation defaults
- hide property badges in property-scoped contexts while keeping them on the all-tasks view

## Testing
- npm run lint *(fails: missing dependencies because npm install is blocked by registry permissions)*

------
https://chatgpt.com/codex/tasks/task_e_68ca43155488832ca714f21730e33a8a