### PR TITLE
Add other income section to property details

### DIFF
--- a/app/(app)/properties/[id]/page.tsx
+++ b/app/(app)/properties/[id]/page.tsx
@@ -17,6 +17,7 @@ import PropertyHero from "./components/PropertyHero";
 import ScrollableSectionBar, { type SectionTab } from "./components/ScrollableSectionBar";
 import RentLedger from "./sections/RentLedger";
 import Expenses from "./sections/Expenses";
+import OtherIncome from "./sections/OtherIncome";
 import Documents from "./sections/Documents";
 import RentReview from "./sections/RentReview";
 import KeyDates from "./sections/KeyDates";
@@ -30,6 +31,7 @@ import PropertyPageSkeleton from "../../../../components/skeletons/PropertyPageS
 const TABS = [
   { id: "rent-ledger", label: "Rent Ledger" },
   { id: "expenses", label: "Expenses" },
+  { id: "other-income", label: "Other Income" },
   { id: "documents", label: "Documents" },
   { id: "tasks", label: "Tasks" },
   { id: "rent-review", label: "Rent Review" },
@@ -135,6 +137,8 @@ export default function PropertyPage() {
         return <RentLedger propertyId={id} />;
       case "expenses":
         return <Expenses propertyId={id} />;
+      case "other-income":
+        return <OtherIncome propertyId={id} />;
       case "documents":
         return <Documents propertyId={id} />;
       case "tasks":

--- a/app/(app)/properties/[id]/sections/OtherIncome.tsx
+++ b/app/(app)/properties/[id]/sections/OtherIncome.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import IncomesTable from "../../../../../components/IncomesTable";
+
+interface OtherIncomeProps {
+  propertyId: string;
+}
+
+const CORE_RENT_CATEGORIES = [
+  "Base rent",
+  "Rent",
+  "Rent payment",
+  "Core rent",
+];
+
+export default function OtherIncome({ propertyId }: OtherIncomeProps) {
+  return (
+    <div className="space-y-4">
+      <IncomesTable
+        propertyId={propertyId}
+        excludeCategories={CORE_RENT_CATEGORIES}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add an Other Income tab alongside the existing property detail sections
- display non-rent income via a new OtherIncome section that reuses the incomes table
- enhance the incomes table with category exclusions, dark theme styling, and an empty state message

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config.* file in this repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d0c38325c8832c8340985be6706599