### PR TITLE
Add Log Income header to income form

### DIFF
--- a/components/IncomeForm.tsx
+++ b/components/IncomeForm.tsx
@@ -225,6 +225,9 @@ export default function IncomeForm({
               });
             }}
           >
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+              Log Income
+            </h2>
             {!propertyId && (
               <label className="block text-gray-700 dark:text-gray-300">
                 Property


### PR DESCRIPTION
## Summary
- add a Log Income heading to the income form modal for clarity

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4a977ceb0832c9b464b0b6b61e2db