### PR TITLE
Fix TasksKanban compile errors

### DIFF
--- a/components/tasks/TasksKanban.tsx
+++ b/components/tasks/TasksKanban.tsx
@@ -326,7 +326,6 @@ export default function TasksKanban({
               type="button"
               onClick={() => handleTabSelect(undefined)}
               className={tabClassName(!selectedPropertyId)}
-
               aria-pressed={!selectedPropertyId}
             >
               All
@@ -357,31 +356,23 @@ export default function TasksKanban({
           </p>
         )}
       </div>
-      {propertyIdFilter && activeProperty && (
-        <p className="text-xs text-gray-500 dark:text-gray-400">
-          Creating tasks for{" "}
-          <span className="font-medium text-gray-700 dark:text-gray-200">
-            {activeProperty.address}
-          </span>
-        </p>
+
+      {editingTask && (
+        <TaskEditModal
+          task={editingTask}
+          properties={properties}
+          vendors={vendors}
+          onClose={() => setEditingTask(null)}
+          onSave={(data) => {
+            updateMut.mutate({ id: editingTask.id, data });
+            setEditingTask(null);
+          }}
+          onArchive={() => {
+            archiveMut.mutate(editingTask.id);
+            setEditingTask(null);
+          }}
+        />
       )}
-    </div>
-    {editingTask && (
-      <TaskEditModal
-        task={editingTask}
-        properties={properties}
-        vendors={vendors}
-        onClose={() => setEditingTask(null)}
-        onSave={(data) => {
-          updateMut.mutate({ id: editingTask.id, data });
-          setEditingTask(null);
-        }}
-        onArchive={() => {
-          archiveMut.mutate(editingTask.id);
-          setEditingTask(null);
-        }}
-      />
-    )}
     {renaming && (
       <ColumnRenameModal
         column={renaming}


### PR DESCRIPTION
## Summary
- normalize the task property filter button markup so its attributes stay attached to the button element
- replace the stale `propertyIdFilter` branch with the existing edit modal block to remove the undefined reference build error

## Testing
- npm install *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cbdab3b30c832cbf01a8dff2e30c0f