### PR TITLE
Add receipt upload to expenses

### DIFF
--- a/app/api/expenses/[id]/receipt/route.ts
+++ b/app/api/expenses/[id]/receipt/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from 'next/server';
+import { writeFile, mkdir } from 'fs/promises';
+import { join } from 'path';
+import { randomUUID } from 'crypto';
+import { expenses } from '../../../store';
+import { prisma } from '../../../../../lib/prisma';
+
+const MAX_RECEIPT_MB = Number(process.env.MAX_UPLOAD_MB ?? 5);
+const ALLOWED_RECEIPT_TYPES = ['image/jpeg', 'image/png', 'application/pdf'];
+
+export async function POST(req: Request, { params }: { params: { id: string } }) {
+  try {
+    const form = await req.formData();
+    const file = form.get('receipt');
+
+    if (!file || !(file instanceof File)) {
+      return NextResponse.json({ error: 'Receipt file is required' }, { status: 400 });
+    }
+
+    if (!ALLOWED_RECEIPT_TYPES.includes(file.type)) {
+      return NextResponse.json({ error: 'Unsupported file type' }, { status: 400 });
+    }
+
+    const sizeMb = file.size / (1024 * 1024);
+    if (sizeMb > MAX_RECEIPT_MB) {
+      return NextResponse.json({ error: 'File too large' }, { status: 400 });
+    }
+
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const extension = file.name.includes('.') ? `.${file.name.split('.').pop()}` : '';
+    const filename = `${params.id}-${randomUUID()}${extension}`;
+    const dir = join(process.cwd(), 'public', 'uploads', 'receipts');
+
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, filename), buffer);
+
+    const url = `/uploads/receipts/${filename}`;
+
+    if (process.env.MOCK_MODE === 'true') {
+      const expense = expenses.find((e) => e.id === params.id);
+      if (!expense) {
+        return NextResponse.json({ error: 'Expense not found' }, { status: 404 });
+      }
+      expense.receiptUrl = url;
+    } else {
+      const record = await (prisma as any).mockData.findUnique({ where: { id: params.id } });
+      if (!record || record.type !== 'expense') {
+        return NextResponse.json({ error: 'Expense not found' }, { status: 404 });
+      }
+      const data = { ...record.data, receiptUrl: url };
+      await (prisma as any).mockData.update({
+        where: { id: params.id },
+        data: { data },
+      });
+    }
+
+    return NextResponse.json({ url });
+  } catch (err) {
+    return NextResponse.json({ error: 'Invalid multipart payload' }, { status: 400 });
+  }
+}

--- a/components/ExpensesTable.tsx
+++ b/components/ExpensesTable.tsx
@@ -144,7 +144,20 @@ export default function ExpensesTable({
                 <td className="p-2">{r.amount}</td>
                 <td className="p-2">{r.gst}</td>
                 <td className="p-2">{r.notes}</td>
-                <td className="p-2">{r.receiptUrl && <span>📎</span>}</td>
+                <td className="p-2">
+                  {r.receiptUrl ? (
+                    <a
+                      href={r.receiptUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-600 underline dark:text-blue-300"
+                    >
+                      View
+                    </a>
+                  ) : (
+                    <span className="text-gray-500 dark:text-gray-400">—</span>
+                  )}
+                </td>
                 <td className="p-2">
                   <button
                     className="text-red-600 underline dark:text-red-400"


### PR DESCRIPTION
## Summary
- add receipt file input to the expense form and upload it after creating an expense
- store uploaded receipt files on the server and persist the receipt URL on each expense
- surface receipt links in the expenses table so users can open the receipt from the grid

## Testing
- `npm run lint` *(fails: ESLint configuration missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d0c5d09098832ca40a70189a2bf025