### PR TITLE
Hide floating property filter in property tasks view

### DIFF
--- a/components/tasks/TasksKanban.tsx
+++ b/components/tasks/TasksKanban.tsx
@@ -485,71 +485,72 @@ export default function TasksKanban({
           <span className="block w-full border rounded p-2 text-sm text-center">Archive</span>
         </Link>
       </div>
-      <div className="pointer-events-none fixed bottom-6 left-1/2 z-30 w-full -translate-x-1/2 px-4">
-        <div className="pointer-events-auto flex flex-col items-center gap-2">
-          <div
-            className="flex flex-wrap justify-center gap-2 rounded-full border border-gray-200 bg-white/90 px-4 py-2 shadow-lg backdrop-blur dark:border-gray-700 dark:bg-gray-900/90"
-            role="tablist"
-            aria-label="Task property filters"
-          >
-            {allowPropertySwitching && (
-              <button
-                type="button"
-                onClick={() => handlePropertySelect(undefined)}
-                className={tabClassName(!selectedPropertyId)}
-                aria-pressed={!selectedPropertyId}
+      {allowPropertySwitching && (
+        <>
+          <div className="pointer-events-none fixed bottom-6 left-1/2 z-30 w-full -translate-x-1/2 px-4">
+            <div className="pointer-events-auto flex flex-col items-center gap-2">
+              <div
+                className="flex flex-wrap justify-center gap-2 rounded-full border border-gray-200 bg-white/90 px-4 py-2 shadow-lg backdrop-blur dark:border-gray-700 dark:bg-gray-900/90"
+                role="tablist"
+                aria-label="Task property filters"
               >
-                All
-              </button>
-            )}
-            {visibleProperties.map((property) => {
-              const isActive = selectedPropertyId === property.id;
-              return (
                 <button
-                  key={property.id}
                   type="button"
-                  onClick={() => handlePropertySelect(property.id)}
-                  className={tabClassName(isActive)}
-                  aria-pressed={isActive}
-                  aria-disabled={!allowPropertySwitching}
+                  onClick={() => handlePropertySelect(undefined)}
+                  className={tabClassName(!selectedPropertyId)}
+                  aria-pressed={!selectedPropertyId}
                 >
-                  {property.address}
+                  All
                 </button>
-              );
-            })}
-            {showCaretButton && (
-              <button
-                type="button"
-                onClick={() => setPropertyModalOpen(true)}
-                className={caretButtonClassName}
-                aria-haspopup="dialog"
-                aria-expanded={isPropertyModalOpen}
-                title="Show all properties"
-                aria-label="Show all properties"
-              >
-                ^
-              </button>
-            )}
+                {visibleProperties.map((property) => {
+                  const isActive = selectedPropertyId === property.id;
+                  return (
+                    <button
+                      key={property.id}
+                      type="button"
+                      onClick={() => handlePropertySelect(property.id)}
+                      className={tabClassName(isActive)}
+                      aria-pressed={isActive}
+                    >
+                      {property.address}
+                    </button>
+                  );
+                })}
+                {showCaretButton && (
+                  <button
+                    type="button"
+                    onClick={() => setPropertyModalOpen(true)}
+                    className={caretButtonClassName}
+                    aria-haspopup="dialog"
+                    aria-expanded={isPropertyModalOpen}
+                    title="Show all properties"
+                    aria-label="Show all properties"
+                  >
+                    ^
+                  </button>
+                )}
+              </div>
+              {selectedPropertyId && activeProperty && (
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  Creating tasks for{" "}
+                  <span className="font-medium text-gray-700 dark:text-gray-200">
+                    {activeProperty.address}
+                  </span>
+                </p>
+              )}
+            </div>
           </div>
-          {selectedPropertyId && activeProperty && (
-            <p className="text-xs text-gray-500 dark:text-gray-400">
-              Creating tasks for{" "}
-              <span className="font-medium text-gray-700 dark:text-gray-200">
-                {activeProperty.address}
-              </span>
-            </p>
-          )}
-        </div>
-      </div>
 
-      <PropertySelectModal
-        open={isPropertyModalOpen}
-        onClose={() => setPropertyModalOpen(false)}
-        properties={propertyTabs}
-        selectedPropertyId={selectedPropertyId}
-        onSelect={handlePropertySelect}
-        allowAll={allowPropertySwitching}
-      />
+          <PropertySelectModal
+            open={isPropertyModalOpen}
+            onClose={() => setPropertyModalOpen(false)}
+            properties={propertyTabs}
+            selectedPropertyId={selectedPropertyId}
+            onSelect={handlePropertySelect}
+            allowAll={allowPropertySwitching}
+          />
+        </>
+      )}
 
       {editingTask && (
         <TaskEditModal


### PR DESCRIPTION
## Summary
- render the floating property filter controls only when property switching is enabled
- keep the property selection modal behind the same guard so property views without switching stay uncluttered

## Testing
- npm run lint *(fails: ESLint 9.34.0 requires eslint.config.js in this project)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0f795e8c832cba2edb4c433df3c2