### PR TITLE
Fix pie chart labels to show rounded dollars

### DIFF
--- a/components/dashboard/PieCard.tsx
+++ b/components/dashboard/PieCard.tsx
@@ -1,4 +1,12 @@
-import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip, Legend } from 'recharts';
+import {
+  ResponsiveContainer,
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  Legend,
+  type PieLabelRenderProps,
+} from 'recharts';
 import { formatMoney } from '../../lib/format';
 
 interface PieCardProps<T> {
@@ -10,13 +18,27 @@ interface PieCardProps<T> {
 
 const COLORS = ['#3b82f6', '#10b981', '#f97316', '#e11d48', '#8b5cf6', '#14b8a6'];
 
+const integerFormatter = new Intl.NumberFormat('en-AU', { maximumFractionDigits: 0 });
+
+const toRoundedDollars = (valueInCents: number) => Math.round(valueInCents / 100);
+
+const renderSliceLabel = ({ value }: PieLabelRenderProps) => {
+  if (typeof value !== 'number') return '';
+  return integerFormatter.format(toRoundedDollars(value));
+};
+
 export default function PieCard<T extends Record<string, any>>({ title, data, labelKey, valueKey }: PieCardProps<T>) {
   return (
     <div className="p-4 rounded-2xl card">
       <div className="mb-4 text-sm text-text-secondary">{title}</div>
       <ResponsiveContainer width="100%" height={300}>
         <PieChart>
-          <Pie data={data} dataKey={valueKey as string} nameKey={labelKey as string} label>
+          <Pie
+            data={data}
+            dataKey={valueKey as string}
+            nameKey={labelKey as string}
+            label={renderSliceLabel}
+          >
             {data.map((_, idx) => (
               <Cell key={idx} fill={COLORS[idx % COLORS.length]} />
             ))}


### PR DESCRIPTION
## Summary
- ensure the pie chart slices render their values as rounded dollar amounts rather than cents
- add a reusable formatter so labels display whole-dollar values with the localised number format

## Testing
- npm run lint *(fails: local dependencies unavailable and the globally provided ESLint 9 expects the new eslint.config.js format)*

------
https://chatgpt.com/codex/tasks/task_e_68d0c7829950832c8c1d705e7463fe4d