### PR TITLE
Adjust property action buttons layout

### DIFF
--- a/app/(app)/properties/[id]/components/ActionButtons.tsx
+++ b/app/(app)/properties/[id]/components/ActionButtons.tsx
@@ -17,7 +17,7 @@ function ActionButton({
   return (
     <Button
       type="button"
-      className={`h-9 whitespace-nowrap rounded-md px-4 text-sm font-semibold ${className}`}
+      className={`h-9 w-full whitespace-nowrap rounded-md px-4 text-sm font-semibold sm:flex-1 sm:w-auto ${className}`}
       {...props}
     >
       {children}
@@ -31,7 +31,7 @@ export default function ActionButtons({
   onUploadDocument,
 }: ActionButtonsProps) {
   return (
-    <div className="flex flex-wrap gap-2">
+    <div className="flex flex-col gap-2 sm:flex-row">
       <ActionButton
         onClick={onAddIncome}
         aria-label="Add Income"


### PR DESCRIPTION
## Summary
- align the property management action buttons in a horizontal row on wider viewports
- allow the buttons to expand evenly while stacking vertically on small screens to avoid overlap

## Testing
- npm install *(fails: npm registry returned 403 for @tanstack/react-query, preventing dependency installation)*
- ESLINT_USE_FLAT_CONFIG=false npm run lint *(fails: missing local eslint dependencies because install step could not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe9f14df4832c92d4266b8dd65266