### PR TITLE
Rebalance property layout columns

### DIFF
--- a/app/(app)/properties/[id]/page.tsx
+++ b/app/(app)/properties/[id]/page.tsx
@@ -175,7 +175,7 @@ export default function PropertyPage() {
         {property && (
           <div className="space-y-6">
             <motion.section
-              className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,360px)_1fr] xl:grid-cols-[minmax(0,420px)_1fr]"
+              className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(360px,420px)_minmax(0,1fr)] xl:grid-cols-[minmax(360px,440px)_minmax(0,1fr)]"
               {...listMotionProps}
             >
               <motion.div className="lg:col-span-2" {...itemMotionProps}>


### PR DESCRIPTION
## Summary
- keep the property page layout’s large-screen left column between 360–440px so the action buttons stay visible without pushing the feature tabs off-screen

## Testing
- ESLINT_USE_FLAT_CONFIG=false npm run lint *(fails: missing local dependency `@typescript-eslint/parser`)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd91d8c18832c9277c3fefa88bff4