### PR TITLE
Add completion action and archive prompt to task cards

### DIFF
--- a/components/tasks/TaskCard.tsx
+++ b/components/tasks/TaskCard.tsx
@@ -6,10 +6,16 @@ export default function TaskCard({
   task,
   onClick,
   showProperties = true,
+  onComplete,
+  isCompleted,
+  isCompleting = false,
 }: {
   task: TaskDto;
   onClick?: () => void;
   showProperties?: boolean;
+  onComplete?: () => void | Promise<void>;
+  isCompleted?: boolean;
+  isCompleting?: boolean;
 }) {
   const REMINDER_DAYS = Number(
     process.env.NEXT_PUBLIC_TASK_REMINDER_DAYS ?? 1
@@ -35,15 +41,29 @@ export default function TaskCard({
       (startOfDue.getTime() - startOfToday.getTime()) / (1000 * 60 * 60 * 24);
     return diff === 1;
   })();
+  const completed =
+    typeof isCompleted === "boolean" ? isCompleted : task.status === "done";
+
   return (
     <div
-      className={`border rounded p-2 ${
+      className={`flex flex-col gap-2 rounded border p-2 ${
         onClick ? "cursor-pointer" : ""
       } ${dueSoon ? "border-yellow-500" : ""}`}
       onClick={onClick}
     >
-      <div className="font-medium">{task.title}</div>
-      <div className="mt-1 space-y-1 text-xs">
+      <div className="flex items-start justify-between gap-2">
+        <div className="font-medium">{task.title}</div>
+        {completed && (
+          <span className="inline-flex h-2.5 w-2.5 items-center justify-center">
+            <span
+              className="h-2.5 w-2.5 rounded-full bg-green-500"
+              aria-hidden
+            />
+            <span className="sr-only">Completed</span>
+          </span>
+        )}
+      </div>
+      <div className="space-y-1 text-xs">
         {task.vendor && <div>Vendor: {task.vendor.name}</div>}
         {showProperties &&
           task.properties.map((p) => (
@@ -61,6 +81,22 @@ export default function TaskCard({
           </div>
         )}
       </div>
+      {!completed && onComplete && (
+        <button
+          type="button"
+          className="mt-1 rounded bg-gray-900 px-3 py-1 text-xs font-semibold text-white hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-400 disabled:cursor-not-allowed disabled:bg-gray-500 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-gray-200"
+          onClick={(event) => {
+            event.stopPropagation();
+            if (isCompleting) return;
+            void Promise.resolve(onComplete()).catch((error) => {
+              console.error("Failed to complete task", error);
+            });
+          }}
+          disabled={isCompleting}
+        >
+          {isCompleting ? "Completing…" : "Complete Task"}
+        </button>
+      )}
     </div>
   );
 }

--- a/components/tasks/TasksKanban.tsx
+++ b/components/tasks/TasksKanban.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import Link from "next/link";
 import {
   DragDropContext,
@@ -16,6 +16,7 @@ import {
   archiveTask,
   listProperties,
   listVendors,
+  completeTask,
 } from "../../lib/api";
 import type { TaskDto } from "../../types/tasks";
 import type { PropertySummary } from "../../types/property";
@@ -139,6 +140,7 @@ export default function TasksKanban({
   const [columnsByProperty, setColumnsByProperty] = useState<ColumnMap>({});
   const [columnsLoaded, setColumnsLoaded] = useState(false);
   const [isPropertyModalOpen, setPropertyModalOpen] = useState(false);
+  const [statusOverrides, setStatusOverrides] = useState<Record<string, string>>({});
 
   useEffect(() => {
     if (initialPropertyId) {
@@ -284,6 +286,11 @@ export default function TasksKanban({
     mutationFn: (id: string) => archiveTask(id),
     onSuccess: () => qc.invalidateQueries({ queryKey: ["tasks"] }),
   });
+  const completeMut = useMutation({
+    mutationFn: (id: string) => completeTask(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["tasks"] }),
+  });
+  const [completingTaskId, setCompletingTaskId] = useState<string | null>(null);
   const [editingTask, setEditingTask] = useState<TaskDto | null>(null);
 
   const [menuColumn, setMenuColumn] = useState<string | null>(null);
@@ -311,6 +318,11 @@ export default function TasksKanban({
       destination.index === source.index
     )
       return;
+    setStatusOverrides((prev) => {
+      if (!prev[draggableId]) return prev;
+      const { [draggableId]: _removed, ...rest } = prev;
+      return rest;
+    });
     updateMut.mutate({ id: draggableId, data: { status: destination.droppableId } });
   };
 
@@ -331,6 +343,19 @@ export default function TasksKanban({
   };
 
   const deleteColumn = (id: string) => {
+    setStatusOverrides((prev) => {
+      if (!Object.keys(prev).length) return prev;
+      let changed = false;
+      const next: Record<string, string> = {};
+      Object.entries(prev).forEach(([taskId, columnId]) => {
+        if (columnId === id) {
+          changed = true;
+          return;
+        }
+        next[taskId] = columnId;
+      });
+      return changed ? next : prev;
+    });
     const remaining = columns.filter((column) => column.id !== id);
     const fallbackColumns = remaining.length ? remaining : createDefaultColumns();
     const fallback = fallbackColumns[0]?.id || "todo";
@@ -389,57 +414,164 @@ export default function TasksKanban({
 
   const showPropertiesOnCards = !selectedPropertyId;
 
+  useEffect(() => {
+    setStatusOverrides((prev) => {
+      if (!Object.keys(prev).length) return prev;
+      const validColumnIds = new Set(columns.map((column) => column.id));
+      let changed = false;
+      const next: Record<string, string> = {};
+
+      Object.entries(prev).forEach(([taskId, columnId]) => {
+        if (!validColumnIds.has(columnId)) {
+          changed = true;
+          return;
+        }
+        next[taskId] = columnId;
+      });
+
+      return changed ? next : prev;
+    });
+  }, [columns]);
+
+  useEffect(() => {
+    setStatusOverrides((prev) => {
+      if (!Object.keys(prev).length) return prev;
+      const next = { ...prev };
+      let changed = false;
+
+      tasks.forEach((task) => {
+        if (task.status !== "done" && next[task.id]) {
+          delete next[task.id];
+          changed = true;
+        }
+      });
+
+      return changed ? next : prev;
+    });
+  }, [tasks]);
+
+  const getDisplayStatus = useCallback(
+    (task: TaskDto) => {
+      const override = statusOverrides[task.id];
+      if (
+        override &&
+        columns.some((column) => column.id === override)
+      ) {
+        return override;
+      }
+      return task.status;
+    },
+    [statusOverrides, columns]
+  );
+
+  const tasksByColumn = useMemo(() => {
+    const grouped = new Map<string, TaskDto[]>();
+    tasks.forEach((task) => {
+      const status = getDisplayStatus(task);
+      const existing = grouped.get(status);
+      if (existing) {
+        existing.push(task);
+      } else {
+        grouped.set(status, [task]);
+      }
+    });
+    return grouped;
+  }, [tasks, getDisplayStatus]);
+
+  const handleCompleteTask = async (task: TaskDto) => {
+    if (completeMut.isPending) return;
+
+    const previousStatus = getDisplayStatus(task);
+    setCompletingTaskId(task.id);
+    try {
+      await completeMut.mutateAsync(task.id);
+    } catch (error) {
+      console.error("Failed to complete task", error);
+      setCompletingTaskId(null);
+      return;
+    }
+
+    const shouldArchive = window.confirm(
+      "Task completed. Would you like to archive it now?"
+    );
+    if (shouldArchive) {
+      try {
+        await archiveMut.mutateAsync(task.id);
+        setStatusOverrides((prev) => {
+          if (!prev[task.id]) return prev;
+          const { [task.id]: _omit, ...rest } = prev;
+          return rest;
+        });
+      } catch (error) {
+        console.error("Failed to archive task", error);
+        setStatusOverrides((prev) => ({
+          ...prev,
+          [task.id]: previousStatus,
+        }));
+      } finally {
+        setCompletingTaskId(null);
+      }
+      return;
+    }
+
+    setStatusOverrides((prev) => ({
+      ...prev,
+      [task.id]: previousStatus,
+    }));
+    setCompletingTaskId(null);
+  };
+
   return (
     <>
       <div className="flex gap-4 overflow-x-auto p-1 pb-32">
         <DragDropContext onDragEnd={handleDragEnd}>
-          {columns.map((col) => (
-            <div key={col.id} className="w-64 flex-shrink-0">
-              <div className="flex items-center justify-between mb-2">
-                <h2 className="font-semibold">{col.title}</h2>
-                <div className="relative">
-                  <button
-                    onClick={() =>
-                      setMenuColumn(menuColumn === col.id ? null : col.id)
-                    }
-                    className="px-1"
-                  >
-                    ⋯
-                  </button>
-                  {menuColumn === col.id && (
-                    <div className="absolute right-0 mt-1 w-28 rounded border bg-white shadow text-sm z-10 dark:bg-gray-800 dark:border-gray-700 dark:text-white">
-                      <button
-                        className="block w-full px-3 py-1 text-left hover:bg-gray-100 dark:hover:bg-gray-700"
-                        onClick={() => {
-                          setMenuColumn(null);
-                          setRenaming(col);
-                        }}
-                      >
-                        Edit
-                      </button>
-                      <button
-                        className="block w-full px-3 py-1 text-left text-red-500 hover:bg-gray-100 dark:text-red-400 dark:hover:bg-gray-700"
-                        onClick={() => {
-                          setMenuColumn(null);
-                          setDeleting(col);
-                        }}
-                      >
-                        Delete
-                      </button>
-                    </div>
-                  )}
+          {columns.map((col) => {
+            const columnTasks = tasksByColumn.get(col.id) ?? [];
+            return (
+              <div key={col.id} className="w-64 flex-shrink-0">
+                <div className="flex items-center justify-between mb-2">
+                  <h2 className="font-semibold">{col.title}</h2>
+                  <div className="relative">
+                    <button
+                      onClick={() =>
+                        setMenuColumn(menuColumn === col.id ? null : col.id)
+                      }
+                      className="px-1"
+                    >
+                      ⋯
+                    </button>
+                    {menuColumn === col.id && (
+                      <div className="absolute right-0 mt-1 w-28 rounded border bg-white shadow text-sm z-10 dark:bg-gray-800 dark:border-gray-700 dark:text-white">
+                        <button
+                          className="block w-full px-3 py-1 text-left hover:bg-gray-100 dark:hover:bg-gray-700"
+                          onClick={() => {
+                            setMenuColumn(null);
+                            setRenaming(col);
+                          }}
+                        >
+                          Edit
+                        </button>
+                        <button
+                          className="block w-full px-3 py-1 text-left text-red-500 hover:bg-gray-100 dark:text-red-400 dark:hover:bg-gray-700"
+                          onClick={() => {
+                            setMenuColumn(null);
+                            setDeleting(col);
+                          }}
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    )}
+                  </div>
                 </div>
-              </div>
-              <Droppable droppableId={col.id}>
-                {(provided) => (
-                  <div
-                    ref={provided.innerRef}
-                    {...provided.droppableProps}
-                    className="space-y-2"
-                  >
-                    {tasks
-                      .filter((t) => t.status === col.id)
-                      .map((task, idx) => (
+                <Droppable droppableId={col.id}>
+                  {(provided) => (
+                    <div
+                      ref={provided.innerRef}
+                      {...provided.droppableProps}
+                      className="space-y-2"
+                    >
+                      {columnTasks.map((task, idx) => (
                         <Draggable
                           key={task.id}
                           draggableId={task.id}
@@ -455,23 +587,34 @@ export default function TasksKanban({
                                 task={task}
                                 onClick={() => setEditingTask(task)}
                                 showProperties={showPropertiesOnCards}
+                                onComplete={
+                                  task.status !== "done"
+                                    ? () => handleCompleteTask(task)
+                                    : undefined
+                                }
+                                isCompleted={task.status === "done"}
+                                isCompleting={
+                                  completingTaskId === task.id &&
+                                  completeMut.isPending
+                                }
                               />
                             </div>
                           )}
                         </Draggable>
                       ))}
-                    {provided.placeholder}
-                    <TaskQuickNew
-                      onCreate={(title) =>
-                        createMut.mutate({ title, status: col.id })
-                      }
-                      placeholder={newTaskPlaceholder}
-                    />
-                  </div>
-                )}
-              </Droppable>
-            </div>
-          ))}
+                      {provided.placeholder}
+                      <TaskQuickNew
+                        onCreate={(title) =>
+                          createMut.mutate({ title, status: col.id })
+                        }
+                        placeholder={newTaskPlaceholder}
+                      />
+                    </div>
+                  )}
+                </Droppable>
+              </div>
+            );
+          })}
         </DragDropContext>
         <div className="w-64 flex-shrink-0">
           <button
@@ -563,6 +706,12 @@ export default function TasksKanban({
             setEditingTask(null);
           }}
           onArchive={() => {
+            setStatusOverrides((prev) => {
+              if (!editingTask) return prev;
+              if (!prev[editingTask.id]) return prev;
+              const { [editingTask.id]: _omit, ...rest } = prev;
+              return rest;
+            });
             archiveMut.mutate(editingTask.id);
             setEditingTask(null);
           }}


### PR DESCRIPTION
## Summary
- add an optional completion button and visual indicator to task cards
- wire the Kanban board to call the completion API, prompt for archiving, and keep unarchived completions in their original column while reusing the existing archive mutation

## Testing
- `npm run lint` *(fails: repository is still on the legacy ESLint config format)*
- `npm run test:unit` *(fails: vitest executable not found before dependencies can be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cea366c568832ca4e9d5f7f088206b