### PR TITLE
Refine property action buttons sizing

### DIFF
--- a/app/(app)/properties/[id]/components/ActionButtons.tsx
+++ b/app/(app)/properties/[id]/components/ActionButtons.tsx
@@ -17,7 +17,7 @@ function ActionButton({
   return (
     <Button
       type="button"
-      className={`h-9 whitespace-nowrap rounded-md px-4 text-sm font-semibold ${className}`}
+      className={`h-9 w-full whitespace-nowrap rounded-md px-3 text-xs font-semibold sm:flex-1 sm:px-2 sm:text-xs ${className}`}
       {...props}
     >
       {children}
@@ -31,27 +31,27 @@ export default function ActionButtons({
   onUploadDocument,
 }: ActionButtonsProps) {
   return (
-    <div className="flex flex-wrap gap-2">
+    <div className="flex flex-col gap-2 sm:flex-row">
       <ActionButton
         onClick={onAddIncome}
         aria-label="Add Income"
         className="bg-green-600 text-white hover:bg-green-700"
       >
-        +Add Income
+        Add Income
       </ActionButton>
       <ActionButton
         onClick={onAddExpense}
         aria-label="Add Expense"
         className="bg-blue-600 text-white hover:bg-blue-700"
       >
-        +Add Expense
+        Add Expense
       </ActionButton>
       <ActionButton
         onClick={onUploadDocument}
         aria-label="Upload Document"
         className="bg-purple-600 text-white hover:bg-purple-700"
       >
-        +Upload Document
+        Upload Document
       </ActionButton>
     </div>
   );


### PR DESCRIPTION
## Summary
- shrink the property action buttons' padding and font size so they stay within the card boundaries
- update the action button labels to remove the leading plus sign while keeping title case wording

## Testing
- npm install *(fails: npm registry returned 403 for @tanstack/react-query, preventing dependency installation)*
- ESLINT_USE_FLAT_CONFIG=false npm run lint *(fails: missing @typescript-eslint/parser because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe9f14df4832c92d4266b8dd65266