### PR TITLE
Update route progress to use navigation state

### DIFF
--- a/components/RouteProgress.tsx
+++ b/components/RouteProgress.tsx
@@ -1,17 +1,36 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { usePathname } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+import { useNavigation } from "next/navigation";
 
 export function RouteProgress() {
-  const path = usePathname();
+  const navigation = useNavigation();
   const [loading, setLoading] = useState(false);
+  const timeoutRef = useRef<number | undefined>();
 
   useEffect(() => {
-    setLoading(true);
-    const id = window.setTimeout(() => setLoading(false), 250);
-    return () => window.clearTimeout(id);
-  }, [path]);
+    if (navigation.state !== "idle") {
+      if (timeoutRef.current !== undefined) {
+        window.clearTimeout(timeoutRef.current);
+        timeoutRef.current = undefined;
+      }
+      if (!loading) {
+        setLoading(true);
+      }
+    } else if (loading) {
+      timeoutRef.current = window.setTimeout(() => {
+        setLoading(false);
+        timeoutRef.current = undefined;
+      }, 250);
+    }
+
+    return () => {
+      if (timeoutRef.current !== undefined) {
+        window.clearTimeout(timeoutRef.current);
+        timeoutRef.current = undefined;
+      }
+    };
+  }, [navigation.state, loading]);
 
   return (
     <div


### PR DESCRIPTION
## Summary
- watch the App Router navigation state instead of the pathname to drive the progress indicator
- keep the progress bar active until navigation settles while avoiding an initial load pulse

## Testing
- npm run lint *(fails: ESLint 9 in this environment requires eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68cf59b3fe98832c9ff4baf3b3a21dde