### PR TITLE
Add status controls and indicator to task details

### DIFF
--- a/components/tasks/TaskCard.tsx
+++ b/components/tasks/TaskCard.tsx
@@ -41,8 +41,28 @@ export default function TaskCard({
       (startOfDue.getTime() - startOfToday.getTime()) / (1000 * 60 * 60 * 24);
     return diff === 1;
   })();
+  const normalizedStatus = (task.status ?? "").toLowerCase();
   const completed =
-    typeof isCompleted === "boolean" ? isCompleted : task.status === "done";
+    typeof isCompleted === "boolean"
+      ? isCompleted
+      : normalizedStatus === "done" || normalizedStatus === "complete";
+  const statusInfo = (() => {
+    switch (normalizedStatus) {
+      case "todo":
+      case "to-do":
+        return { color: "bg-blue-500", label: "To-Do" } as const;
+      case "doing":
+        return { color: "bg-orange-500", label: "Doing" } as const;
+      case "done":
+      case "complete":
+      case "completed":
+        return { color: "bg-green-500", label: "Complete" } as const;
+      default:
+        return completed
+          ? ({ color: "bg-green-500", label: "Complete" } as const)
+          : undefined;
+    }
+  })();
 
   return (
     <div
@@ -53,13 +73,13 @@ export default function TaskCard({
     >
       <div className="flex items-start justify-between gap-2">
         <div className="font-medium">{task.title}</div>
-        {completed && (
+        {statusInfo && (
           <span className="inline-flex h-2.5 w-2.5 items-center justify-center">
             <span
-              className="h-2.5 w-2.5 rounded-full bg-green-500"
+              className={`h-2.5 w-2.5 rounded-full ${statusInfo.color}`}
               aria-hidden
             />
-            <span className="sr-only">Completed</span>
+            <span className="sr-only">{statusInfo.label}</span>
           </span>
         )}
       </div>

--- a/components/tasks/TaskEditModal.tsx
+++ b/components/tasks/TaskEditModal.tsx
@@ -4,6 +4,31 @@ import type { TaskDto } from "../../types/tasks";
 import type { PropertySummary } from "../../types/property";
 import type { Vendor } from "../../lib/api";
 
+const STATUS_OPTIONS = [
+  { value: "todo", label: "To-Do" },
+  { value: "doing", label: "Doing" },
+  { value: "done", label: "Complete" },
+] as const;
+
+type StatusOptionValue = (typeof STATUS_OPTIONS)[number]["value"];
+
+const normalizeStatus = (value: TaskDto["status"]): StatusOptionValue => {
+  const normalized = (value ?? "").toLowerCase();
+  switch (normalized) {
+    case "todo":
+    case "to-do":
+      return "todo";
+    case "doing":
+      return "doing";
+    case "done":
+    case "complete":
+    case "completed":
+      return "done";
+    default:
+      return "todo";
+  }
+};
+
 export default function TaskEditModal({
   task,
   properties,
@@ -26,6 +51,9 @@ export default function TaskEditModal({
   const [selectedProps, setSelectedProps] = useState<string[]>(
     task.properties.map((p) => p.id)
   );
+  const [status, setStatus] = useState<StatusOptionValue>(
+    normalizeStatus(task.status)
+  );
   const [vendorId, setVendorId] = useState<string>(task.vendor?.id ?? "");
   const [attachments, setAttachments] = useState<
     TaskDto["attachments"]
@@ -39,6 +67,7 @@ export default function TaskEditModal({
     setSelectedProps(task.properties.map((p) => p.id));
     setVendorId(task.vendor?.id ?? "");
     setAttachments(task.attachments ?? []);
+    setStatus(normalizeStatus(task.status));
   }, [task]);
 
   const handleFiles = (files: FileList | null) => {
@@ -65,6 +94,7 @@ export default function TaskEditModal({
       dueTime: dueTime || undefined,
       properties: props,
       vendor: vendor ? { id: vendor.id!, name: vendor.name } : null,
+      status,
       attachments,
     });
   };
@@ -162,6 +192,20 @@ export default function TaskEditModal({
             {vendors.map((v) => (
               <option key={v.id} value={v.id}>
                 {v.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="mb-1 block text-sm dark:text-gray-200">Status</label>
+          <select
+            className="w-full rounded-md border border-gray-300 p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+            value={status}
+            onChange={(e) => setStatus(normalizeStatus(e.target.value))}
+          >
+            {STATUS_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
               </option>
             ))}
           </select>


### PR DESCRIPTION
## Summary
- add normalized task status options to the task edit modal and persist the selection when saving
- show a color-coded status indicator on task cards for To-Do, Doing, and Complete states

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config.js)*


------
https://chatgpt.com/codex/tasks/task_e_68d4a9241d94832cb0579552240aea02