### PR TITLE
Embed analytics builder background inline

### DIFF
--- a/app/(app)/analytics/builder-background.ts
+++ b/app/(app)/analytics/builder-background.ts
@@ -1,0 +1,1 @@
+export { ANALYTICS_BUILDER_BACKGROUND } from './builder/background-image';

--- a/app/(app)/analytics/page.tsx
+++ b/app/(app)/analytics/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useState } from 'react';
 
 import { ANALYTICS_OVERVIEW_BACKGROUND } from './overview-background';
+import { ANALYTICS_BUILDER_BACKGROUND } from './builder-background';
 
 // Landing page for the analytics section. Provides quick links to the
 // overview, custom analytics and builder areas, along with a placeholder for
@@ -16,16 +17,16 @@ export default function AnalyticsPage() {
       <h1 className="text-2xl font-semibold">Analytics</h1>
       <div className="grid flex-1 gap-4 md:grid-cols-3 md:grid-rows-[repeat(2,minmax(0,1fr))]">
         <div
-          className="group relative flex h-full flex-col gap-6 overflow-hidden rounded-lg border bg-cover bg-center bg-no-repeat p-6 shadow-lg transition-shadow duration-300 hover:shadow-2xl focus-within:shadow-2xl backdrop-blur md:col-span-2 md:row-span-2"
+          className="group relative flex h-full flex-col gap-6 overflow-hidden rounded-lg border bg-cover bg-center bg-no-repeat p-6 shadow-lg transition-shadow duration-300 ease-out hover:shadow-2xl focus-within:shadow-2xl backdrop-blur md:col-span-2 md:row-span-2"
           style={{ backgroundImage: `url(${ANALYTICS_OVERVIEW_BACKGROUND})` }}
         >
           <span
-            className="pointer-events-none absolute inset-0 z-0 bg-white opacity-70 transition-opacity duration-300 dark:bg-gray-900 dark:opacity-60 group-hover:opacity-40 group-focus-within:opacity-40 dark:group-hover:opacity-30 dark:group-focus-within:opacity-30"
+            className="pointer-events-none absolute inset-0 z-0 bg-white opacity-70 transition-opacity duration-300 ease-in-out dark:bg-gray-900 dark:opacity-60 group-hover:opacity-40 group-focus-within:opacity-40 dark:group-hover:opacity-30 dark:group-focus-within:opacity-30"
             aria-hidden="true"
           />
           <Link
             href="/analytics/overview"
-            className="absolute inset-0 z-10"
+            className="absolute inset-0 z-10 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent dark:focus-visible:ring-white/40"
             aria-label="Go to overview"
           />
           <div className="pointer-events-none relative z-20">
@@ -51,15 +52,20 @@ export default function AnalyticsPage() {
         </div>
         <Link
           href="/analytics/custom"
-          className="flex items-center justify-center rounded-lg border bg-white/10 p-6 text-2xl font-semibold shadow-lg transition-shadow duration-300 hover:shadow-2xl focus-visible:shadow-2xl backdrop-blur dark:bg-gray-900/20 md:col-start-3 md:row-start-1 md:h-full md:text-3xl"
+          className="flex items-center justify-center rounded-lg border bg-white/10 p-6 text-2xl font-semibold shadow-lg transition-shadow duration-300 ease-out hover:shadow-2xl focus-visible:shadow-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent dark:bg-gray-900/20 dark:focus-visible:ring-white/40 md:col-start-3 md:row-start-1 md:h-full md:text-3xl"
         >
           My Custom Analytics
         </Link>
         <Link
           href="/analytics/builder"
-          className="flex items-center justify-center rounded-lg border bg-white/10 p-6 text-2xl font-semibold shadow-lg transition-shadow duration-300 hover:shadow-2xl focus-visible:shadow-2xl backdrop-blur dark:bg-gray-900/20 md:col-start-3 md:row-start-2 md:h-full md:text-3xl"
+          className="group relative flex h-full flex-col justify-center gap-4 overflow-hidden rounded-lg border bg-cover bg-center bg-no-repeat p-6 text-2xl font-semibold shadow-lg transition-shadow duration-300 ease-out hover:shadow-2xl focus-visible:shadow-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent backdrop-blur dark:focus-visible:ring-white/40 md:col-start-3 md:row-start-2 md:h-full md:text-3xl"
+          style={{ backgroundImage: `url(${ANALYTICS_BUILDER_BACKGROUND})` }}
         >
-          Analytics Builder
+          <span
+            className="pointer-events-none absolute inset-0 z-0 bg-white opacity-70 transition-opacity duration-300 ease-in-out dark:bg-gray-900 dark:opacity-60 group-hover:opacity-40 group-focus-visible:opacity-40 dark:group-hover:opacity-30 dark:group-focus-visible:opacity-30"
+            aria-hidden="true"
+          />
+          <span className="relative z-10">Analytics Builder</span>
         </Link>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- re-export the builder background constant so the analytics card uses the inline base64 data URI
- drop the analytics builder PNG asset now that the background loads from code

## Testing
- `npm run lint` *(fails: ESLint 9 requires migrating to eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68cf600d4718832c9bd4114422e0cdb5