### PR TITLE
Fix ExpensesTable JSX structure

### DIFF
--- a/components/ExpensesTable.tsx
+++ b/components/ExpensesTable.tsx
@@ -160,13 +160,6 @@ export default function ExpensesTable({
           </select>
         )}
         <input
-          type="text"
-          className="p-1 bg-white dark:bg-gray-800 dark:text-white border-0 focus:outline-none focus:ring-0 placeholder-gray-500 dark:placeholder-gray-400"
-          placeholder="Search for an expense"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-        />
-        <input
           type="date"
           className="border p-1 bg-white dark:bg-gray-800 dark:border-gray-700 dark:text-white"
           value={from}
@@ -218,7 +211,11 @@ export default function ExpensesTable({
           />
         </div>
       </div>
-      {data.length ? (
+      {data.length === 0 ? (
+        <EmptyState message="No expenses found." />
+      ) : filteredData.length === 0 ? (
+        <EmptyState message="No expenses match your search." />
+      ) : (
         <table className="min-w-full border bg-white dark:bg-gray-800 dark:border-gray-700">
           <thead>
             <tr className="bg-gray-100 dark:bg-gray-700">
@@ -234,7 +231,7 @@ export default function ExpensesTable({
             </tr>
           </thead>
           <tbody>
-            {data.map((r) => (
+            {filteredData.map((r) => (
               <tr key={r.id} className="border-t dark:border-gray-700">
                 {!propertyId && (
                   <td className="p-2">{propertyMap[r.propertyId] || r.propertyId}</td>
@@ -249,81 +246,49 @@ export default function ExpensesTable({
                   <ReceiptLink url={r.receiptUrl} />
                 </td>
                 <td className="p-2">
-                  <button
-                    className="text-red-600 underline dark:text-red-400"
-                    onClick={() => {
-                      if (confirm("Delete this expense?")) {
-                        deleteMutation.mutate(r.id);
-                      }
-                    }}
-                  >
-                    Delete
-                  </button>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      className={iconButtonClass}
+                      onClick={() => handleEdit(r)}
+                      aria-label="Edit expense"
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 20 20"
+                        fill="currentColor"
+                        className="h-5 w-5"
+                      >
+                        <path d="M17.414 2.586a2 2 0 0 0-2.828 0l-1.086 1.086 2.828 2.828 1.086-1.086a2 2 0 0 0 0-2.828ZM14.57 7.5 11.672 4.672 4 12.343V15.5h3.157L14.5 7.5Z" />
+                        <path d="M2 6a2 2 0 0 1 2-2h4a1 1 0 1 1 0 2H4v10h10v-4a1 1 0 1 1 2 0v4a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6Z" />
+                      </svg>
+                    </button>
+                    <button
+                      type="button"
+                      className={`${iconButtonClass} text-red-600 hover:text-red-500 dark:text-red-400 dark:hover:text-red-300`}
+                      onClick={() => setDeleteTarget(r)}
+                      aria-label="Delete expense"
+                      disabled={deleteMutation.isPending}
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 20 20"
+                        fill="currentColor"
+                        className="h-5 w-5"
+                      >
+                        <path
+                          fillRule="evenodd"
+                          d="M8.75 3a1.75 1.75 0 0 0-1.744 1.602l-.035.348H4a.75.75 0 0 0 0 1.5h.532l.634 9.182A2.25 2.25 0 0 0 7.41 17.75h5.18a2.25 2.25 0 0 0 2.244-2.118L15.468 6.45H16a.75.75 0 0 0 0-1.5h-2.97l-.035-.348A1.75 1.75 0 0 0 11.25 3h-2.5ZM9.75 7a.75.75 0 0 0-1.5 0v6a.75.75 0 0 0 1.5 0V7Zm2.75-.75a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0V7a.75.75 0 0 1 .75-.75Z"
+                          clipRule="evenodd"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </td>
               </tr>
-            </thead>
-            <tbody>
-              {filteredData.map((r) => (
-                <tr key={r.id} className="border-t dark:border-gray-700">
-                  {!propertyId && (
-                    <td className="p-2">{propertyMap[r.propertyId] || r.propertyId}</td>
-                  )}
-                  <td className="p-2">{r.date}</td>
-                  <td className="p-2">{r.category}</td>
-                  <td className="p-2">{r.vendor}</td>
-                  <td className="p-2">{r.amount}</td>
-                  <td className="p-2">{r.gst}</td>
-                  <td className="p-2">{r.notes}</td>
-                  <td className="p-2">{r.receiptUrl && <span>📎</span>}</td>
-                  <td className="p-2">
-                    <div className="flex items-center gap-2">
-                      <button
-                        type="button"
-                        className={iconButtonClass}
-                        onClick={() => handleEdit(r)}
-                        aria-label="Edit expense"
-                      >
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          viewBox="0 0 20 20"
-                          fill="currentColor"
-                          className="h-5 w-5"
-                        >
-                          <path d="M17.414 2.586a2 2 0 0 0-2.828 0l-1.086 1.086 2.828 2.828 1.086-1.086a2 2 0 0 0 0-2.828ZM14.5 7.5 11.672 4.672 4 12.343V15.5h3.157L14.5 7.5Z" />
-                          <path d="M2 6a2 2 0 0 1 2-2h4a1 1 0 1 1 0 2H4v10h10v-4a1 1 0 1 1 2 0v4a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6Z" />
-                        </svg>
-                      </button>
-                      <button
-                        type="button"
-                        className={`${iconButtonClass} text-red-600 hover:text-red-500 dark:text-red-400 dark:hover:text-red-300`}
-                        onClick={() => setDeleteTarget(r)}
-                        aria-label="Delete expense"
-                        disabled={deleteMutation.isPending}
-                      >
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          viewBox="0 0 20 20"
-                          fill="currentColor"
-                          className="h-5 w-5"
-                        >
-                          <path
-                            fillRule="evenodd"
-                            d="M8.75 3a1.75 1.75 0 0 0-1.744 1.602l-.035.348H4a.75.75 0 0 0 0 1.5h.532l.634 9.182A2.25 2.25 0 0 0 7.41 17.75h5.18a2.25 2.25 0 0 0 2.244-2.118L15.468 6.45H16a.75.75 0 0 0 0-1.5h-2.97l-.035-.348A1.75 1.75 0 0 0 11.25 3h-2.5ZM9.75 7a.75.75 0 0 0-1.5 0v6a.75.75 0 0 0 1.5 0V7Zm2.75-.75a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0V7a.75.75 0 0 1 .75-.75Z"
-                            clipRule="evenodd"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        ) : (
-          <EmptyState message="No expenses match your search." />
-        )
-      ) : (
-        <EmptyState message="No expenses found." />
+            ))}
+          </tbody>
+        </table>
       )}
       <ExpenseForm
         propertyId={propertyId}


### PR DESCRIPTION
## Summary
- fix the ExpensesTable JSX structure so only filtered rows render inside a single table body
- show dedicated empty states when no expenses exist or no rows match the current filters
- remove the duplicated search input that targeted the same query state

## Testing
- npm run lint *(fails: ESLint 9 requires an eslint.config file in this environment)*
- npm run test:unit *(fails: vitest binary unavailable because dependencies could not be installed; npm install returns 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d123878dd4832cb56fad96f15a50b3