### PR TITLE
Restore property card navigation and fix rent layout

### DIFF
--- a/components/PropertyOverviewCard.tsx
+++ b/components/PropertyOverviewCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import Link from "next/link";
+import { useRouter } from "next/navigation";
+import type { KeyboardEvent } from "react";
 import type { PropertySummary } from "../types/property";
 
 interface Props {
@@ -8,28 +9,51 @@ interface Props {
 }
 
 export default function PropertyOverviewCard({ property }: Props) {
+  const router = useRouter();
+  const detailPath = `/properties/${property.id}`;
+
+  const navigateToDetails = () => {
+    router.push(detailPath);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+    if (event.key === "Enter") {
+      navigateToDetails();
+      return;
+    }
+
+    if (event.key === " " || event.key === "Spacebar") {
+      event.preventDefault();
+      navigateToDetails();
+    }
+  };
+
   return (
-    <div className="border rounded overflow-hidden h-64 grid grid-rows-2">
+    <article
+      role="link"
+      tabIndex={0}
+      aria-label={`View details for ${property.address}`}
+      onClick={navigateToDetails}
+      onKeyDown={handleKeyDown}
+      className="grid h-64 cursor-pointer grid-rows-[65%_35%] overflow-hidden rounded-lg border bg-white text-left shadow-sm transition hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-slate-800 dark:bg-slate-900 dark:text-slate-100 dark:focus-visible:ring-slate-400 dark:focus-visible:ring-offset-slate-950"
+    >
       <img
         src={property.imageUrl || "/default-house.svg"}
         alt={`Photo of ${property.address}`}
-        className="w-full h-full object-cover"
+        className="h-full w-full object-cover"
       />
-      <div className="p-4 flex flex-col justify-between">
-        <div>
-          <h2 className="text-lg font-semibold">
-            <Link
-              href={`/properties/${property.id}`}
-              className="text-blue-600 underline"
-            >
-              {property.address}
-            </Link>
+      <div className="flex flex-col justify-between gap-3 bg-slate-50 px-4 py-3 dark:bg-slate-900">
+        <div className="space-y-1">
+          <h2 className="text-xl font-semibold leading-tight tracking-tight text-slate-900 dark:text-slate-100">
+            {property.address}
           </h2>
-          <p>Tenant: {property.tenant}</p>
+          <p className="text-sm text-slate-600 dark:text-slate-300">Tenant: {property.tenant}</p>
         </div>
-        <p className="text-right font-semibold">${property.rent}/week</p>
+        <p className="text-right text-lg font-semibold leading-tight text-slate-900 dark:text-slate-100">
+          ${property.rent}/week
+        </p>
       </div>
-    </div>
+    </article>
   );
 }
 


### PR DESCRIPTION
## Summary
- restore property card navigation by handling clicks and keyboard events with the Next.js router so the whole card remains interactive without the Link runtime error
- keep the 65/35 layout and spacing tweaks so the tenant and rent/week details stay visible inside the detail panel

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68d3d6e108f8832cbed4e157c471580c