### PR TITLE
Add route transition skeletons

### DIFF
--- a/app/(app)/properties/[id]/page.tsx
+++ b/app/(app)/properties/[id]/page.tsx
@@ -6,7 +6,6 @@ import { useQuery } from "@tanstack/react-query";
 import { motion, useReducedMotion, type Variants } from "framer-motion";
 
 import { SharedTile } from "../../../../components/SharedTile";
-import Skeleton from "../../../../components/Skeleton";
 import IncomeForm from "../../../../components/IncomeForm";
 import ExpenseForm from "../../../../components/ExpenseForm";
 import DocumentUploadModal from "../../../../components/DocumentUploadModal";
@@ -26,6 +25,7 @@ import TenantCRM from "./sections/TenantCRM";
 import Inspections from "./sections/Inspections";
 import CreateListing from "./sections/CreateListing";
 import Vendors from "./sections/Vendors";
+import PropertyPageSkeleton from "../../../../components/skeletons/PropertyPageSkeleton";
 
 const TABS = [
   { id: "rent-ledger", label: "Rent Ledger" },
@@ -263,39 +263,3 @@ function PropertySummaryTile({ property }: { property: PropertySummary }) {
   );
 }
 
-function PropertyPageSkeleton() {
-  return (
-    <div className="space-y-6">
-      <div className="rounded-2xl border bg-white p-4 shadow-sm dark:border-gray-800 dark:bg-gray-900">
-        <Skeleton className="h-5 w-32" />
-        <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-3">
-          <Skeleton className="h-4 w-24" />
-          <Skeleton className="h-4 w-24" />
-          <Skeleton className="h-4 w-28" />
-        </div>
-      </div>
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,360px)_1fr] xl:grid-cols-[minmax(0,420px)_1fr]">
-        <div className="overflow-hidden rounded-lg border bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900">
-          <Skeleton className="h-48 w-full" />
-          <div className="space-y-3 p-6">
-            <Skeleton className="h-6 w-3/4" />
-            <Skeleton className="h-4 w-full" />
-            <Skeleton className="h-4 w-2/3" />
-            <Skeleton className="h-4 w-1/2" />
-          </div>
-        </div>
-        <div className="flex min-h-[32rem] flex-col overflow-hidden rounded-lg border bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900">
-          <div className="border-b border-gray-100 px-4 pb-1 pt-4 dark:border-gray-800 sm:px-6">
-            <Skeleton className="h-5 w-40" />
-          </div>
-          <div className="flex-1 space-y-3 overflow-hidden px-4 pb-6 pt-4 sm:px-6">
-            <Skeleton className="h-4 w-full" />
-            <Skeleton className="h-4 w-11/12" />
-            <Skeleton className="h-4 w-5/6" />
-            <Skeleton className="h-4 w-4/5" />
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}

--- a/app/(app)/tasks/page.tsx
+++ b/app/(app)/tasks/page.tsx
@@ -1,23 +1,49 @@
 "use client";
 
 import { useState } from "react";
+import { useIsFetching } from "@tanstack/react-query";
 import TasksKanban, {
   type TasksKanbanContext,
 } from "../../../components/tasks/TasksKanban";
 import Clock from "../../../components/Clock";
+import TasksSkeleton from "../../../components/skeletons/TasksSkeleton";
 
 export default function TasksPage() {
   const [activeProperty, setActiveProperty] =
     useState<TasksKanbanContext | null>(null);
   const title = activeProperty ? `Tasks: ${activeProperty.address}` : "Tasks";
+  const pendingCount = useIsFetching({
+    predicate: (query) => {
+      const [key] = query.queryKey;
+      if (typeof key !== "string") {
+        return false;
+      }
+      if (key !== "tasks" && key !== "properties") {
+        return false;
+      }
+      return query.state.status === "pending";
+    },
+  });
+  const isLoading = pendingCount > 0;
 
   return (
-    <div className="p-6 space-y-4">
-      <header className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold">{title}</h1>
-        <Clock className="text-2xl font-semibold" />
-      </header>
-      <TasksKanban onContextChange={setActiveProperty} />
+    <div className="relative">
+      {isLoading && (
+        <div className="pointer-events-none absolute inset-0 z-10 overflow-hidden bg-white/90 backdrop-blur-sm dark:bg-gray-950/70">
+          <TasksSkeleton />
+        </div>
+      )}
+      <div
+        className={`p-6 space-y-4 transition-opacity duration-200 ${
+          isLoading ? "opacity-0" : "opacity-100"
+        }`}
+      >
+        <header className="flex items-center justify-between">
+          <h1 className="text-2xl font-semibold">{title}</h1>
+          <Clock className="text-2xl font-semibold" />
+        </header>
+        <TasksKanban onContextChange={setActiveProperty} />
+      </div>
     </div>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 import Providers from './providers';
 import Sidebar from '../components/Sidebar';
 import TitleUpdater from '../components/TitleUpdater';
-import { RouteProgress } from '../components/RouteProgress';
+import { RouteTransitionProvider } from '../components/RouteProgress';
 
 export const metadata = { title: 'PropTech' };
 
@@ -12,12 +12,13 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <html lang="en" data-theme="light">
       <body className="min-h-screen">
         <Providers>
-          <RouteProgress />
-          <TitleUpdater />
-          <div className="flex h-screen overflow-hidden">
-            <Sidebar />
-            <main className="flex-1 overflow-y-auto">{children}</main>
-          </div>
+          <RouteTransitionProvider>
+            <TitleUpdater />
+            <div className="flex h-screen overflow-hidden">
+              <Sidebar />
+              <main className="flex-1 overflow-y-auto">{children}</main>
+            </div>
+          </RouteTransitionProvider>
         </Providers>
       </body>
     </html>

--- a/app/properties/page.tsx
+++ b/app/properties/page.tsx
@@ -3,30 +3,45 @@
 import { useQuery } from '@tanstack/react-query';
 import Link from 'next/link';
 import PropertyOverviewCard from '../../components/PropertyOverviewCard';
+import PropertiesGridSkeleton from '../../components/skeletons/PropertiesGridSkeleton';
 import { listProperties } from '../../lib/api';
 import type { PropertySummary } from '../../types/property';
 
 export default function PropertiesPage() {
-  const { data = [] } = useQuery<PropertySummary[]>({
+  const {
+    data = [],
+    isPending,
+  } = useQuery<PropertySummary[]>({
     queryKey: ['properties'],
     queryFn: listProperties,
   });
 
   return (
-    <div className="p-6 space-y-4">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold">Properties</h1>
-        <Link
-          href="/properties/new"
-          className="px-2 py-1 bg-blue-500 text-white"
-        >
-          Add Property
-        </Link>
-      </div>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {data.map((p) => (
-          <PropertyOverviewCard key={p.id} property={p} />
-        ))}
+    <div className="relative">
+      {isPending && (
+        <div className="pointer-events-none absolute inset-0 z-10 overflow-hidden bg-white/90 backdrop-blur-sm dark:bg-gray-950/70">
+          <PropertiesGridSkeleton />
+        </div>
+      )}
+      <div
+        className={`p-6 space-y-4 transition-opacity duration-200 ${
+          isPending ? 'opacity-0' : 'opacity-100'
+        }`}
+      >
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-semibold">Properties</h1>
+          <Link
+            href="/properties/new"
+            className="px-2 py-1 bg-blue-500 text-white"
+          >
+            Add Property
+          </Link>
+        </div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {data.map((p) => (
+            <PropertyOverviewCard key={p.id} property={p} />
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/components/PageTransition.tsx
+++ b/components/PageTransition.tsx
@@ -3,6 +3,9 @@
 import type { ReactNode } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 
+import { useRouteTransition } from "./RouteProgress";
+import { getRouteSkeleton } from "./skeletons";
+
 interface PageTransitionProps {
   children: ReactNode;
   routeKey: string;
@@ -11,6 +14,8 @@ interface PageTransitionProps {
 
 export default function PageTransition({ children, routeKey, className }: PageTransitionProps) {
   const reduceMotion = useReducedMotion();
+  const { isNavigating, targetPath } = useRouteTransition();
+  const skeleton = getRouteSkeleton(targetPath ?? routeKey);
 
   const animationProps = reduceMotion
     ? {
@@ -24,11 +29,36 @@ export default function PageTransition({ children, routeKey, className }: PageTr
         exit: { opacity: 0, transition: { duration: 0.1, ease: "easeIn" } },
       };
 
+  const skeletonMotion = reduceMotion
+    ? {
+        initial: { opacity: 1 },
+        animate: { opacity: 1 },
+        exit: { opacity: 1 },
+      }
+    : {
+        initial: { opacity: 0 },
+        animate: { opacity: 1, transition: { duration: 0.12, ease: "easeOut" } },
+        exit: { opacity: 0, transition: { duration: 0.12, ease: "easeIn" } },
+      };
+
   return (
-    <AnimatePresence mode="wait">
-      <motion.div key={routeKey} {...animationProps} className={className}>
-        {children}
-      </motion.div>
-    </AnimatePresence>
+    <div className="relative">
+      <AnimatePresence mode="wait">
+        <motion.div key={routeKey} {...animationProps} className={className}>
+          {children}
+        </motion.div>
+      </AnimatePresence>
+      <AnimatePresence>
+        {isNavigating && skeleton ? (
+          <motion.div
+            key="route-skeleton"
+            {...skeletonMotion}
+            className="pointer-events-none absolute inset-0 z-40 overflow-hidden bg-white/90 backdrop-blur-sm dark:bg-gray-950/70"
+          >
+            <div className="pointer-events-none overflow-y-auto">{skeleton}</div>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
+    </div>
   );
 }

--- a/components/RouteProgress.tsx
+++ b/components/RouteProgress.tsx
@@ -1,37 +1,52 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { useNavigation } from "next/navigation";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { usePathname, useSearchParams } from "next/navigation";
 
-export function RouteProgress() {
-  const navigation = useNavigation();
-  const [loading, setLoading] = useState(false);
-  const timeoutRef = useRef<number | undefined>();
+interface RouteTransitionContextValue {
+  isNavigating: boolean;
+  targetPath: string | null;
+}
 
-  useEffect(() => {
-    if (navigation.state !== "idle") {
-      if (timeoutRef.current !== undefined) {
-        window.clearTimeout(timeoutRef.current);
-        timeoutRef.current = undefined;
-      }
-      if (!loading) {
-        setLoading(true);
-      }
-    } else if (loading) {
-      timeoutRef.current = window.setTimeout(() => {
-        setLoading(false);
-        timeoutRef.current = undefined;
-      }, 250);
-    }
+const RouteTransitionContext = createContext<RouteTransitionContextValue>({
+  isNavigating: false,
+  targetPath: null,
+});
 
-    return () => {
-      if (timeoutRef.current !== undefined) {
-        window.clearTimeout(timeoutRef.current);
-        timeoutRef.current = undefined;
-      }
-    };
-  }, [navigation.state, loading]);
+export function useRouteTransition() {
+  return useContext(RouteTransitionContext);
+}
 
+export function RouteTransitionProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const manager = useRouteTransitionManager();
+
+  return (
+    <RouteTransitionContext.Provider
+      value={{
+        isNavigating: manager.loading,
+        targetPath: manager.targetPath,
+      }}
+    >
+      {children}
+      <RouteProgressBar loading={manager.loading} />
+    </RouteTransitionContext.Provider>
+  );
+}
+
+function RouteProgressBar({ loading }: { loading: boolean }) {
   return (
     <div
       aria-hidden
@@ -42,4 +57,160 @@ export function RouteProgress() {
       />
     </div>
   );
+}
+
+function resolveTargetPath(url: Parameters<History["pushState"]>[2]): string | null {
+  if (!url) {
+    return null;
+  }
+
+  if (typeof url === "string") {
+    try {
+      const parsed = new URL(
+        url,
+        typeof window === "undefined" ? "http://localhost" : window.location.href
+      );
+      return `${parsed.pathname}${parsed.search}`;
+    } catch {
+      return url.startsWith("/") ? url : `/${url}`;
+    }
+  }
+
+  try {
+    const parsed = new URL(url.toString(), window.location.href);
+    return `${parsed.pathname}${parsed.search}`;
+  } catch {
+    return null;
+  }
+}
+
+function useRouteTransitionManager() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const searchParamsKey = useMemo(
+    () => searchParams?.toString() ?? "",
+    [searchParams]
+  );
+
+  const [loading, setLoading] = useState(false);
+  const [targetPath, setTargetPath] = useState<string | null>(null);
+  const isMountedRef = useRef(false);
+  const hasInitializedRef = useRef(false);
+  const hideTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+  const fallbackTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+
+  const clearHideTimeout = useCallback(() => {
+    if (hideTimeoutRef.current !== undefined) {
+      clearTimeout(hideTimeoutRef.current);
+      hideTimeoutRef.current = undefined;
+    }
+  }, []);
+
+  const clearFallbackTimeout = useCallback(() => {
+    if (fallbackTimeoutRef.current !== undefined) {
+      clearTimeout(fallbackTimeoutRef.current);
+      fallbackTimeoutRef.current = undefined;
+    }
+  }, []);
+
+  const startLoading = useCallback(
+    (nextPath?: string | null) => {
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      clearHideTimeout();
+      clearFallbackTimeout();
+
+      if (nextPath) {
+        setTargetPath(nextPath);
+      }
+
+      setLoading(true);
+
+      fallbackTimeoutRef.current = window.setTimeout(() => {
+        setLoading(false);
+        setTargetPath(null);
+        fallbackTimeoutRef.current = undefined;
+      }, 10000);
+    },
+    [clearFallbackTimeout, clearHideTimeout]
+  );
+
+  const finishLoading = useCallback(() => {
+    if (!isMountedRef.current) {
+      return;
+    }
+
+    clearFallbackTimeout();
+    clearHideTimeout();
+
+    hideTimeoutRef.current = window.setTimeout(() => {
+      setLoading(false);
+      setTargetPath(null);
+      hideTimeoutRef.current = undefined;
+    }, 250);
+  }, [clearFallbackTimeout, clearHideTimeout]);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+      clearHideTimeout();
+      clearFallbackTimeout();
+    };
+  }, [clearFallbackTimeout, clearHideTimeout]);
+
+  useEffect(() => {
+    if (!hasInitializedRef.current) {
+      hasInitializedRef.current = true;
+      return;
+    }
+
+    finishLoading();
+  }, [finishLoading, pathname, searchParamsKey]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const { history } = window;
+
+    const wrap =
+      <Fn extends History["pushState"] | History["replaceState"]>(fn: Fn) =>
+      function wrapped(this: History, ...args: Parameters<Fn>) {
+        const nextPath = resolveTargetPath(args[2]);
+        startLoading(nextPath);
+
+        try {
+          return fn.apply(this, args as Parameters<Fn>);
+        } catch (error) {
+          finishLoading();
+          throw error;
+        }
+      } as Fn;
+
+    const originalPushState = history.pushState;
+    const originalReplaceState = history.replaceState;
+
+    history.pushState = wrap(originalPushState);
+    history.replaceState = wrap(originalReplaceState);
+
+    const handlePopState = () => {
+      const next = `${window.location.pathname}${window.location.search}`;
+      startLoading(next);
+    };
+
+    window.addEventListener("popstate", handlePopState);
+
+    return () => {
+      history.pushState = originalPushState;
+      history.replaceState = originalReplaceState;
+      window.removeEventListener("popstate", handlePopState);
+    };
+  }, [finishLoading, startLoading]);
+
+  return { loading, targetPath };
 }

--- a/components/skeletons/AnalyticsSkeleton.tsx
+++ b/components/skeletons/AnalyticsSkeleton.tsx
@@ -1,0 +1,36 @@
+import Skeleton from "../Skeleton";
+
+export default function AnalyticsSkeleton() {
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-8 w-48" />
+      </div>
+      <div className="grid gap-4 md:grid-cols-3 md:grid-rows-[repeat(2,minmax(0,1fr))]">
+        <div className="relative flex flex-col gap-4 overflow-hidden rounded-lg border bg-white/70 p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900/70 md:col-span-2 md:row-span-2">
+          <Skeleton className="h-10 w-40" />
+          <div className="space-y-3">
+            <Skeleton className="h-4 w-3/5" />
+            <Skeleton className="h-4 w-2/3" />
+            <Skeleton className="h-4 w-1/2" />
+          </div>
+          <div className="mt-auto space-y-2">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-4 w-1/3" />
+          </div>
+        </div>
+        <div className="rounded-lg border bg-white/70 p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900/70">
+          <Skeleton className="h-6 w-32" />
+          <Skeleton className="mt-4 h-4 w-3/4" />
+          <Skeleton className="mt-2 h-4 w-2/3" />
+        </div>
+        <div className="rounded-lg border bg-white/70 p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900/70">
+          <Skeleton className="h-6 w-32" />
+          <Skeleton className="mt-4 h-4 w-3/4" />
+          <Skeleton className="mt-2 h-4 w-2/3" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/skeletons/PropertiesGridSkeleton.tsx
+++ b/components/skeletons/PropertiesGridSkeleton.tsx
@@ -1,0 +1,25 @@
+import Skeleton from "../Skeleton";
+
+export default function PropertiesGridSkeleton() {
+  return (
+    <div className="space-y-4 p-6">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-8 w-32" />
+      </div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, index) => (
+          <div
+            key={index}
+            className="rounded-2xl border bg-white p-4 shadow-sm dark:border-gray-800 dark:bg-gray-900"
+          >
+            <Skeleton className="h-40 w-full rounded-xl" />
+            <Skeleton className="mt-4 h-5 w-3/4" />
+            <Skeleton className="mt-2 h-4 w-1/2" />
+            <Skeleton className="mt-2 h-4 w-2/3" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/skeletons/PropertyPageSkeleton.tsx
+++ b/components/skeletons/PropertyPageSkeleton.tsx
@@ -1,0 +1,57 @@
+import Skeleton from "../Skeleton";
+
+export default function PropertyPageSkeleton() {
+  return (
+    <div className="space-y-6 p-6">
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,360px)_1fr] xl:grid-cols-[minmax(0,420px)_1fr]">
+        <div className="lg:col-span-2 rounded-2xl border bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div className="space-y-2">
+              <Skeleton className="h-8 w-64" />
+              <Skeleton className="h-4 w-40" />
+              <Skeleton className="h-4 w-32" />
+            </div>
+            <div className="grid grid-cols-3 gap-4">
+              {Array.from({ length: 3 }).map((_, index) => (
+                <div key={index} className="space-y-2">
+                  <Skeleton className="h-3 w-12" />
+                  <Skeleton className="h-5 w-16" />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+        <div className="rounded-2xl border bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+          <Skeleton className="h-48 w-full rounded-xl" />
+          <div className="mt-4 space-y-2">
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-4 w-1/2" />
+            <Skeleton className="h-4 w-2/3" />
+          </div>
+          <div className="mt-6 grid grid-cols-2 gap-2">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+          </div>
+        </div>
+        <div className="rounded-2xl border bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+          <div className="flex gap-3 overflow-x-auto">
+            {Array.from({ length: 6 }).map((_, index) => (
+              <Skeleton key={index} className="h-9 w-24 rounded-full" />
+            ))}
+          </div>
+          <div className="mt-4 space-y-3">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <div key={index} className="rounded-xl border bg-white p-4 shadow-sm dark:border-gray-800 dark:bg-gray-900/80">
+                <Skeleton className="h-4 w-1/2" />
+                <Skeleton className="mt-2 h-4 w-3/4" />
+                <Skeleton className="mt-2 h-3 w-2/3" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/skeletons/TasksSkeleton.tsx
+++ b/components/skeletons/TasksSkeleton.tsx
@@ -1,0 +1,42 @@
+import Skeleton from "../Skeleton";
+
+export default function TasksSkeleton() {
+  const columns = ["ASAP", "Soon", "Later", "Done"];
+
+  return (
+    <div className="p-6">
+      <div className="flex h-full flex-col gap-4">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-8 w-64" />
+          <Skeleton className="h-8 w-24" />
+        </div>
+        <div className="flex gap-4 overflow-x-auto p-1 pb-32">
+          {columns.map((title) => (
+            <div key={title} className="w-64 flex-shrink-0">
+              <Skeleton className="h-6 w-32" />
+            <div className="mt-4 space-y-3">
+              {Array.from({ length: 3 }).map((_, cardIndex) => (
+                <div
+                  key={cardIndex}
+                  className="rounded-lg border bg-white p-3 shadow-sm dark:border-gray-800 dark:bg-gray-900"
+                >
+                  <Skeleton className="h-4 w-3/4" />
+                  <Skeleton className="mt-2 h-3 w-2/3" />
+                  <Skeleton className="mt-2 h-3 w-1/2" />
+                </div>
+              ))}
+              <Skeleton className="h-10 w-full" />
+            </div>
+          </div>
+        ))}
+          <div className="w-64 flex-shrink-0">
+            <Skeleton className="h-12 w-full" />
+          </div>
+          <div className="w-64 flex-shrink-0">
+            <Skeleton className="h-12 w-full" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/skeletons/index.tsx
+++ b/components/skeletons/index.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from "react";
+
+import AnalyticsSkeleton from "./AnalyticsSkeleton";
+import PropertiesGridSkeleton from "./PropertiesGridSkeleton";
+import PropertyPageSkeleton from "./PropertyPageSkeleton";
+import TasksSkeleton from "./TasksSkeleton";
+
+function normalizePath(path: string): string {
+  try {
+    const url = new URL(path, typeof window === "undefined" ? "http://localhost" : window.location.origin);
+    return url.pathname;
+  } catch {
+    const cleaned = path.split(/[?#]/)[0] ?? path;
+    return cleaned.startsWith("/") ? cleaned : `/${cleaned}`;
+  }
+}
+
+export function getRouteSkeleton(path: string | null | undefined): ReactNode | null {
+  if (!path) {
+    return null;
+  }
+
+  const pathname = normalizePath(path);
+
+  if (pathname.startsWith("/analytics")) {
+    return <AnalyticsSkeleton />;
+  }
+
+  if (pathname.startsWith("/tasks")) {
+    return <TasksSkeleton />;
+  }
+
+  if (pathname === "/properties") {
+    return <PropertiesGridSkeleton />;
+  }
+
+  if (pathname.startsWith("/properties/")) {
+    return <PropertyPageSkeleton />;
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- wrap the layout in a new route transition provider so the progress bar and page transitions share navigation state
- surface route-specific skeleton overlays during transitions using new analytics, tasks and property placeholders
- show the same skeletons while tasks and properties data hydrate to avoid blank states on initial render

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf5b7f707c832c9e2b034aaea89c13