### PR TITLE
Add smooth transitions between major app sections

### DIFF
--- a/components/PageTransition.tsx
+++ b/components/PageTransition.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useRef, type ReactNode } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { useEffect, useMemo, useRef, type ReactNode } from "react";
 
 interface PageTransitionProps {
   children: ReactNode;
@@ -8,8 +9,18 @@ interface PageTransitionProps {
   className?: string;
 }
 
+function getTopLevelSegment(path: string): string {
+  if (!path || path === "/") {
+    return "/";
+  }
+
+  const segments = path.split("/").filter(Boolean);
+  return segments[0] ?? "/";
+}
+
 export default function PageTransition({ children, routeKey, className }: PageTransitionProps) {
   const rootRef = useRef<HTMLDivElement | null>(null);
+  const transitionKey = useMemo(() => getTopLevelSegment(routeKey), [routeKey]);
 
   useEffect(() => {
     const node = rootRef.current;
@@ -33,8 +44,18 @@ export default function PageTransition({ children, routeKey, className }: PageTr
   }, [routeKey]);
 
   return (
-    <div ref={rootRef} className={className}>
-      {children}
-    </div>
+    <AnimatePresence initial={false} mode="wait">
+      <motion.div
+        key={transitionKey}
+        ref={rootRef}
+        className={className}
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: -12 }}
+        transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
+      >
+        {children}
+      </motion.div>
+    </AnimatePresence>
   );
 }


### PR DESCRIPTION
## Summary
- add a framer-motion powered page transition wrapper so navigating between major sections fades and slides smoothly
- derive the transition key from the top-level route segment to avoid animating intra-section tab switches while keeping scroll resets

## Testing
- npm run lint *(fails: ESLint 9 expects eslint.config.js and local install is unavailable due to registry restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d3cba9e50c832c8415890f39b0a001