### PR TITLE
Restore analytics page layout height

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -9,5 +9,9 @@ export default function AppLayout({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const routeKey = pathname ?? "/";
 
-  return <PageTransition routeKey={routeKey}>{children}</PageTransition>;
+  return (
+    <PageTransition routeKey={routeKey} className="h-full">
+      {children}
+    </PageTransition>
+  );
 }


### PR DESCRIPTION
## Summary
- ensure the PageTransition wrapper fills the available height so analytics cards can stretch across the page

## Testing
- npm run lint *(fails: ESLint 9 requires eslint.config.js and repo still uses legacy configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68cf5dc89800832ca3317b73b49fffc3