### PR TITLE
Add completion action and archive prompt to task cards

### DIFF
--- a/components/tasks/TaskCard.tsx
+++ b/components/tasks/TaskCard.tsx
@@ -6,10 +6,16 @@ export default function TaskCard({
   task,
   onClick,
   showProperties = true,
+  onComplete,
+  isCompleted,
+  isCompleting = false,
 }: {
   task: TaskDto;
   onClick?: () => void;
   showProperties?: boolean;
+  onComplete?: () => void | Promise<void>;
+  isCompleted?: boolean;
+  isCompleting?: boolean;
 }) {
   const REMINDER_DAYS = Number(
     process.env.NEXT_PUBLIC_TASK_REMINDER_DAYS ?? 1
@@ -35,15 +41,29 @@ export default function TaskCard({
       (startOfDue.getTime() - startOfToday.getTime()) / (1000 * 60 * 60 * 24);
     return diff === 1;
   })();
+  const completed =
+    typeof isCompleted === "boolean" ? isCompleted : task.status === "done";
+
   return (
     <div
-      className={`border rounded p-2 ${
+      className={`flex flex-col gap-2 rounded border p-2 ${
         onClick ? "cursor-pointer" : ""
       } ${dueSoon ? "border-yellow-500" : ""}`}
       onClick={onClick}
     >
-      <div className="font-medium">{task.title}</div>
-      <div className="mt-1 space-y-1 text-xs">
+      <div className="flex items-start justify-between gap-2">
+        <div className="font-medium">{task.title}</div>
+        {completed && (
+          <span className="inline-flex h-2.5 w-2.5 items-center justify-center">
+            <span
+              className="h-2.5 w-2.5 rounded-full bg-green-500"
+              aria-hidden
+            />
+            <span className="sr-only">Completed</span>
+          </span>
+        )}
+      </div>
+      <div className="space-y-1 text-xs">
         {task.vendor && <div>Vendor: {task.vendor.name}</div>}
         {showProperties &&
           task.properties.map((p) => (
@@ -61,6 +81,22 @@ export default function TaskCard({
           </div>
         )}
       </div>
+      {!completed && onComplete && (
+        <button
+          type="button"
+          className="mt-1 rounded bg-gray-900 px-3 py-1 text-xs font-semibold text-white hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-400 disabled:cursor-not-allowed disabled:bg-gray-500 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-gray-200"
+          onClick={(event) => {
+            event.stopPropagation();
+            if (isCompleting) return;
+            void Promise.resolve(onComplete()).catch((error) => {
+              console.error("Failed to complete task", error);
+            });
+          }}
+          disabled={isCompleting}
+        >
+          {isCompleting ? "Completing…" : "Complete Task"}
+        </button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add an optional completion button and visual indicator to task cards
- wire the Kanban board to call the completion API, display the new button, and ask about archiving
- reuse the existing archive mutation when the user chooses to archive immediately after completing a task

## Testing
- `npm run lint` *(fails: repository is still on the legacy ESLint config format)*
- `npm run test:unit` *(fails: vitest executable not found before dependencies can be installed)*
- `npm install` *(fails: registry access returns HTTP 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cea366c568832ca4e9d5f7f088206b