### PR TITLE
Add analytics overview background artwork

### DIFF
--- a/app/(app)/analytics/page.tsx
+++ b/app/(app)/analytics/page.tsx
@@ -13,17 +13,24 @@ export default function AnalyticsPage() {
     <div className="flex h-full flex-col gap-6 p-6">
       <h1 className="text-2xl font-semibold">Analytics</h1>
       <div className="grid flex-1 gap-4 md:grid-cols-3 md:grid-rows-[repeat(2,minmax(0,1fr))]">
-        <div className="relative flex h-full flex-col gap-6 rounded-lg border bg-white/10 p-6 shadow-lg backdrop-blur dark:bg-gray-900/20 md:col-span-2 md:row-span-2">
+        <div
+          className="relative flex h-full flex-col gap-6 overflow-hidden rounded-lg border bg-cover bg-center bg-no-repeat p-6 shadow-lg backdrop-blur md:col-span-2 md:row-span-2"
+          style={{ backgroundImage: "url('/analytics-overview-bg.svg')" }}
+        >
+          <span
+            className="pointer-events-none absolute inset-0 z-0 bg-white/70 dark:bg-gray-900/60"
+            aria-hidden="true"
+          />
           <Link
             href="/analytics/overview"
-            className="absolute inset-0"
+            className="absolute inset-0 z-10"
             aria-label="Go to overview"
           />
-          <div className="pointer-events-none relative z-10">
+          <div className="pointer-events-none relative z-20">
             <span className="text-4xl font-bold md:text-5xl">Overview</span>
           </div>
           <div
-            className="relative z-10 mt-auto"
+            className="relative z-20 mt-auto"
             onClick={e => e.stopPropagation()}
           >
             <input

--- a/public/analytics-overview-bg.svg
+++ b/public/analytics-overview-bg.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" fill="#e5d9c3" />
+  <g fill="#263638">
+    <circle cx="234" cy="214" r="148" />
+    <path d="M288 124a140 140 0 0 0 0 180 140 140 0 0 0 0-180z" fill="#324548" />
+  </g>
+  <circle cx="256" cy="242" r="188" fill="none" stroke="#1f2c2e" stroke-width="6" opacity="0.8" />
+  <path d="M256 54v56" stroke="#1f2c2e" stroke-width="4" />
+  <path d="M182 86c36-36 88-44 132-24" fill="none" stroke="#1f2c2e" stroke-width="4" />
+  <path d="M272 256h132" stroke="#1f2c2e" stroke-width="4" />
+  <path d="M404 256l30-30" stroke="#1f2c2e" stroke-width="4" />
+  <path d="M404 256l30 30" stroke="#1f2c2e" stroke-width="4" />
+  <circle cx="440" cy="226" r="14" fill="#263638" />
+  <circle cx="440" cy="118" r="38" fill="none" stroke="#1f2c2e" stroke-width="4" opacity="0.6" />
+  <path d="M420 112c-20 0-36 16-36 36" fill="none" stroke="#1f2c2e" stroke-width="4" opacity="0.4" />
+  <g fill="#1f2c2e">
+    <rect x="78" y="332" width="24" height="96" />
+    <rect x="114" y="300" width="24" height="128" />
+    <rect x="150" y="270" width="24" height="158" />
+    <rect x="186" y="242" width="24" height="186" />
+  </g>
+  <path d="M364 370l70 120h-140z" fill="#d8c7a9" stroke="#1f2c2e" stroke-width="4" />
+  <circle cx="364" cy="436" r="12" fill="#1f2c2e" />
+  <g fill="#1f2c2e">
+    <circle cx="360" cy="174" r="6" />
+    <circle cx="384" cy="174" r="6" />
+    <circle cx="408" cy="174" r="6" />
+    <circle cx="360" cy="198" r="6" />
+    <circle cx="384" cy="198" r="6" />
+    <circle cx="408" cy="198" r="6" />
+    <circle cx="360" cy="222" r="6" />
+    <circle cx="384" cy="222" r="6" />
+    <circle cx="408" cy="222" r="6" />
+  </g>
+  <path d="M86 148l144 144" fill="none" stroke="#1f2c2e" stroke-width="4" />
+  <path d="M110 124l144 144" fill="none" stroke="#1f2c2e" stroke-width="4" />
+  <path d="M134 100l144 144" fill="none" stroke="#1f2c2e" stroke-width="4" />
+  <path d="M256 242l84-84" fill="none" stroke="#1f2c2e" stroke-width="4" opacity="0.5" />
+</svg>


### PR DESCRIPTION
## Summary
- add an abstract analytics illustration as a reusable SVG asset
- update the overview tile in analytics to display the new artwork with a soft overlay for readability

## Testing
- npm run lint *(fails: ESLint 9 expects eslint.config.js in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68cea44bd940832c8f3630c3931610b4