### PR TITLE
Improve route progress navigation tracking

### DIFF
--- a/components/RouteProgress.tsx
+++ b/components/RouteProgress.tsx
@@ -1,36 +1,142 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { useNavigation } from "next/navigation";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+type RouterInstance = ReturnType<typeof useRouter>;
+type MutableRouterInstance = {
+  -readonly [Key in keyof RouterInstance]: RouterInstance[Key];
+};
 
 export function RouteProgress() {
-  const navigation = useNavigation();
-  const [loading, setLoading] = useState(false);
-  const timeoutRef = useRef<number | undefined>();
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const searchParamsKey = useMemo(
+    () => searchParams?.toString() ?? "",
+    [searchParams]
+  );
 
-  useEffect(() => {
-    if (navigation.state !== "idle") {
-      if (timeoutRef.current !== undefined) {
-        window.clearTimeout(timeoutRef.current);
-        timeoutRef.current = undefined;
-      }
-      if (!loading) {
-        setLoading(true);
-      }
-    } else if (loading) {
-      timeoutRef.current = window.setTimeout(() => {
-        setLoading(false);
-        timeoutRef.current = undefined;
-      }, 250);
+  const [loading, setLoading] = useState(false);
+  const isMountedRef = useRef(false);
+  const hasInitializedRef = useRef(false);
+  const hideTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+  const fallbackTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+
+  const clearHideTimeout = useCallback(() => {
+    if (hideTimeoutRef.current !== undefined) {
+      clearTimeout(hideTimeoutRef.current);
+      hideTimeoutRef.current = undefined;
+    }
+  }, []);
+
+  const clearFallbackTimeout = useCallback(() => {
+    if (fallbackTimeoutRef.current !== undefined) {
+      clearTimeout(fallbackTimeoutRef.current);
+      fallbackTimeoutRef.current = undefined;
+    }
+  }, []);
+
+  const startLoading = useCallback(() => {
+    if (!isMountedRef.current) {
+      return;
     }
 
+    clearHideTimeout();
+    clearFallbackTimeout();
+
+    setLoading(true);
+
+    fallbackTimeoutRef.current = window.setTimeout(() => {
+      setLoading(false);
+      fallbackTimeoutRef.current = undefined;
+    }, 10000);
+  }, [clearFallbackTimeout, clearHideTimeout]);
+
+  const finishLoading = useCallback(() => {
+    if (!isMountedRef.current) {
+      return;
+    }
+
+    clearFallbackTimeout();
+    clearHideTimeout();
+
+    hideTimeoutRef.current = window.setTimeout(() => {
+      setLoading(false);
+      hideTimeoutRef.current = undefined;
+    }, 250);
+  }, [clearFallbackTimeout, clearHideTimeout]);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+
     return () => {
-      if (timeoutRef.current !== undefined) {
-        window.clearTimeout(timeoutRef.current);
-        timeoutRef.current = undefined;
-      }
+      isMountedRef.current = false;
+      clearHideTimeout();
+      clearFallbackTimeout();
     };
-  }, [navigation.state, loading]);
+  }, [clearFallbackTimeout, clearHideTimeout]);
+
+  useEffect(() => {
+    if (!hasInitializedRef.current) {
+      hasInitializedRef.current = true;
+      return;
+    }
+
+    finishLoading();
+  }, [finishLoading, pathname, searchParamsKey]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const mutableRouter = router as MutableRouterInstance;
+
+    const wrap =
+      <Fn extends (...args: unknown[]) => unknown>(fn: Fn) =>
+      ((...args: Parameters<Fn>) => {
+        startLoading();
+
+        try {
+          const result = fn.apply(mutableRouter, args as Parameters<Fn>);
+
+          if (
+            result &&
+            typeof result === "object" &&
+            "catch" in result &&
+            typeof (result as Promise<unknown>).catch === "function"
+          ) {
+            (result as Promise<unknown>).catch(() => {
+              finishLoading();
+            });
+          }
+
+          return result;
+        } catch (error) {
+          finishLoading();
+          throw error;
+        }
+      }) as Fn;
+
+    const originalPush = mutableRouter.push;
+    const originalReplace = mutableRouter.replace;
+
+    mutableRouter.push = wrap(originalPush);
+    mutableRouter.replace = wrap(originalReplace);
+
+    const handlePopState = () => {
+      startLoading();
+    };
+
+    window.addEventListener("popstate", handlePopState);
+
+    return () => {
+      mutableRouter.push = originalPush;
+      mutableRouter.replace = originalReplace;
+      window.removeEventListener("popstate", handlePopState);
+    };
+  }, [finishLoading, router, startLoading]);
 
   return (
     <div


### PR DESCRIPTION
## Summary
- rework RouteProgress to memoize the query string, guard initial renders, and manage both hide and fallback timers for the loading animation
- hook into router push/replace calls and browser popstate events so the progress bar starts at navigation begin and always resets even when a transition aborts

## Testing
- npm run lint *(fails: ESLint configuration is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf5b7f707c832c9e2b034aaea89c13