### PR TITLE
Add client directives to analytics client modules

### DIFF
--- a/app/(app)/analytics/components/DateRangeFilter.tsx
+++ b/app/(app)/analytics/components/DateRangeFilter.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState } from 'react';
 import type { AnalyticsStateType } from '../../../lib/schemas';
 

--- a/app/(app)/analytics/components/VizSpreadsheet.tsx
+++ b/app/(app)/analytics/components/VizSpreadsheet.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState } from 'react';
 
 interface IncomeItem {

--- a/components/PhotoUpload.tsx
+++ b/components/PhotoUpload.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useId, useState } from 'react';
 
 interface Props {

--- a/hooks/useAnalytics.ts
+++ b/hooks/useAnalytics.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useQuery, useMutation } from '@tanstack/react-query';
 import type { AnalyticsStateType } from '../lib/schemas';
 

--- a/lib/urlState.ts
+++ b/lib/urlState.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useEffect } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { AnalyticsState, AnalyticsStateType } from './schemas';


### PR DESCRIPTION
## Summary
- add `'use client';` to client-facing analytics utilities and components to avoid server component hook usage

## Testing
- npm run build *(fails: next not found prior to installing dependencies)*
- npm install *(fails: received 403 when downloading @tanstack/react-query)*

------
https://chatgpt.com/codex/tasks/task_e_68cbdd5e5ba8832c8ee2390492aef7ac