### PR TITLE
Fix duplicate tasks section wiring

### DIFF
--- a/app/(app)/properties/[id]/page.tsx
+++ b/app/(app)/properties/[id]/page.tsx
@@ -23,7 +23,6 @@ import TenantCRM from "./sections/TenantCRM";
 import Inspections from "./sections/Inspections";
 import CreateListing from "./sections/CreateListing";
 import Vendors from "./sections/Vendors";
-import TasksSection from "./sections/Tasks";
 
 const TABS = [
   { id: "rent-ledger", label: "Rent Ledger" },
@@ -32,7 +31,6 @@ const TABS = [
   { id: "tasks", label: "Tasks" },
   { id: "rent-review", label: "Rent Review" },
   { id: "key-dates", label: "Key Dates" },
-  { id: "tasks", label: "Tasks" },
   { id: "tenant-crm", label: "Tenant CRM" },
   { id: "inspections", label: "Inspections" },
   { id: "create-listing", label: "Create Listing" },
@@ -92,10 +90,6 @@ export default function PropertyPage() {
         return <RentReview propertyId={id} />;
       case "key-dates":
         return <KeyDates propertyId={id} />;
-      case "tasks":
-        return (
-          <TasksSection propertyId={id} propertyAddress={property.address} />
-        );
       case "tenant-crm":
         return <TenantCRM propertyId={id} />;
       case "inspections":


### PR DESCRIPTION
## Summary
- remove the duplicate `TasksSection` import on the property page
- keep a single `tasks` tab entry and render branch in the property view switch

## Testing
- npm run dev *(fails: next binary missing because dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbdd5d1b58832cab620a7b08887c54