### PR TITLE
Ensure rent income populates ledger

### DIFF
--- a/app/(app)/properties/[id]/sections/OtherIncome.tsx
+++ b/app/(app)/properties/[id]/sections/OtherIncome.tsx
@@ -11,6 +11,8 @@ const CORE_RENT_CATEGORIES = [
   "Rent",
   "Rent payment",
   "Core rent",
+  "Arrears catch-up",
+  "Arrears catchup",
 ];
 
 export default function OtherIncome({ propertyId }: OtherIncomeProps) {

--- a/app/api/properties/[id]/income/[incomeId]/route.ts
+++ b/app/api/properties/[id]/income/[incomeId]/route.ts
@@ -1,4 +1,9 @@
 import { prisma } from '../../../../../../lib/prisma';
+import {
+  type IncomeRecord,
+  removeLedgerForIncome,
+  syncLedgerForIncome,
+} from '../ledger';
 
 export async function GET(
   _req: Request,
@@ -35,6 +40,7 @@ export async function PATCH(
     where: { id: params.incomeId },
     data: { data },
   });
+  await syncLedgerForIncome(data as IncomeRecord, row.data as IncomeRecord);
   return Response.json(data);
 }
 
@@ -46,6 +52,7 @@ export async function DELETE(
   if (!row || (row.data as any).propertyId !== params.id) {
     return new Response(null, { status: 404 });
   }
+  await removeLedgerForIncome(row.data as IncomeRecord);
   await prisma.mockData.delete({ where: { id: params.incomeId } });
   return new Response(null, { status: 204 });
 }

--- a/app/api/properties/[id]/income/ledger.ts
+++ b/app/api/properties/[id]/income/ledger.ts
@@ -1,0 +1,239 @@
+import { randomUUID } from "crypto";
+
+import { prisma } from "../../../../../lib/prisma";
+
+export type IncomeRecord = {
+  id: string;
+  propertyId: string;
+  tenantId?: string | null;
+  date: string;
+  category?: string | null;
+  amount: number;
+  notes?: string | null;
+  label?: string | null;
+  evidenceUrl?: string | null;
+  evidenceName?: string | null;
+};
+
+const LEDGER_CATEGORY_ALIASES = [
+  "base rent",
+  "rent",
+  "rent payment",
+  "core rent",
+  "arrears catch up",
+  "arrears catchup",
+];
+
+const LEDGER_CATEGORY_SET = new Set(LEDGER_CATEGORY_ALIASES);
+
+const normalizeCategory = (value?: string | null) =>
+  value?.toLowerCase().replace(/[\-_]/g, " ").replace(/\s+/g, " ").trim() ?? "";
+
+const shouldSyncToLedger = (category?: string | null) =>
+  LEDGER_CATEGORY_SET.has(normalizeCategory(category));
+
+const removeUndefined = <T extends Record<string, unknown>>(input: T) => {
+  const output: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (value !== undefined) {
+      output[key] = value;
+    }
+  }
+  return output as T;
+};
+
+const fetchLedgerEntries = async () => {
+  const rows = await prisma.mockData.findMany({ where: { type: "rentLedger" } });
+  return rows.map((row) => ({ id: row.id, data: row.data as any }));
+};
+
+const upsertLedgerEntry = async (
+  income: IncomeRecord,
+  previous?: IncomeRecord | null
+) => {
+  const ledgerEntries = await fetchLedgerEntries();
+  let target = ledgerEntries.find(
+    (entry) => entry.data?.sourceIncomeId === income.id
+  );
+
+  if (!target && previous) {
+    target = ledgerEntries.find(
+      (entry) => entry.data?.sourceIncomeId === previous.id
+    );
+  }
+
+  if (!target) {
+    target = ledgerEntries.find(
+      (entry) =>
+        entry.data?.propertyId === income.propertyId &&
+        entry.data?.dueDate === income.date &&
+        !entry.data?.sourceIncomeId
+    );
+  }
+
+  const evidenceUrl = income.evidenceUrl ?? undefined;
+  const evidenceName = income.evidenceName ?? undefined;
+  const description = income.label ?? income.category ?? undefined;
+
+  if (target) {
+    const existing = target.data ?? {};
+    const sameSource = existing.sourceIncomeId === income.id;
+    const updated = { ...existing } as Record<string, any>;
+
+    if (!sameSource) {
+      updated.previousStatus = existing.status;
+      updated.previousPaidDate = existing.paidDate;
+      updated.previousAmount = existing.amount;
+      updated.previousEvidenceUrl = existing.evidenceUrl;
+      updated.previousEvidenceName = existing.evidenceName;
+      updated.previousDescription = existing.description;
+      updated.previousDueDate = existing.dueDate;
+    }
+
+    updated.propertyId = income.propertyId;
+    if (income.tenantId !== undefined) {
+      updated.tenantId = income.tenantId ?? undefined;
+    }
+    updated.amount = income.amount;
+    updated.dueDate = income.date;
+    updated.status = "paid";
+    updated.paidDate = income.date;
+    updated.sourceIncomeId = income.id;
+    if (description) {
+      updated.description = description;
+    }
+    if (evidenceUrl !== undefined) {
+      updated.evidenceUrl = evidenceUrl;
+    }
+    if (evidenceName !== undefined) {
+      updated.evidenceName = evidenceName;
+    }
+
+    const cleaned = removeUndefined(updated);
+    await prisma.mockData.update({
+      where: { id: target.id },
+      data: { data: cleaned },
+    });
+    return;
+  }
+
+  const id = randomUUID();
+  const newEntry = removeUndefined({
+    id,
+    propertyId: income.propertyId,
+    tenantId: income.tenantId ?? undefined,
+    amount: income.amount,
+    dueDate: income.date,
+    status: "paid",
+    paidDate: income.date,
+    sourceIncomeId: income.id,
+    description: description ?? "Rent income",
+    evidenceUrl,
+    evidenceName,
+  });
+
+  await prisma.mockData.create({
+    data: { id, type: "rentLedger", data: newEntry },
+  });
+};
+
+const restoreLedgerEntry = async (income: IncomeRecord) => {
+  const ledgerEntries = await fetchLedgerEntries();
+  const match = ledgerEntries.find(
+    (entry) => entry.data?.sourceIncomeId === income.id
+  );
+  if (!match) return;
+
+  const data = match.data ?? {};
+  if (
+    Object.prototype.hasOwnProperty.call(data, "previousStatus") ||
+    Object.prototype.hasOwnProperty.call(data, "previousPaidDate") ||
+    Object.prototype.hasOwnProperty.call(data, "previousAmount") ||
+    Object.prototype.hasOwnProperty.call(data, "previousEvidenceUrl") ||
+    Object.prototype.hasOwnProperty.call(data, "previousEvidenceName") ||
+    Object.prototype.hasOwnProperty.call(data, "previousDescription") ||
+    Object.prototype.hasOwnProperty.call(data, "previousDueDate")
+  ) {
+    const restored = { ...data } as Record<string, any>;
+    if (Object.prototype.hasOwnProperty.call(data, "previousStatus")) {
+      restored.status = data.previousStatus;
+    }
+    if (Object.prototype.hasOwnProperty.call(data, "previousPaidDate")) {
+      if (data.previousPaidDate) {
+        restored.paidDate = data.previousPaidDate;
+      } else {
+        delete restored.paidDate;
+      }
+    }
+    if (Object.prototype.hasOwnProperty.call(data, "previousAmount")) {
+      restored.amount = data.previousAmount;
+    }
+    if (Object.prototype.hasOwnProperty.call(data, "previousEvidenceUrl")) {
+      if (data.previousEvidenceUrl) {
+        restored.evidenceUrl = data.previousEvidenceUrl;
+      } else {
+        delete restored.evidenceUrl;
+      }
+    }
+    if (Object.prototype.hasOwnProperty.call(data, "previousEvidenceName")) {
+      if (data.previousEvidenceName) {
+        restored.evidenceName = data.previousEvidenceName;
+      } else {
+        delete restored.evidenceName;
+      }
+    }
+    if (Object.prototype.hasOwnProperty.call(data, "previousDescription")) {
+      if (data.previousDescription) {
+        restored.description = data.previousDescription;
+      } else {
+        delete restored.description;
+      }
+    }
+    if (Object.prototype.hasOwnProperty.call(data, "previousDueDate")) {
+      restored.dueDate = data.previousDueDate;
+    }
+
+    delete restored.sourceIncomeId;
+    delete restored.previousStatus;
+    delete restored.previousPaidDate;
+    delete restored.previousAmount;
+    delete restored.previousEvidenceUrl;
+    delete restored.previousEvidenceName;
+    delete restored.previousDescription;
+    delete restored.previousDueDate;
+
+    const cleaned = removeUndefined(restored);
+    await prisma.mockData.update({
+      where: { id: match.id },
+      data: { data: cleaned },
+    });
+    return;
+  }
+
+  await prisma.mockData.delete({ where: { id: match.id } });
+};
+
+export const syncLedgerForIncome = async (
+  current: IncomeRecord,
+  previous?: IncomeRecord | null
+) => {
+  const wasLedger = previous ? shouldSyncToLedger(previous.category) : false;
+  const isLedger = shouldSyncToLedger(current.category);
+
+  if (isLedger) {
+    await upsertLedgerEntry(current, previous ?? null);
+    return;
+  }
+
+  if (wasLedger) {
+    await restoreLedgerEntry(previous!);
+  }
+};
+
+export const removeLedgerForIncome = async (income: IncomeRecord) => {
+  if (!shouldSyncToLedger(income.category)) {
+    return;
+  }
+  await restoreLedgerEntry(income);
+};
+

--- a/components/IncomesTable.tsx
+++ b/components/IncomesTable.tsx
@@ -108,6 +108,7 @@ export default function IncomesTable({
             <tr className="bg-gray-100 dark:bg-gray-700">
               <th className="p-2 text-left">Date</th>
               <th className="p-2 text-left">Category</th>
+              <th className="p-2 text-left">Evidence</th>
               <th className="p-2 text-left">Amount</th>
               <th className="p-2 text-left">Notes</th>
               <th className="p-2 text-left">Actions</th>
@@ -117,7 +118,21 @@ export default function IncomesTable({
             {rows.map((r) => (
               <tr key={r.id} className="border-t dark:border-gray-700">
                 <td className="p-2">{r.date}</td>
-                <td className="p-2">{r.category}</td>
+                <td className="p-2">{r.category || r.label || "—"}</td>
+                <td className="p-2">
+                  {r.evidenceUrl ? (
+                    <a
+                      href={r.evidenceUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-600 underline hover:text-blue-500 dark:text-blue-300"
+                    >
+                      {r.evidenceName || "View"}
+                    </a>
+                  ) : (
+                    "—"
+                  )}
+                </td>
                 <td className="p-2">{r.amount}</td>
                 <td className="p-2">{r.notes}</td>
                 <td className="p-2">


### PR DESCRIPTION
## Summary
- add a shared helper to sync qualifying income records with the rent ledger, including updates and deletions
- hook the income create/update/delete routes into the ledger synchronisation so base rent and arrears catch-up payments populate the ledger automatically
- show uploaded evidence links in the other income table and filter arrears catch-up payments out of that tab

## Testing
- npm run lint *(fails: repository still uses legacy ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68d3d58b6020832c9b1af8ebf7f032f9