### PR TITLE
Restore property card navigation without Link

### DIFF
--- a/components/PropertyOverviewCard.tsx
+++ b/components/PropertyOverviewCard.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useCallback } from "react";
+import type { KeyboardEvent } from "react";
 import type { PropertySummary } from "../types/property";
 
 interface Props {
@@ -8,28 +10,51 @@ interface Props {
 }
 
 export default function PropertyOverviewCard({ property }: Props) {
+  const detailPath = `/properties/${property.id}`;
+  const router = useRouter();
+
+  const handleNavigate = useCallback(() => {
+    router.push(detailPath);
+  }, [detailPath, router]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLElement>) => {
+      if (event.key === "Enter" || event.key === " " || event.key === "Spacebar") {
+        event.preventDefault();
+        handleNavigate();
+      }
+    },
+    [handleNavigate],
+  );
+
   return (
-    <div className="border rounded overflow-hidden h-64 grid grid-rows-2">
-      <img
-        src={property.imageUrl || "/default-house.svg"}
-        alt={`Photo of ${property.address}`}
-        className="w-full h-full object-cover"
-      />
-      <div className="p-4 flex flex-col justify-between">
-        <div>
-          <h2 className="text-lg font-semibold">
-            <Link
-              href={`/properties/${property.id}`}
-              className="text-blue-600 underline"
-            >
-              {property.address}
-            </Link>
-          </h2>
-          <p>Tenant: {property.tenant}</p>
-        </div>
-        <p className="text-right font-semibold">${property.rent}/week</p>
+    <article
+      role="link"
+      tabIndex={0}
+      aria-label={`View details for ${property.address}`}
+      onClick={handleNavigate}
+      onKeyDown={handleKeyDown}
+      className="group flex h-64 cursor-pointer flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white text-left shadow-sm transition hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100 dark:focus-visible:ring-slate-400 dark:focus-visible:ring-offset-slate-950"
+    >
+      <div className="relative shrink-0 basis-[65%] overflow-hidden">
+        <img
+          src={property.imageUrl || "/default-house.svg"}
+          alt={`Photo of ${property.address}`}
+          className="h-full w-full object-cover transition duration-300 group-hover:scale-[1.03]"
+        />
       </div>
-    </div>
+      <div className="flex shrink-0 basis-[35%] flex-col justify-between gap-3 bg-slate-50/95 px-4 pb-3 pt-4 text-slate-900 dark:bg-slate-800/90 dark:text-slate-100">
+        <div className="space-y-1.5">
+          <h2 className="text-lg font-semibold leading-snug tracking-tight text-slate-900 dark:text-white">
+            {property.address}
+          </h2>
+          <p className="text-sm text-slate-600 dark:text-slate-300">Tenant: {property.tenant}</p>
+        </div>
+        <p className="text-right text-lg font-semibold text-indigo-600 dark:text-indigo-300">
+          ${property.rent}/week
+        </p>
+      </div>
+    </article>
   );
 }
 


### PR DESCRIPTION
## Summary
- replace the Link wrapper with a keyboard-accessible article that uses the Next.js router to navigate on click or key press
- retain the 65/35 layout while lifting the detail panel spacing so the rent per week stays visible

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file)*
- npm run build *(fails: `next` CLI not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3d6e108f8832cbed4e157c471580c