### PR TITLE
Add property-scoped tasks management

### DIFF
--- a/app/(app)/properties/[id]/page.tsx
+++ b/app/(app)/properties/[id]/page.tsx
@@ -23,11 +23,13 @@ import TenantCRM from "./sections/TenantCRM";
 import Inspections from "./sections/Inspections";
 import CreateListing from "./sections/CreateListing";
 import Vendors from "./sections/Vendors";
+import TasksSection from "./sections/Tasks";
 
 const TABS = [
   { id: "rent-ledger", label: "Rent Ledger" },
   { id: "expenses", label: "Expenses" },
   { id: "documents", label: "Documents" },
+  { id: "tasks", label: "Tasks" },
   { id: "rent-review", label: "Rent Review" },
   { id: "key-dates", label: "Key Dates" },
   { id: "tenant-crm", label: "Tenant CRM" },
@@ -78,6 +80,13 @@ export default function PropertyPage() {
         return <Expenses propertyId={id} />;
       case "documents":
         return <Documents propertyId={id} />;
+      case "tasks":
+        return (
+          <TasksSection
+            propertyId={id}
+            propertyAddress={property.address}
+          />
+        );
       case "rent-review":
         return <RentReview propertyId={id} />;
       case "key-dates":

--- a/app/(app)/properties/[id]/sections/Tasks.tsx
+++ b/app/(app)/properties/[id]/sections/Tasks.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import TasksKanban from "../../../../../components/tasks/TasksKanban";
+
+interface PropertyTasksProps {
+  propertyId: string;
+  propertyAddress: string;
+}
+
+export default function PropertyTasks({
+  propertyId,
+  propertyAddress,
+}: PropertyTasksProps) {
+  return (
+    <div className="space-y-4">
+      <header className="space-y-1">
+        <h2 className="text-xl font-semibold">Tasks: {propertyAddress}</h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          Tasks created in this view are automatically linked to this property.
+        </p>
+      </header>
+      <TasksKanban initialPropertyId={propertyId} allowPropertySwitching={false} />
+    </div>
+  );
+}

--- a/app/(app)/tasks/page.tsx
+++ b/app/(app)/tasks/page.tsx
@@ -1,17 +1,23 @@
 "use client";
 
-import TasksKanban from "../../../components/tasks/TasksKanban";
+import { useState } from "react";
+import TasksKanban, {
+  type TasksKanbanContext,
+} from "../../../components/tasks/TasksKanban";
 import Clock from "../../../components/Clock";
-import Link from "next/link";
 
 export default function TasksPage() {
+  const [activeProperty, setActiveProperty] =
+    useState<TasksKanbanContext | null>(null);
+  const title = activeProperty ? `Tasks: ${activeProperty.address}` : "Tasks";
+
   return (
     <div className="p-6 space-y-4">
       <header className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold">Tasks</h1>
+        <h1 className="text-2xl font-semibold">{title}</h1>
         <Clock className="text-2xl font-semibold" />
       </header>
-      <TasksKanban />
+      <TasksKanban onContextChange={setActiveProperty} />
     </div>
   );
 }

--- a/components/tasks/TaskCard.tsx
+++ b/components/tasks/TaskCard.tsx
@@ -5,9 +5,11 @@ import type { TaskDto } from "../../types/tasks";
 export default function TaskCard({
   task,
   onClick,
+  showProperties = true,
 }: {
   task: TaskDto;
   onClick?: () => void;
+  showProperties?: boolean;
 }) {
   const REMINDER_DAYS = Number(
     process.env.NEXT_PUBLIC_TASK_REMINDER_DAYS ?? 1
@@ -43,9 +45,10 @@ export default function TaskCard({
       <div className="font-medium">{task.title}</div>
       <div className="mt-1 space-y-1 text-xs">
         {task.vendor && <div>Vendor: {task.vendor.name}</div>}
-        {task.properties.map((p) => (
-          <div key={p.id}>{p.address}</div>
-        ))}
+        {showProperties &&
+          task.properties.map((p) => (
+            <div key={p.id}>{p.address}</div>
+          ))}
         {task.attachments?.length ? (
           <div>📎 {task.attachments.length}</div>
         ) : null}

--- a/components/tasks/TaskQuickNew.tsx
+++ b/components/tasks/TaskQuickNew.tsx
@@ -1,15 +1,17 @@
 "use client";
-import { useState } from "react";
+import { useState, type KeyboardEvent } from "react";
 
 export default function TaskQuickNew({
   onCreate,
   className = "",
+  placeholder = "+ New task",
 }: {
   onCreate: (title: string) => void;
   className?: string;
+  placeholder?: string;
 }) {
   const [title, setTitle] = useState("");
-  const handleKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKey = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter" && title.trim()) {
       onCreate(title.trim());
       setTitle("");
@@ -17,8 +19,10 @@ export default function TaskQuickNew({
   };
   return (
     <input
-      className="w-full border rounded p-2 mb-2 bg-white dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-      placeholder="+ New task"
+      className={["w-full border rounded p-2 mb-2 bg-white dark:border-gray-600 dark:bg-gray-700 dark:text-white", className]
+        .filter(Boolean)
+        .join(" ")}
+      placeholder={placeholder}
       value={title}
       onChange={(e) => setTitle(e.target.value)}
       onKeyDown={handleKey}

--- a/components/tasks/TaskRow.tsx
+++ b/components/tasks/TaskRow.tsx
@@ -10,12 +10,14 @@ export default function TaskRow({
   onUpdate,
   onDelete,
   onToggle,
+  showProperties = true,
 }: {
   task: TaskDto;
   properties: PropertySummary[];
   onUpdate: (data: Partial<TaskDto>) => void;
   onDelete: () => void;
   onToggle: () => void;
+  showProperties?: boolean;
 }) {
   const [title, setTitle] = useState(task.title);
   const [editing, setEditing] = useState(false);
@@ -105,9 +107,10 @@ export default function TaskRow({
             onBlur={handleBlur}
           />
           <div className="flex flex-wrap gap-1 mt-1">
-            {task.properties.map((p) => (
-              <PropertyBadge key={p.id} address={p.address} />
-            ))}
+            {showProperties &&
+              task.properties.map((p) => (
+                <PropertyBadge key={p.id} address={p.address} />
+              ))}
             {task.dueDate && (
               <span
                 className={`text-xs ${

--- a/components/tasks/TasksKanban.tsx
+++ b/components/tasks/TasksKanban.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import {
@@ -17,12 +18,26 @@ import {
   listVendors,
 } from "../../lib/api";
 import type { TaskDto } from "../../types/tasks";
+import type { PropertySummary } from "../../types/property";
 import TaskCard from "./TaskCard";
 import TaskQuickNew from "./TaskQuickNew";
 import TaskEditModal from "./TaskEditModal";
 import ColumnRenameModal from "./ColumnRenameModal";
 import ColumnDeleteModal from "./ColumnDeleteModal";
 import ColumnCreateModal from "./ColumnCreateModal";
+
+const TAB_BASE_CLASSES =
+  "rounded-full border px-4 py-1.5 text-sm transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-300 dark:focus:ring-gray-600";
+const TAB_ACTIVE_CLASSES =
+  "bg-gray-900 text-white border-gray-900 dark:bg-gray-100 dark:text-gray-900";
+const TAB_INACTIVE_CLASSES =
+  "bg-white text-gray-700 border-gray-200 hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-700";
+
+const tabClassName = (isActive: boolean) =>
+  [
+    TAB_BASE_CLASSES,
+    isActive ? TAB_ACTIVE_CLASSES : TAB_INACTIVE_CLASSES,
+  ].join(" ");
 
 type Column = { id: string; title: string };
 
@@ -35,13 +50,34 @@ const DEFAULT_COLUMNS: Column[] = [
 
 const STORAGE_KEY = "task-columns";
 
-export default function TasksKanban() {
+type PropertyContext = Pick<PropertySummary, "id" | "address">;
+export type TasksKanbanContext = PropertyContext;
+
+type TasksKanbanProps = {
+  initialPropertyId?: string;
+  allowPropertySwitching?: boolean;
+  onContextChange?: (property: PropertyContext | null) => void;
+};
+
+export default function TasksKanban({
+  initialPropertyId,
+  allowPropertySwitching = true,
+  onContextChange,
+}: TasksKanbanProps) {
   const qc = useQueryClient();
-  const { data: tasks = [] } = useQuery<TaskDto[]>({
-    queryKey: ["tasks"],
-    queryFn: () => listTasks(),
-  });
-  const { data: properties = [] } = useQuery({
+  const [activeFilter, setActiveFilter] = useState<string>(
+    initialPropertyId ?? "all"
+  );
+
+  useEffect(() => {
+    if (initialPropertyId) {
+      setActiveFilter(initialPropertyId);
+    } else if (!allowPropertySwitching) {
+      setActiveFilter("all");
+    }
+  }, [initialPropertyId, allowPropertySwitching]);
+
+  const { data: properties = [] } = useQuery<PropertySummary[]>({
     queryKey: ["properties"],
     queryFn: () => listProperties(),
   });
@@ -49,15 +85,59 @@ export default function TasksKanban() {
     queryKey: ["vendors"],
     queryFn: () => listVendors(),
   });
-  const defaultProp = properties[0];
+
+  useEffect(() => {
+    if (!allowPropertySwitching) return;
+    if (activeFilter === "all") return;
+    if (!properties.length) return;
+    const exists = properties.some((property) => property.id === activeFilter);
+    if (!exists) {
+      setActiveFilter("all");
+    }
+  }, [activeFilter, allowPropertySwitching, properties]);
+
+  const selectedPropertyId = activeFilter !== "all" ? activeFilter : undefined;
+
+  const { data: tasks = [] } = useQuery<TaskDto[]>({
+    queryKey: ["tasks", { propertyId: selectedPropertyId ?? null }],
+    queryFn: () =>
+      selectedPropertyId
+        ? listTasks({ propertyId: selectedPropertyId })
+        : listTasks(),
+  });
+
+  const activeProperty = selectedPropertyId
+    ? properties.find((property) => property.id === selectedPropertyId)
+    : undefined;
+
+  useEffect(() => {
+    if (!onContextChange) return;
+    if (activeProperty) {
+      onContextChange({
+        id: activeProperty.id,
+        address: activeProperty.address,
+      });
+    } else {
+      onContextChange(null);
+    }
+  }, [activeProperty, onContextChange]);
+
+  const defaultPropertyForCreation = selectedPropertyId
+    ? activeProperty ?? null
+    : properties[0] ?? null;
 
   const createMut = useMutation({
     mutationFn: ({ title, status }: { title: string; status: string }) =>
       createTask({
         title,
         status,
-        properties: defaultProp
-          ? [{ id: defaultProp.id, address: defaultProp.address }]
+        properties: defaultPropertyForCreation
+          ? [
+              {
+                id: defaultPropertyForCreation.id,
+                address: defaultPropertyForCreation.address,
+              },
+            ]
           : [],
       }),
     onSuccess: () => qc.invalidateQueries({ queryKey: ["tasks"] }),
@@ -118,98 +198,163 @@ export default function TasksKanban() {
       );
   };
 
-  return (<>
-    <div className="flex gap-4 overflow-x-auto p-1">
-      <DragDropContext onDragEnd={handleDragEnd}>
-        {columns.map((col) => (
-          <div key={col.id} className="w-64 flex-shrink-0">
-            <div className="flex items-center justify-between mb-2">
-              <h2 className="font-semibold">{col.title}</h2>
-              <div className="relative">
-                <button
-                  onClick={() =>
-                    setMenuColumn(menuColumn === col.id ? null : col.id)
-                  }
-                  className="px-1"
-                >
-                  ⋯
-                </button>
-                {menuColumn === col.id && (
-                  <div className="absolute right-0 mt-1 w-28 rounded border bg-white shadow text-sm z-10 dark:bg-gray-800 dark:border-gray-700 dark:text-white">
-                    <button
-                      className="block w-full px-3 py-1 text-left hover:bg-gray-100 dark:hover:bg-gray-700"
-                      onClick={() => {
-                        setMenuColumn(null);
-                        setRenaming(col);
-                      }}
-                    >
-                      Edit
-                    </button>
-                    <button
-                      className="block w-full px-3 py-1 text-left text-red-500 hover:bg-gray-100 dark:text-red-400 dark:hover:bg-gray-700"
-                      onClick={() => {
-                        setMenuColumn(null);
-                        setDeleting(col);
-                      }}
-                    >
-                      Delete
-                    </button>
+  const handleTabSelect = (propertyId?: string) => {
+    if (!allowPropertySwitching) return;
+    if (!propertyId) {
+      setActiveFilter("all");
+    } else {
+      setActiveFilter(propertyId);
+    }
+  };
+
+  const newTaskPlaceholder = activeProperty
+    ? `+ New task for ${activeProperty.address}`
+    : "+ New task";
+
+  const propertyTabs: PropertySummary[] = allowPropertySwitching
+    ? properties
+    : activeProperty
+      ? [activeProperty]
+      : [];
+
+  const showPropertiesOnCards = !selectedPropertyId;
+
+  return (
+    <>
+      <div className="flex gap-4 overflow-x-auto p-1">
+        <DragDropContext onDragEnd={handleDragEnd}>
+          {columns.map((col) => (
+            <div key={col.id} className="w-64 flex-shrink-0">
+              <div className="flex items-center justify-between mb-2">
+                <h2 className="font-semibold">{col.title}</h2>
+                <div className="relative">
+                  <button
+                    onClick={() =>
+                      setMenuColumn(menuColumn === col.id ? null : col.id)
+                    }
+                    className="px-1"
+                  >
+                    ⋯
+                  </button>
+                  {menuColumn === col.id && (
+                    <div className="absolute right-0 mt-1 w-28 rounded border bg-white shadow text-sm z-10 dark:bg-gray-800 dark:border-gray-700 dark:text-white">
+                      <button
+                        className="block w-full px-3 py-1 text-left hover:bg-gray-100 dark:hover:bg-gray-700"
+                        onClick={() => {
+                          setMenuColumn(null);
+                          setRenaming(col);
+                        }}
+                      >
+                        Edit
+                      </button>
+                      <button
+                        className="block w-full px-3 py-1 text-left text-red-500 hover:bg-gray-100 dark:text-red-400 dark:hover:bg-gray-700"
+                        onClick={() => {
+                          setMenuColumn(null);
+                          setDeleting(col);
+                        }}
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  )}
+                </div>
+              </div>
+              <Droppable droppableId={col.id}>
+                {(provided) => (
+                  <div
+                    ref={provided.innerRef}
+                    {...provided.droppableProps}
+                    className="space-y-2"
+                  >
+                    {tasks
+                      .filter((t) => t.status === col.id)
+                      .map((task, idx) => (
+                        <Draggable
+                          key={task.id}
+                          draggableId={task.id}
+                          index={idx}
+                        >
+                          {(prov) => (
+                            <div
+                              ref={prov.innerRef}
+                              {...prov.draggableProps}
+                              {...prov.dragHandleProps}
+                            >
+                              <TaskCard
+                                task={task}
+                                onClick={() => setEditingTask(task)}
+                                showProperties={showPropertiesOnCards}
+                              />
+                            </div>
+                          )}
+                        </Draggable>
+                      ))}
+                    {provided.placeholder}
+                    <TaskQuickNew
+                      onCreate={(title) =>
+                        createMut.mutate({ title, status: col.id })
+                      }
+                      placeholder={newTaskPlaceholder}
+                    />
                   </div>
                 )}
-              </div>
+              </Droppable>
             </div>
-            <Droppable droppableId={col.id}>
-              {(provided) => (
-                <div
-                  ref={provided.innerRef}
-                  {...provided.droppableProps}
-                  className="space-y-2"
-                >
-                  {tasks
-                    .filter((t) => t.status === col.id)
-                    .map((task, idx) => (
-                      <Draggable
-                        key={task.id}
-                        draggableId={task.id}
-                        index={idx}
-                      >
-                        {(prov) => (
-                          <div
-                            ref={prov.innerRef}
-                            {...prov.draggableProps}
-                            {...prov.dragHandleProps}
-                          >
-                            <TaskCard task={task} onClick={() => setEditingTask(task)} />
-                          </div>
-                        )}
-                      </Draggable>
-                    ))}
-                  {provided.placeholder}
-                  <TaskQuickNew
-                    onCreate={(title) =>
-                      createMut.mutate({ title, status: col.id })
-                    }
-                  />
-                </div>
-              )}
-            </Droppable>
-          </div>
-        ))}
-      </DragDropContext>
-      <div className="w-64 flex-shrink-0">
-        <button
-          onClick={() => setCreating(true)}
-          className="w-full border rounded p-2 text-sm"
-        >
-          + Add Column
-        </button>
+          ))}
+        </DragDropContext>
+        <div className="w-64 flex-shrink-0">
+          <button
+            onClick={() => setCreating(true)}
+            className="w-full border rounded p-2 text-sm"
+          >
+            + Add Column
+          </button>
+        </div>
+        <Link href="/tasks/archive" className="w-64 flex-shrink-0">
+          <span className="block w-full border rounded p-2 text-sm text-center">Archive</span>
+        </Link>
       </div>
-      <Link
-        href="/tasks/archive"
-        className="w-64 flex-shrink-0"
-      >
-        <span className="block w-full border rounded p-2 text-sm text-center">Archive</span>
-      </Link>
+      <div className="mt-10 flex flex-col items-center gap-2">
+        <div
+          className="flex flex-wrap justify-center gap-2"
+          role="tablist"
+          aria-label="Task property filters"
+        >
+          {allowPropertySwitching && (
+            <button
+              type="button"
+              onClick={() => handleTabSelect(undefined)}
+              className={tabClassName(!selectedPropertyId)}
+              aria-pressed={!selectedPropertyId}
+            >
+              All
+            </button>
+          )}
+          {propertyTabs.map((property) => {
+            const isActive = selectedPropertyId === property.id;
+            return (
+              <button
+                key={property.id}
+                type="button"
+                onClick={() => handleTabSelect(property.id)}
+                className={tabClassName(isActive)}
+                aria-pressed={isActive}
+                aria-disabled={!allowPropertySwitching}
+              >
+                {property.address}
+              </button>
+            );
+          })}
+        </div>
+        {selectedPropertyId && activeProperty && (
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            Creating tasks for{" "}
+            <span className="font-medium text-gray-700 dark:text-gray-200">
+              {activeProperty.address}
+            </span>
+          </p>
+        )}
       </div>
       {editingTask && (
         <TaskEditModal
@@ -250,4 +395,3 @@ export default function TasksKanban() {
     </>
   );
 }
-


### PR DESCRIPTION
## Summary
- add a Tasks tab to the property detail page that hosts a property-scoped kanban board and clarifies the address context
- extend the kanban so it filters by property, emits the active context, defaults quick adds to the selected address, and surfaces property filter chips with guidance
- update the Tasks page header and task displays to reflect the current property selection, hiding badges when a specific property is in focus
- stabilize the kanban tab helper by hoisting the styling constants and helper so the board compiles reliably

## Testing
- npm run lint *(fails: ESLint 9.34.0 expects an eslint.config.js in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca43155488832ca714f21730e33a8a