### PR TITLE
Fix stuck route transitions when navigating to other features

### DIFF
--- a/components/RouteProgress.tsx
+++ b/components/RouteProgress.tsx
@@ -12,6 +12,8 @@ import {
 } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 
+import { normalizePath } from "./skeletons";
+
 interface RouteTransitionContextValue {
   isNavigating: boolean;
   targetPath: string | null;
@@ -122,8 +124,24 @@ function useRouteTransitionManager() {
       clearHideTimeout();
       clearFallbackTimeout();
 
-      if (nextPath) {
-        setTargetPath(nextPath);
+      const resolvedPath = nextPath ? resolveTargetPath(nextPath) : null;
+
+      if (resolvedPath && typeof window !== "undefined") {
+        const currentPath = `${window.location.pathname}${window.location.search}`;
+        const normalizedCurrent = normalizePath(currentPath);
+        const normalizedNext = normalizePath(resolvedPath);
+
+        if (normalizedCurrent === normalizedNext) {
+          setLoading(false);
+          setTargetPath(null);
+          return;
+        }
+      }
+
+      if (resolvedPath) {
+        setTargetPath(resolvedPath);
+      } else {
+        setTargetPath(null);
       }
 
       setLoading(true);


### PR DESCRIPTION
## Summary
- normalize captured target paths in the route transition manager
- skip starting a navigation state when the requested URL matches the current location to avoid a stuck loading overlay

## Testing
- npm run lint *(fails: ESLint 9 requires an `eslint.config.js` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0c3169580832c900cb6379bc61362