### PR TITLE
Remove transition effects

### DIFF
--- a/app/(app)/analytics/page.tsx
+++ b/app/(app)/analytics/page.tsx
@@ -18,11 +18,11 @@ export default function AnalyticsPage() {
       <h1 className="text-2xl font-semibold">Analytics</h1>
       <div className="grid flex-1 gap-4 md:grid-cols-3 md:grid-rows-[repeat(2,minmax(0,1fr))]">
         <div
-          className="group relative flex h-full flex-col gap-6 overflow-hidden rounded-lg border bg-cover bg-center bg-no-repeat p-6 shadow-lg transition-shadow duration-300 ease-out hover:shadow-2xl focus-within:shadow-2xl backdrop-blur md:col-span-2 md:row-span-2"
+          className="group relative flex h-full flex-col gap-6 overflow-hidden rounded-lg border bg-cover bg-center bg-no-repeat p-6 shadow-lg hover:shadow-2xl focus-within:shadow-2xl backdrop-blur md:col-span-2 md:row-span-2"
           style={{ backgroundImage: `url(${ANALYTICS_OVERVIEW_BACKGROUND})` }}
         >
           <span
-            className="pointer-events-none absolute inset-0 z-0 bg-white opacity-70 transition-opacity duration-300 ease-in-out dark:bg-gray-900 dark:opacity-60 group-hover:opacity-40 group-focus-within:opacity-40 dark:group-hover:opacity-30 dark:group-focus-within:opacity-30"
+            className="pointer-events-none absolute inset-0 z-0 bg-white opacity-70 dark:bg-gray-900 dark:opacity-60 group-hover:opacity-40 group-focus-within:opacity-40 dark:group-hover:opacity-30 dark:group-focus-within:opacity-30"
             aria-hidden="true"
           />
           <Link
@@ -52,11 +52,11 @@ export default function AnalyticsPage() {
           </div>
         </div>
         <div
-          className="group relative flex h-full flex-col justify-center gap-4 overflow-hidden rounded-lg border bg-cover bg-center bg-no-repeat p-6 shadow-lg transition-shadow duration-300 ease-out hover:shadow-2xl focus-visible:shadow-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent backdrop-blur dark:focus-visible:ring-white/40 md:col-start-3 md:row-start-1"
+          className="group relative flex h-full flex-col justify-center gap-4 overflow-hidden rounded-lg border bg-cover bg-center bg-no-repeat p-6 shadow-lg hover:shadow-2xl focus-visible:shadow-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent backdrop-blur dark:focus-visible:ring-white/40 md:col-start-3 md:row-start-1"
           style={{ backgroundImage: `url(${ANALYTICS_CUSTOM_BACKGROUND})` }}
         >
           <span
-            className="pointer-events-none absolute inset-0 z-0 bg-white opacity-70 transition-opacity duration-300 dark:bg-gray-900 dark:opacity-60 group-hover:opacity-30 group-focus-within:opacity-30 dark:group-hover:opacity-20 dark:group-focus-within:opacity-20"
+            className="pointer-events-none absolute inset-0 z-0 bg-white opacity-70 dark:bg-gray-900 dark:opacity-60 group-hover:opacity-30 group-focus-within:opacity-30 dark:group-hover:opacity-20 dark:group-focus-within:opacity-20"
             aria-hidden="true"
           />
           <Link
@@ -70,11 +70,11 @@ export default function AnalyticsPage() {
         </div>
         <Link
           href="/analytics/builder"
-          className="group relative flex h-full flex-col justify-center gap-4 overflow-hidden rounded-lg border bg-cover bg-center bg-no-repeat p-6 shadow-lg transition-shadow duration-300 ease-out hover:shadow-2xl focus-visible:shadow-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent backdrop-blur dark:focus-visible:ring-white/40 md:col-start-3 md:row-start-2 md:h-full"
+          className="group relative flex h-full flex-col justify-center gap-4 overflow-hidden rounded-lg border bg-cover bg-center bg-no-repeat p-6 shadow-lg hover:shadow-2xl focus-visible:shadow-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent backdrop-blur dark:focus-visible:ring-white/40 md:col-start-3 md:row-start-2 md:h-full"
           style={{ backgroundImage: `url(${ANALYTICS_BUILDER_BACKGROUND})` }}
         >
           <span
-            className="pointer-events-none absolute inset-0 z-0 bg-white opacity-70 transition-opacity duration-300 ease-in-out dark:bg-gray-900 dark:opacity-60 group-hover:opacity-40 group-focus-visible:opacity-40 dark:group-hover:opacity-30 dark:group-focus-visible:opacity-30"
+            className="pointer-events-none absolute inset-0 z-0 bg-white opacity-70 dark:bg-gray-900 dark:opacity-60 group-hover:opacity-40 group-focus-visible:opacity-40 dark:group-hover:opacity-30 dark:group-focus-visible:opacity-30"
             aria-hidden="true"
           />
           <span className="relative z-10 text-3xl font-semibold md:text-4xl lg:text-[44px]">Analytics Builder</span>

--- a/app/(app)/properties/[id]/components/ScrollableSectionBar.tsx
+++ b/app/(app)/properties/[id]/components/ScrollableSectionBar.tsx
@@ -119,15 +119,15 @@ export default function ScrollableSectionBar({
       tablist:
         "flex w-full items-center gap-2 overflow-x-auto whitespace-nowrap rounded-full border border-gray-200 bg-white/90 px-3 py-2 text-center shadow-lg backdrop-blur supports-[backdrop-filter]:bg-white/75 dark:border-gray-700 dark:bg-gray-900/90",
       tabBase:
-        "flex-shrink-0 whitespace-nowrap rounded-full border px-4 py-1.5 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-300 dark:focus:ring-gray-600",
+        "flex-shrink-0 whitespace-nowrap rounded-full border px-4 py-1.5 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-300 dark:focus:ring-gray-600",
       tabActive:
         "border-gray-900 bg-gray-900 text-white dark:border-gray-100 dark:bg-gray-100 dark:text-gray-900",
       tabInactive:
         "border-transparent bg-white text-gray-700 hover:bg-gray-100 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700",
       fadeLeft:
-        "pointer-events-none absolute inset-y-1 left-1 w-6 rounded-l-full bg-gradient-to-r from-white/90 via-white/60 to-transparent transition-opacity duration-200 supports-[backdrop-filter]:from-white/70 dark:from-gray-900/90 dark:via-gray-900/60",
+        "pointer-events-none absolute inset-y-1 left-1 w-6 rounded-l-full bg-gradient-to-r from-white/90 via-white/60 to-transparent supports-[backdrop-filter]:from-white/70 dark:from-gray-900/90 dark:via-gray-900/60",
       fadeRight:
-        "pointer-events-none absolute inset-y-1 right-1 w-6 rounded-r-full bg-gradient-to-l from-white/90 via-white/60 to-transparent transition-opacity duration-200 supports-[backdrop-filter]:from-white/70 dark:from-gray-900/90 dark:via-gray-900/60",
+        "pointer-events-none absolute inset-y-1 right-1 w-6 rounded-r-full bg-gradient-to-l from-white/90 via-white/60 to-transparent supports-[backdrop-filter]:from-white/70 dark:from-gray-900/90 dark:via-gray-900/60",
     },
     contained: {
       root: "flex w-full justify-start",
@@ -135,15 +135,15 @@ export default function ScrollableSectionBar({
       tablist:
         "flex w-full items-center gap-2 overflow-x-auto whitespace-nowrap pb-4",
       tabBase:
-        "flex-shrink-0 whitespace-nowrap rounded-md px-3 py-2 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-gray-300 focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-gray-600 dark:focus:ring-offset-gray-900",
+        "flex-shrink-0 whitespace-nowrap rounded-md px-3 py-2 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-gray-300 focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-gray-600 dark:focus:ring-offset-gray-900",
       tabActive:
         "bg-gray-900 text-white shadow-sm dark:bg-gray-100 dark:text-gray-900",
       tabInactive:
         "text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white",
       fadeLeft:
-        "pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r from-white via-white/70 to-transparent transition-opacity duration-200 dark:from-gray-900 dark:via-gray-900/70",
+        "pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r from-white via-white/70 to-transparent dark:from-gray-900 dark:via-gray-900/70",
       fadeRight:
-        "pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-white via-white/70 to-transparent transition-opacity duration-200 dark:from-gray-900 dark:via-gray-900/70",
+        "pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-white via-white/70 to-transparent dark:from-gray-900 dark:via-gray-900/70",
     },
   };
 

--- a/app/(app)/properties/[id]/page.tsx
+++ b/app/(app)/properties/[id]/page.tsx
@@ -3,7 +3,6 @@
 import { useMemo, useState } from "react";
 import { useParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
-import { motion, useReducedMotion, type Variants } from "framer-motion";
 
 import { SharedTile } from "../../../../components/SharedTile";
 import IncomeForm from "../../../../components/IncomeForm";
@@ -52,24 +51,6 @@ const dateFormatter = new Intl.DateTimeFormat(undefined, {
   year: "numeric",
 });
 
-const listVariants: Variants = {
-  hidden: {},
-  show: {
-    transition: {
-      staggerChildren: 0.03,
-    },
-  },
-};
-
-const itemVariants: Variants = {
-  hidden: { y: 8, opacity: 0 },
-  show: {
-    y: 0,
-    opacity: 1,
-    transition: { duration: 0.15, ease: "easeOut" },
-  },
-};
-
 function formatRent(value?: number) {
   if (typeof value !== "number" || !Number.isFinite(value)) {
     return "—";
@@ -116,11 +97,6 @@ export default function PropertyPage() {
     return <div className="p-6">Failed to load property</div>;
   }
 
-  const reduceMotion = useReducedMotion();
-  const listMotionProps = reduceMotion
-    ? {}
-    : { variants: listVariants, initial: "hidden" as const, animate: "show" as const };
-  const itemMotionProps = reduceMotion ? {} : { variants: itemVariants };
   const ready = Boolean(property);
 
   const handleTabSelect = (tab: string) => {
@@ -162,30 +138,19 @@ export default function PropertyPage() {
 
   return (
     <div className="relative">
-      <motion.div
-        initial={{ opacity: 1 }}
-        animate={{ opacity: ready ? 0 : 1 }}
-        transition={{ duration: 0.12 }}
-        className={`p-6 ${ready ? "pointer-events-none absolute inset-0" : ""}`}
-      >
-        <PropertyPageSkeleton />
-      </motion.div>
-      <motion.div
-        initial={{ opacity: 0 }}
-        animate={{ opacity: ready ? 1 : 0 }}
-        transition={{ duration: 0.12 }}
-        className="p-6"
-      >
-        {property && (
+      {!ready && (
+        <div className="p-6">
+          <PropertyPageSkeleton />
+        </div>
+      )}
+      {property && (
+        <div className="p-6">
           <div className="space-y-6">
-            <motion.section
-              className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(360px,420px)_minmax(0,1fr)] xl:grid-cols-[minmax(360px,440px)_minmax(0,1fr)]"
-              {...listMotionProps}
-            >
-              <motion.div className="lg:col-span-2" {...itemMotionProps}>
+            <section className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(360px,420px)_minmax(0,1fr)] xl:grid-cols-[minmax(360px,440px)_minmax(0,1fr)]">
+              <div className="lg:col-span-2">
                 <PropertySummaryTile property={property} />
-              </motion.div>
-              <motion.div {...itemMotionProps}>
+              </div>
+              <div>
                 <PropertyHero
                   property={property}
                   onEdit={() => setEditOpen(true)}
@@ -193,8 +158,8 @@ export default function PropertyPage() {
                   onAddExpense={() => setExpenseOpen(true)}
                   onUploadDocument={() => setDocumentOpen(true)}
                 />
-              </motion.div>
-              <motion.div {...itemMotionProps}>
+              </div>
+              <div>
                 <section className="flex min-h-[32rem] flex-col overflow-hidden rounded-lg border bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900">
                   <div className="flex-shrink-0 border-b border-gray-100 px-4 pb-1 pt-4 sm:px-6 dark:border-gray-800">
                     <ScrollableSectionBar
@@ -214,15 +179,15 @@ export default function PropertyPage() {
                     {renderSection(resolvedTab)}
                   </div>
                 </section>
-              </motion.div>
-            </motion.section>
+              </div>
+            </section>
             <IncomeForm propertyId={id} open={incomeOpen} onOpenChange={setIncomeOpen} showTrigger={false} />
             <ExpenseForm propertyId={id} open={expenseOpen} onOpenChange={setExpenseOpen} showTrigger={false} />
             <DocumentUploadModal propertyId={id} open={documentOpen} onClose={() => setDocumentOpen(false)} />
             <PropertyEditModal property={property} open={editOpen} onClose={() => setEditOpen(false)} />
           </div>
-        )}
-      </motion.div>
+        </div>
+      )}
     </div>
   );
 }
@@ -266,4 +231,3 @@ function PropertySummaryTile({ property }: { property: PropertySummary }) {
     </SharedTile>
   );
 }
-

--- a/app/(app)/tasks/page.tsx
+++ b/app/(app)/tasks/page.tsx
@@ -33,11 +33,7 @@ export default function TasksPage() {
           <TasksSkeleton />
         </div>
       )}
-      <div
-        className={`p-6 space-y-4 transition-opacity duration-200 ${
-          isLoading ? "opacity-0" : "opacity-100"
-        }`}
-      >
+      <div className={`p-6 space-y-4 ${isLoading ? "opacity-0" : "opacity-100"}`}>
         <header className="flex items-center justify-between">
           <h1 className="text-2xl font-semibold">{title}</h1>
           <Clock className="text-2xl font-semibold" />

--- a/app/properties/page.tsx
+++ b/app/properties/page.tsx
@@ -23,11 +23,7 @@ export default function PropertiesPage() {
           <PropertiesGridSkeleton />
         </div>
       )}
-      <div
-        className={`p-6 space-y-4 transition-opacity duration-200 ${
-          isPending ? 'opacity-0' : 'opacity-100'
-        }`}
-      >
+      <div className={`p-6 space-y-4 ${isPending ? 'opacity-0' : 'opacity-100'}`}>
         <div className="flex items-center justify-between">
           <h1 className="text-2xl font-semibold">Properties</h1>
           <Link

--- a/components/DashboardPnlMiniChart.tsx
+++ b/components/DashboardPnlMiniChart.tsx
@@ -66,7 +66,7 @@ export default function DashboardPnlMiniChart() {
           </AreaChart>
         </ResponsiveContainer>
       </div>
-      <div className="flex justify-between text-xs mt-2 opacity-0 group-hover:opacity-100 transition-opacity text-text-secondary">
+      <div className="flex justify-between text-xs mt-2 opacity-0 group-hover:opacity-100 text-text-secondary">
         <div>Income: {totals.income}</div>
         <div>Expenses: {totals.expenses}</div>
         <div>Net: {totals.net}</div>

--- a/components/ExpensesTable.tsx
+++ b/components/ExpensesTable.tsx
@@ -97,7 +97,7 @@ export default function ExpensesTable({
   );
 
   const iconButtonClass =
-    "rounded p-1 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-gray-100";
+    "rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-gray-100";
 
   const editDefaults = useMemo(() => {
     if (!editingExpense) return undefined;
@@ -330,7 +330,7 @@ export default function ExpensesTable({
             <div className="mt-4 flex justify-end gap-2">
               <button
                 type="button"
-                className="rounded-md border border-gray-300 px-3 py-1 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+                className="rounded-md border border-gray-300 px-3 py-1 text-sm font-medium text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
                 onClick={() => setDeleteTarget(null)}
                 disabled={deleteMutation.isPending}
               >
@@ -338,7 +338,7 @@ export default function ExpensesTable({
               </button>
               <button
                 type="button"
-                className="rounded-md bg-red-600 px-3 py-1 text-sm font-medium text-white transition-colors hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-60"
+                className="rounded-md bg-red-600 px-3 py-1 text-sm font-medium text-white hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-60"
                 onClick={() => {
                   if (!deleteTarget) return;
                   deleteMutation.mutate(deleteTarget.id, {

--- a/components/PageTransition.tsx
+++ b/components/PageTransition.tsx
@@ -1,10 +1,6 @@
 "use client";
 
 import { useEffect, useRef, type ReactNode } from "react";
-import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
-
-import { useRouteTransition } from "./RouteProgress";
-import { getRouteSkeleton, normalizePath } from "./skeletons";
 
 interface PageTransitionProps {
   children: ReactNode;
@@ -12,20 +8,7 @@ interface PageTransitionProps {
   className?: string;
 }
 
-function getTopLevelSegment(pathname: string | null): string | null {
-  if (!pathname) {
-    return null;
-  }
-
-  const segments = pathname.split("/").filter(Boolean);
-  return segments[0] ?? null;
-}
-
 export default function PageTransition({ children, routeKey, className }: PageTransitionProps) {
-  const reduceMotion = useReducedMotion();
-  const { isNavigating, targetPath } = useRouteTransition();
-  const skeleton = getRouteSkeleton(targetPath ?? routeKey);
-
   const rootRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -39,7 +22,7 @@ export default function PageTransition({ children, routeKey, className }: PageTr
       return;
     }
 
-    if (scrollContainer.scrollTop !== 0) {
+    if (scrollContainer.scrollTop !== 0 || scrollContainer.scrollLeft !== 0) {
       if (typeof scrollContainer.scrollTo === "function") {
         scrollContainer.scrollTo({ top: 0, left: 0, behavior: "auto" });
       } else {
@@ -49,60 +32,9 @@ export default function PageTransition({ children, routeKey, className }: PageTr
     }
   }, [routeKey]);
 
-  const currentPathname = routeKey ? normalizePath(routeKey) : null;
-  const targetPathname = targetPath ? normalizePath(targetPath) : null;
-
-  let shouldShowSkeleton = false;
-  if (isNavigating && skeleton) {
-    if (targetPathname && currentPathname && targetPathname !== currentPathname) {
-      const currentSegment = getTopLevelSegment(currentPathname);
-      const targetSegment = getTopLevelSegment(targetPathname);
-      shouldShowSkeleton = currentSegment !== targetSegment;
-    }
-  }
-
-  const animationProps = reduceMotion
-    ? {
-        initial: { opacity: 1 },
-        animate: { opacity: 1 },
-        exit: { opacity: 1 },
-      }
-    : {
-        initial: { opacity: 0 },
-        animate: { opacity: 1, transition: { duration: 0.16, ease: "easeOut" } },
-        exit: { opacity: 0, transition: { duration: 0.1, ease: "easeIn" } },
-      };
-
-  const skeletonMotion = reduceMotion
-    ? {
-        initial: { opacity: 1 },
-        animate: { opacity: 1 },
-        exit: { opacity: 1 },
-      }
-    : {
-        initial: { opacity: 0 },
-        animate: { opacity: 1, transition: { duration: 0.12, ease: "easeOut" } },
-        exit: { opacity: 0, transition: { duration: 0.12, ease: "easeIn" } },
-      };
-
   return (
-    <div ref={rootRef} className="relative h-full">
-      <AnimatePresence mode="wait">
-        <motion.div key={routeKey} {...animationProps} className={className}>
-          {children}
-        </motion.div>
-      </AnimatePresence>
-      <AnimatePresence>
-        {shouldShowSkeleton ? (
-          <motion.div
-            key="route-skeleton"
-            {...skeletonMotion}
-            className="pointer-events-none absolute inset-0 z-40 overflow-hidden bg-white/90 backdrop-blur-sm dark:bg-gray-950/70"
-          >
-            <div className="pointer-events-none overflow-y-auto">{skeleton}</div>
-          </motion.div>
-        ) : null}
-      </AnimatePresence>
+    <div ref={rootRef} className={className}>
+      {children}
     </div>
   );
 }

--- a/components/RouteProgress.tsx
+++ b/components/RouteProgress.tsx
@@ -54,9 +54,7 @@ function RouteProgressBar({ loading }: { loading: boolean }) {
       aria-hidden
       className="pointer-events-none fixed left-0 top-0 z-50 h-0.5 w-full bg-transparent"
     >
-      <div
-        className={`h-full ${loading ? "w-full" : "w-0"} bg-black/60 transition-[width] duration-200`}
-      />
+      <div className={`h-full ${loading ? "w-full" : "w-0"} bg-black/60`} />
     </div>
   );
 }

--- a/components/SharedTile.tsx
+++ b/components/SharedTile.tsx
@@ -1,17 +1,11 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { motion, useReducedMotion } from "framer-motion";
 
 export function SharedTile({ children }: { children: ReactNode }) {
-  const reduceMotion = useReducedMotion();
-
   return (
-    <motion.div
-      layoutId={reduceMotion ? undefined : "summary"}
-      className="rounded-2xl border bg-white p-4 shadow-sm dark:border-gray-800 dark:bg-gray-900"
-    >
+    <div className="rounded-2xl border bg-white p-4 shadow-sm dark:border-gray-800 dark:bg-gray-900">
       {children}
-    </motion.div>
+    </div>
   );
 }

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -132,7 +132,7 @@ export default function Sidebar() {
     <div
       onMouseEnter={() => setOpen(true)}
       onMouseLeave={() => setOpen(false)}
-      className={`relative h-screen bg-bg-base border-r border-[var(--border)] transition-all ${
+      className={`relative h-screen bg-bg-base border-r border-[var(--border)] ${
         open ? "w-64" : "w-16"
       }`}
     >

--- a/components/dashboard/DashboardPage.tsx
+++ b/components/dashboard/DashboardPage.tsx
@@ -1,7 +1,7 @@
 'use client';
+
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { motion, useReducedMotion, type Variants } from 'framer-motion';
 
 import Skeleton from '../Skeleton';
 import { SharedTile } from '../SharedTile';
@@ -13,24 +13,6 @@ import { getDashboard } from '../../lib/dashboard';
 import { formatMoney } from '../../lib/format';
 import Header from './Header';
 import type { DashboardDTO, PortfolioSummary } from '../../types/dashboard';
-
-const listVariants: Variants = {
-  hidden: {},
-  show: {
-    transition: {
-      staggerChildren: 0.03,
-    },
-  },
-};
-
-const itemVariants: Variants = {
-  hidden: { y: 8, opacity: 0 },
-  show: {
-    y: 0,
-    opacity: 1,
-    transition: { duration: 0.15, ease: 'easeOut' },
-  },
-};
 
 // Use the first day of the current month to show month-to-date data.
 const startOfMonth = (d: Date) => new Date(d.getFullYear(), d.getMonth(), 1);
@@ -62,21 +44,13 @@ export default function DashboardPage() {
 
   return (
     <div className="relative">
-      <motion.div
-        initial={{ opacity: 1 }}
-        animate={{ opacity: ready ? 0 : 1 }}
-        transition={{ duration: 0.12 }}
-        className={`p-6 ${ready ? 'pointer-events-none absolute inset-0' : ''}`}
-      >
-        <DashboardSkeleton />
-      </motion.div>
-      <motion.div
-        initial={{ opacity: 0 }}
-        animate={{ opacity: ready ? 1 : 0 }}
-        transition={{ duration: 0.12 }}
-        className="p-6"
-      >
-        {data && (
+      {!ready && (
+        <div className="p-6">
+          <DashboardSkeleton />
+        </div>
+      )}
+      {data && (
+        <div className="p-6">
           <DashboardContent
             data={data}
             from={from}
@@ -84,8 +58,8 @@ export default function DashboardPage() {
             fyLabel={fyLabel}
             fyHint={fyHint}
           />
-        )}
-      </motion.div>
+        </div>
+      )}
     </div>
   );
 }
@@ -103,87 +77,75 @@ function DashboardContent({
   fyLabel: string;
   fyHint: string;
 }) {
-  const reduceMotion = useReducedMotion();
-  const containerMotion = reduceMotion
-    ? {}
-    : { variants: listVariants, initial: 'hidden' as const, animate: 'show' as const };
-  const itemMotion = reduceMotion ? {} : { variants: itemVariants };
-  const headerMotion = reduceMotion
-    ? {}
-    : {
-        initial: { opacity: 0, y: 8 },
-        animate: { opacity: 1, y: 0, transition: { duration: 0.18, ease: 'easeOut' } },
-      };
-
   return (
     <div className="space-y-6">
-      <motion.div {...headerMotion}>
+      <div>
         <Header from={from} to={to} />
-      </motion.div>
+      </div>
       <div className="grid gap-6 lg:grid-cols-12">
-        <motion.div className="space-y-6 lg:col-span-8" {...containerMotion}>
-          <motion.section className="grid gap-4 md:grid-cols-2" {...containerMotion}>
-            <motion.div className="md:col-span-2" {...itemMotion}>
+        <div className="space-y-6 lg:col-span-8">
+          <section className="grid gap-4 md:grid-cols-2">
+            <div className="md:col-span-2">
               <PortfolioSummaryTile summary={data.portfolio} />
-            </motion.div>
-            <motion.div {...itemMotion}>
+            </div>
+            <div>
               <MetricCard
                 title="YTD Cashflow"
                 value={formatMoney(data.cashflow.ytdNet.amountCents)}
                 hint="Year to Date"
               />
-            </motion.div>
-            <motion.div {...itemMotion}>
+            </div>
+            <div>
               <MetricCard
                 title="MTD Cashflow"
                 value={formatMoney(data.cashflow.mtdNet.amountCents)}
                 hint="Month to Date"
               />
-            </motion.div>
-            <motion.div {...itemMotion}>
+            </div>
+            <div>
               <MetricCard
                 title={`${fyLabel} Income`}
                 value={formatMoney(data.cashflow.fyIncome.amountCents)}
                 hint={fyHint}
               />
-            </motion.div>
-            <motion.div {...itemMotion}>
+            </div>
+            <div>
               <MetricCard
                 title={`${fyLabel} Expenses`}
                 value={formatMoney(data.cashflow.fyExpense.amountCents)}
                 hint={fyHint}
               />
-            </motion.div>
-          </motion.section>
-          <motion.div {...itemMotion}>
+            </div>
+          </section>
+          <div>
             <CashflowLineChart data={data.lineSeries.points} />
-          </motion.div>
-          <motion.section className="grid gap-4 md:grid-cols-2" {...containerMotion}>
-            <motion.div {...itemMotion}>
+          </div>
+          <section className="grid gap-4 md:grid-cols-2">
+            <div>
               <PieCard
                 title="Income by Property"
                 data={data.incomeByProperty}
                 labelKey="propertyName"
                 valueKey="incomeCents"
               />
-            </motion.div>
-            <motion.div {...itemMotion}>
+            </div>
+            <div>
               <PieCard
                 title="Expenses by Category"
                 data={data.expensesByCategory}
                 labelKey="category"
                 valueKey="amountCents"
               />
-            </motion.div>
-          </motion.section>
-        </motion.div>
-        <motion.section className="space-y-4 lg:col-span-4" {...containerMotion}>
+            </div>
+          </section>
+        </div>
+        <section className="space-y-4 lg:col-span-4">
           {data.properties.map((p) => (
-            <motion.div key={p.propertyId} {...itemMotion}>
+            <div key={p.propertyId}>
               <PropertyCard data={p} />
-            </motion.div>
+            </div>
           ))}
-        </motion.section>
+        </section>
       </div>
     </div>
   );

--- a/components/tasks/TaskCard.tsx
+++ b/components/tasks/TaskCard.tsx
@@ -46,7 +46,7 @@ export default function TaskCard({
 
   return (
     <div
-      className={`group relative flex flex-col rounded border p-2 transition-colors ${
+      className={`group relative flex flex-col rounded border p-2 ${
         onClick ? "cursor-pointer" : ""
       } ${dueSoon ? "border-yellow-500" : ""}`}
       onClick={onClick}
@@ -82,10 +82,10 @@ export default function TaskCard({
         )}
       </div>
       {!completed && onComplete && (
-        <div className="max-h-0 overflow-hidden transition-[max-height,padding] duration-200 ease-out group-focus-within:max-h-16 group-focus-within:pt-2 group-hover:max-h-16 group-hover:pt-2">
+        <div className="max-h-0 overflow-hidden group-focus-within:max-h-16 group-focus-within:pt-2 group-hover:max-h-16 group-hover:pt-2">
           <button
             type="button"
-            className="w-full rounded bg-gray-900 px-3 py-1.5 text-xs font-semibold text-white opacity-0 transition hover:bg-gray-700 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 group-focus-within:opacity-100 group-hover:opacity-100 disabled:cursor-not-allowed disabled:bg-gray-500 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-gray-200 dark:focus-visible:ring-gray-500"
+            className="w-full rounded bg-gray-900 px-3 py-1.5 text-xs font-semibold text-white opacity-0 hover:bg-gray-700 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 group-focus-within:opacity-100 group-hover:opacity-100 disabled:cursor-not-allowed disabled:bg-gray-500 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-gray-200 dark:focus-visible:ring-gray-500"
             onClick={(event) => {
               event.stopPropagation();
               if (isCompleting) return;

--- a/components/tasks/TasksKanban.tsx
+++ b/components/tasks/TasksKanban.tsx
@@ -28,7 +28,7 @@ import ColumnDeleteModal from "./ColumnDeleteModal";
 import ColumnCreateModal from "./ColumnCreateModal";
 
 const TAB_BASE_CLASSES =
-  "rounded-full border px-4 py-1.5 text-sm transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-300 dark:focus:ring-gray-600";
+  "rounded-full border px-4 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-300 dark:focus:ring-gray-600";
 const TAB_ACTIVE_CLASSES =
   "bg-gray-900 text-white border-gray-900 dark:bg-gray-100 dark:text-gray-900";
 const TAB_INACTIVE_CLASSES =
@@ -978,7 +978,7 @@ function TaskCompletionPrompt({
             type="button"
             onClick={onKeep}
             disabled={archiving}
-            className="rounded border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-800"
+            className="rounded border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-800"
           >
             Keep in list
           </button>
@@ -986,7 +986,7 @@ function TaskCompletionPrompt({
             type="button"
             onClick={onArchive}
             disabled={archiving}
-            className="rounded bg-gray-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-gray-700 disabled:cursor-not-allowed disabled:bg-gray-500 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-gray-200"
+            className="rounded bg-gray-900 px-4 py-2 text-sm font-semibold text-white hover:bg-gray-700 disabled:cursor-not-allowed disabled:bg-gray-500 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-gray-200"
           >
             {archiving ? "Archiving…" : "Archive task"}
           </button>
@@ -1019,7 +1019,7 @@ function PropertySelectModal({
 
   const optionClassName = (isActive: boolean) =>
     [
-      "flex w-full items-center justify-between gap-3 rounded-lg border px-4 py-2 text-sm transition",
+      "flex w-full items-center justify-between gap-3 rounded-lg border px-4 py-2 text-sm",
       isActive
         ? "border-gray-900 bg-gray-900 text-white shadow-sm dark:border-gray-100 dark:bg-gray-100 dark:text-gray-900"
         : "border-gray-200 text-gray-700 hover:bg-gray-100 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800",
@@ -1079,7 +1079,7 @@ function PropertySelectModal({
           <button
             type="button"
             onClick={onClose}
-            className="rounded-full p-1 text-gray-500 transition hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-300 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100 dark:focus:ring-gray-600"
+            className="rounded-full p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-300 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100 dark:focus:ring-gray-600"
             aria-label="Close property selector"
           >
             ×
@@ -1131,7 +1131,7 @@ function PropertySelectModal({
                               </button>
                               <span
                                 {...draggableProvided.dragHandleProps}
-                                className="ml-1 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full text-lg text-gray-400 transition hover:text-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 focus-visible:ring-offset-2 focus-visible:ring-offset-white active:cursor-grabbing cursor-grab dark:text-gray-500 dark:hover:text-gray-300 dark:focus-visible:ring-gray-600 dark:focus-visible:ring-offset-gray-900"
+                                className="ml-1 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full text-lg text-gray-400 hover:text-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 focus-visible:ring-offset-2 focus-visible:ring-offset-white active:cursor-grabbing cursor-grab dark:text-gray-500 dark:hover:text-gray-300 dark:focus-visible:ring-gray-600 dark:focus-visible:ring-offset-gray-900"
                                 aria-label={`Reorder ${property.address}`}
                               >
                                 <span aria-hidden="true">⋮⋮</span>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -6,7 +6,7 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
 
 export function Button({ className = "", variant = "primary", ...props }: ButtonProps) {
   const base =
-    "px-3 py-1 rounded disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] ring-offset-2 ring-offset-[var(--bg-base)] transition-colors";
+    "px-3 py-1 rounded disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] ring-offset-2 ring-offset-[var(--bg-base)]";
   const variants: Record<string, string> = {
     primary:
       "bg-[var(--primary)] hover:bg-[var(--primary-hover)] active:bg-[var(--primary-active)] text-white",


### PR DESCRIPTION
## Summary
- remove framer-motion based page transitions and render dashboard and property views without animations
- strip transition utility classes from shared UI components, navigation, analytics cards, and task views to ensure immediate state changes
- simplify the PageTransition wrapper to only reset scroll position while keeping route progress behavior without animated widths

## Testing
- npm run lint *(fails: ESLint requires migration to eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d27d2eae70832cb9ac0c9840707a98