### PR TITLE
Adjust property layout column widths

### DIFF
--- a/app/(app)/properties/[id]/page.tsx
+++ b/app/(app)/properties/[id]/page.tsx
@@ -175,7 +175,7 @@ export default function PropertyPage() {
         {property && (
           <div className="space-y-6">
             <motion.section
-              className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,360px)_1fr] xl:grid-cols-[minmax(0,420px)_1fr]"
+              className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(400px,440px)_minmax(0,1fr)] xl:grid-cols-[minmax(460px,520px)_minmax(0,1fr)]"
               {...listMotionProps}
             >
               <motion.div className="lg:col-span-2" {...itemMotionProps}>


### PR DESCRIPTION
## Summary
- widen the property details column on the property page at large breakpoints so its contents remain visible
- keep the tabbed content pane flexible so it gives up space before collapsing the property details card

## Testing
- ESLINT_USE_FLAT_CONFIG=false npm run lint *(fails: missing local dependencies; npm install blocked by 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd91d8c18832c9277c3fefa88bff4