### PR TITLE
Increase property functions bar padding

### DIFF
--- a/app/(app)/properties/[id]/page.tsx
+++ b/app/(app)/properties/[id]/page.tsx
@@ -167,6 +167,7 @@ export default function PropertyPage() {
                       activeTab={resolvedTab}
                       onTabSelect={handleTabSelect}
                       variant="contained"
+                      className="pt-3 pb-2 sm:pt-4 sm:pb-3"
                     />
                   </div>
                   <div


### PR DESCRIPTION
## Summary
- add vertical padding to the property management functions bar so the active tab outline is no longer clipped

## Testing
- npm install *(fails: registry access is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c0c2bd98832ca4028edc71cc829c