### PR TITLE
Smooth hover animation for task completion button

### DIFF
--- a/components/tasks/TaskCard.tsx
+++ b/components/tasks/TaskCard.tsx
@@ -82,10 +82,12 @@ export default function TaskCard({
         )}
       </div>
       {!completed && onComplete && (
-        <div className="max-h-0 overflow-hidden group-focus-within:max-h-16 group-focus-within:pt-2 group-hover:max-h-16 group-hover:pt-2">
+        <div
+          className="max-h-0 overflow-hidden pt-0 transition-all duration-300 ease-in-out group-focus-within:max-h-16 group-focus-within:pt-2 group-hover:max-h-16 group-hover:pt-2"
+        >
           <button
             type="button"
-            className="w-full rounded bg-gray-900 px-3 py-1.5 text-xs font-semibold text-white opacity-0 hover:bg-gray-700 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 group-focus-within:opacity-100 group-hover:opacity-100 disabled:cursor-not-allowed disabled:bg-gray-500 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-gray-200 dark:focus-visible:ring-gray-500"
+            className="w-full rounded bg-gray-900 px-3 py-1.5 text-xs font-semibold text-white opacity-0 transition-opacity duration-300 ease-in-out hover:bg-gray-700 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 group-focus-within:opacity-100 group-hover:opacity-100 disabled:cursor-not-allowed disabled:bg-gray-500 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-gray-200 dark:focus-visible:ring-gray-500"
             onClick={(event) => {
               event.stopPropagation();
               if (isCompleting) return;


### PR DESCRIPTION
## Summary
- add easing and duration transitions to the task card action container
- smooth the opacity transition on the "Complete Task" button for a softer reveal

## Testing
- npm run lint *(fails: ESLint not configured in environment-provided v9)*


------
https://chatgpt.com/codex/tasks/task_e_68d3da0528b4832c8ecaaad32905d514