### PR TITLE
Ensure analytics cards stretch to the viewport

### DIFF
--- a/components/PageTransition.tsx
+++ b/components/PageTransition.tsx
@@ -42,7 +42,7 @@ export default function PageTransition({ children, routeKey, className }: PageTr
       };
 
   return (
-    <div className="relative">
+    <div className="relative h-full">
       <AnimatePresence mode="wait">
         <motion.div key={routeKey} {...animationProps} className={className}>
           {children}


### PR DESCRIPTION
## Summary
- ensure the page transition wrapper spans the full height so analytics cards can fill the viewport

## Testing
- npm install *(fails: 403 Forbidden when fetching @tanstack/react-query)*

------
https://chatgpt.com/codex/tasks/task_e_68cf745531f0832c95f767d213596a49