### PR TITLE
Refactor tab class helper

### DIFF
--- a/components/tasks/TasksKanban.tsx
+++ b/components/tasks/TasksKanban.tsx
@@ -219,10 +219,12 @@ export default function TasksKanban({
     "bg-white text-gray-700 border-gray-200 hover:bg-gray-100",
     "dark:bg-gray-800 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-700",
   ].join(" ");
-  const getTabClassName = (isActive: boolean) =>
-    [tabBaseClasses, isActive ? tabActiveClasses : tabInactiveClasses].join(
-      " "
-    );
+  const getTabClassName = (isActive: boolean) => {
+    return [
+      tabBaseClasses,
+      isActive ? tabActiveClasses : tabInactiveClasses,
+    ].join(" ");
+  };
 
   return (
     <>


### PR DESCRIPTION
## Summary
- refactor the tab class name helper in the kanban component to use a block-bodied arrow function that explicitly returns the combined classes

## Testing
- npm run dev *(fails: Next.js binary missing because dependencies cannot be installed in the environment; npm install returns 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8826e390832c8851508279b71135