### PR TITLE
Keep task cards visible when updating status indicator

### DIFF
--- a/components/tasks/TaskCard.tsx
+++ b/components/tasks/TaskCard.tsx
@@ -1,6 +1,10 @@
 "use client";
 import React from "react";
 import type { TaskDto } from "../../types/tasks";
+import {
+  deriveIndicatorForTask,
+  getIndicatorPresentation,
+} from "./statusIndicator";
 
 export default function TaskCard({
   task,
@@ -41,8 +45,15 @@ export default function TaskCard({
       (startOfDue.getTime() - startOfToday.getTime()) / (1000 * 60 * 60 * 24);
     return diff === 1;
   })();
+  const normalizedStatus = (task.status ?? "").toLowerCase();
   const completed =
-    typeof isCompleted === "boolean" ? isCompleted : task.status === "done";
+    typeof isCompleted === "boolean"
+      ? isCompleted
+      : normalizedStatus === "done" || normalizedStatus === "complete";
+  const indicatorValue = completed
+    ? "done"
+    : deriveIndicatorForTask({ status: task.status, tags: task.tags });
+  const statusInfo = getIndicatorPresentation(indicatorValue);
 
   return (
     <div
@@ -53,13 +64,13 @@ export default function TaskCard({
     >
       <div className="flex items-start justify-between gap-2">
         <div className="font-medium">{task.title}</div>
-        {completed && (
+        {statusInfo && (
           <span className="inline-flex h-2.5 w-2.5 items-center justify-center">
             <span
-              className="h-2.5 w-2.5 rounded-full bg-green-500"
+              className={`h-2.5 w-2.5 rounded-full ${statusInfo.color}`}
               aria-hidden
             />
-            <span className="sr-only">Completed</span>
+            <span className="sr-only">{statusInfo.label}</span>
           </span>
         )}
       </div>

--- a/components/tasks/TaskEditModal.tsx
+++ b/components/tasks/TaskEditModal.tsx
@@ -3,6 +3,13 @@ import { useState, useEffect } from "react";
 import type { TaskDto } from "../../types/tasks";
 import type { PropertySummary } from "../../types/property";
 import type { Vendor } from "../../lib/api";
+import {
+  STATUS_INDICATOR_OPTIONS,
+  coerceStatusIndicatorValue,
+  deriveIndicatorForTask,
+  mergeIndicatorIntoTags,
+  type StatusIndicatorValue,
+} from "./statusIndicator";
 
 export default function TaskEditModal({
   task,
@@ -26,6 +33,9 @@ export default function TaskEditModal({
   const [selectedProps, setSelectedProps] = useState<string[]>(
     task.properties.map((p) => p.id)
   );
+  const [statusIndicator, setStatusIndicator] = useState<StatusIndicatorValue>(
+    deriveIndicatorForTask({ status: task.status, tags: task.tags })
+  );
   const [vendorId, setVendorId] = useState<string>(task.vendor?.id ?? "");
   const [attachments, setAttachments] = useState<
     TaskDto["attachments"]
@@ -39,6 +49,9 @@ export default function TaskEditModal({
     setSelectedProps(task.properties.map((p) => p.id));
     setVendorId(task.vendor?.id ?? "");
     setAttachments(task.attachments ?? []);
+    setStatusIndicator(
+      deriveIndicatorForTask({ status: task.status, tags: task.tags })
+    );
   }, [task]);
 
   const handleFiles = (files: FileList | null) => {
@@ -58,6 +71,8 @@ export default function TaskEditModal({
     const vendor = vendorId
       ? vendors.find((v) => v.id === vendorId)
       : undefined;
+    const nextTags = mergeIndicatorIntoTags(task.tags, statusIndicator);
+
     onSave({
       title,
       description,
@@ -66,6 +81,7 @@ export default function TaskEditModal({
       properties: props,
       vendor: vendor ? { id: vendor.id!, name: vendor.name } : null,
       attachments,
+      tags: nextTags,
     });
   };
 
@@ -162,6 +178,24 @@ export default function TaskEditModal({
             {vendors.map((v) => (
               <option key={v.id} value={v.id}>
                 {v.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="mb-1 block text-sm dark:text-gray-200">Status</label>
+          <select
+            className="w-full rounded-md border border-gray-300 p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+            value={statusIndicator}
+            onChange={(e) =>
+              setStatusIndicator(
+                coerceStatusIndicatorValue(e.target.value)
+              )
+            }
+          >
+            {STATUS_INDICATOR_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
               </option>
             ))}
           </select>

--- a/components/tasks/statusIndicator.ts
+++ b/components/tasks/statusIndicator.ts
@@ -1,0 +1,102 @@
+import type { TaskDto } from "../../types/tasks";
+
+export const STATUS_INDICATOR_TAG_PREFIX = "__status_indicator:";
+
+export const STATUS_INDICATOR_OPTIONS = [
+  { value: "todo", label: "To-Do", color: "bg-blue-500" },
+  { value: "doing", label: "Doing", color: "bg-orange-500" },
+  { value: "done", label: "Complete", color: "bg-green-500" },
+] as const;
+
+export type StatusIndicatorValue =
+  (typeof STATUS_INDICATOR_OPTIONS)[number]["value"];
+
+const optionByValue = STATUS_INDICATOR_OPTIONS.reduce(
+  (acc, option) => {
+    acc[option.value] = option;
+    return acc;
+  },
+  {} as Record<StatusIndicatorValue, (typeof STATUS_INDICATOR_OPTIONS)[number]>
+);
+
+const normalizeString = (value?: string | null) =>
+  (value ?? "").trim().toLowerCase();
+
+const isDoneStatus = (status?: string | null) => {
+  const normalized = normalizeString(status);
+  return (
+    normalized === "done" ||
+    normalized === "completed" ||
+    normalized === "complete"
+  );
+};
+
+const isDoingStatus = (status?: string | null) => {
+  const normalized = normalizeString(status);
+  return (
+    normalized === "doing" ||
+    normalized === "in_progress" ||
+    normalized === "in-progress" ||
+    normalized === "in progress"
+  );
+};
+
+export const isStatusIndicatorValue = (
+  value: string
+): value is StatusIndicatorValue =>
+  STATUS_INDICATOR_OPTIONS.some((option) => option.value === value);
+
+export const coerceStatusIndicatorValue = (
+  value?: string | null
+): StatusIndicatorValue => {
+  if (value && isStatusIndicatorValue(value)) {
+    return value;
+  }
+  return "todo";
+};
+
+export const extractIndicatorFromTags = (
+  tags?: string[] | null
+): StatusIndicatorValue | null => {
+  if (!tags?.length) return null;
+  const match = tags.find((tag) =>
+    tag.startsWith(STATUS_INDICATOR_TAG_PREFIX)
+  );
+  if (!match) return null;
+  const [, value] = match.split(STATUS_INDICATOR_TAG_PREFIX);
+  return value && isStatusIndicatorValue(value) ? value : null;
+};
+
+export const deriveIndicatorForTask = (
+  task: Pick<TaskDto, "status" | "tags">
+): StatusIndicatorValue => {
+  if (isDoneStatus(task.status)) {
+    return "done";
+  }
+
+  const tagged = extractIndicatorFromTags(task.tags);
+  if (tagged) {
+    return tagged;
+  }
+
+  if (isDoingStatus(task.status)) {
+    return "doing";
+  }
+
+  return "todo";
+};
+
+export const mergeIndicatorIntoTags = (
+  tags: string[] | undefined,
+  indicator: StatusIndicatorValue
+): string[] => {
+  const base = tags?.filter(
+    (tag) => !tag.startsWith(STATUS_INDICATOR_TAG_PREFIX)
+  ) ?? [];
+
+  return [...base, `${STATUS_INDICATOR_TAG_PREFIX}${indicator}`];
+};
+
+export const getIndicatorPresentation = (
+  indicator: StatusIndicatorValue
+) => optionByValue[indicator];


### PR DESCRIPTION
## Summary
- add a shared status indicator helper that stores the To-Do/Doing/Complete selection in a dedicated tag without altering the kanban status
- update the task edit modal to save the indicator tag and leave the task's real status unchanged so cards stay in their original columns
- render task cards using the saved indicator tag (or completion state) for the blue/orange/green pill instead of relying on the kanban status value

## Testing
- npm install *(fails: registry returns HTTP 403 for @tanstack/react-query)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a9241d94832cb0579552240aea02