### PR TITLE
Adjust property section navigation layout

### DIFF
--- a/app/(app)/properties/[id]/page.tsx
+++ b/app/(app)/properties/[id]/page.tsx
@@ -115,19 +115,20 @@ export default function PropertyPage() {
             onUploadDocument={() => setDocumentOpen(true)}
           />
         </div>
-        <section className="relative flex min-h-[32rem] flex-col rounded-lg border bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900">
-          <ScrollableSectionBar
-            tabs={TABS}
-            activeTab={resolvedTab}
-            onTabSelect={handleTabSelect}
-            className="pointer-events-none absolute left-0 right-0 top-0 z-10 -translate-y-1/2 px-4"
-          />
+        <section className="flex min-h-[32rem] flex-col rounded-lg border bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900">
+          <div className="flex-shrink-0 px-4 pb-4 pt-6 sm:px-6">
+            <ScrollableSectionBar
+              tabs={TABS}
+              activeTab={resolvedTab}
+              onTabSelect={handleTabSelect}
+            />
+          </div>
           <div
             role="tabpanel"
             id={`panel-${resolvedTab}`}
             aria-labelledby={`tab-${resolvedTab}`}
             tabIndex={0}
-            className="flex-1 overflow-auto px-4 pb-6 pt-16"
+            className="flex-1 overflow-auto px-4 pb-6 pt-6 sm:px-6"
           >
             {renderSection(resolvedTab)}
           </div>


### PR DESCRIPTION
## Summary
- place the property section navigation bar inside a fixed header area instead of floating it over the panel
- update the tab panel padding to align with the new header spacing

## Testing
- npm run lint *(fails: ESLint could not find configuration file in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf9991f30832c9cc8631c2d6c2e55