### PR TITLE
Remove background image from analytics builder page

### DIFF
--- a/app/(app)/analytics/builder/page.tsx
+++ b/app/(app)/analytics/builder/page.tsx
@@ -15,7 +15,6 @@ import VizSpreadsheet from '../components/VizSpreadsheet';
 import { AnalyticsState, AnalyticsStateType } from '../../../../lib/schemas';
 import { useUrlState } from '../../../../lib/urlState';
 import { useSeries } from '../../../../hooks/useAnalytics';
-import { ANALYTICS_BUILDER_BACKGROUND } from './background-image';
 
 const now = new Date();
 const defaultState = AnalyticsState.parse({
@@ -63,10 +62,7 @@ export default function AnalyticsBuilderPage() {
   }
 
   return (
-    <div
-      className="flex min-h-screen w-full bg-cover bg-center bg-no-repeat"
-      style={{ backgroundImage: `url(${ANALYTICS_BUILDER_BACKGROUND})` }}
-    >
+    <div className="flex min-h-screen w-full">
       <div className="flex-1 p-6 space-y-4">
         <div className="flex items-center gap-2 mb-4 mt-2">
           <Link href="/analytics" className="text-blue-600 hover:underline">


### PR DESCRIPTION
## Summary
- remove the background image styling from the analytics builder page container so it inherits the default system background color

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd30c9108832cae9a73e6a620cd24