### PR TITLE
Fix property card navigation and rent positioning

### DIFF
--- a/components/PropertyOverviewCard.tsx
+++ b/components/PropertyOverviewCard.tsx
@@ -9,27 +9,27 @@ interface Props {
 
 export default function PropertyOverviewCard({ property }: Props) {
   return (
-    <div className="border rounded overflow-hidden h-64 grid grid-rows-2">
+    <Link
+      href={`/properties/${property.id}`}
+      className="grid h-64 grid-rows-[65%_35%] overflow-hidden rounded-lg border bg-white text-left shadow-sm transition hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-slate-800 dark:bg-slate-900 dark:text-slate-100 dark:focus-visible:ring-slate-400 dark:focus-visible:ring-offset-slate-950"
+    >
       <img
         src={property.imageUrl || "/default-house.svg"}
         alt={`Photo of ${property.address}`}
-        className="w-full h-full object-cover"
+        className="h-full w-full object-cover"
       />
-      <div className="p-4 flex flex-col justify-between">
-        <div>
-          <h2 className="text-lg font-semibold">
-            <Link
-              href={`/properties/${property.id}`}
-              className="text-blue-600 underline"
-            >
-              {property.address}
-            </Link>
+      <div className="flex flex-col gap-3 bg-slate-50 px-4 py-3 dark:bg-slate-900">
+        <div className="space-y-1">
+          <h2 className="text-xl font-semibold leading-tight tracking-tight text-slate-900 dark:text-slate-100">
+            {property.address}
           </h2>
-          <p>Tenant: {property.tenant}</p>
+          <p className="text-sm text-slate-600 dark:text-slate-300">Tenant: {property.tenant}</p>
         </div>
-        <p className="text-right font-semibold">${property.rent}/week</p>
+        <p className="text-right text-lg font-semibold leading-tight text-slate-900 dark:text-slate-100">
+          ${property.rent}/week
+        </p>
       </div>
-    </div>
+    </Link>
   );
 }
 


### PR DESCRIPTION
## Summary
- wrap the property overview card in a Next.js Link so the entire card navigates to the property details
- adjust spacing and typography in the detail panel so the rent/week amount stays visible within the 65/35 layout

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68d3d6e108f8832cbed4e157c471580c