### PR TITLE
Add cashflow chart mode toggle

### DIFF
--- a/components/dashboard/CashflowLineChart.tsx
+++ b/components/dashboard/CashflowLineChart.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import type { KeyboardEvent } from 'react';
+import type { KeyboardEvent, MouseEvent } from 'react';
+import { useMemo, useState } from 'react';
 import { ResponsiveContainer, LineChart, Line, Tooltip, Legend, XAxis, YAxis, CartesianGrid } from 'recharts';
 import { useRouter } from 'next/navigation';
 
@@ -11,8 +12,34 @@ interface Props {
   data: TimeSeriesPoint[];
 }
 
+type ChartMode = 'running' | 'cumulative';
+
 export default function CashflowLineChart({ data }: Props) {
   const router = useRouter();
+  const [mode, setMode] = useState<ChartMode>('running');
+
+  const chartData = useMemo(() => {
+    if (mode === 'running') {
+      return data;
+    }
+
+    let runningCashIn = 0;
+    let runningCashOut = 0;
+    let runningNet = 0;
+
+    return data.map((point) => {
+      runningCashIn += point.cashInCents;
+      runningCashOut += point.cashOutCents;
+      runningNet += point.netCents;
+
+      return {
+        ...point,
+        cashInCents: runningCashIn,
+        cashOutCents: runningCashOut,
+        netCents: runningNet,
+      } satisfies TimeSeriesPoint;
+    });
+  }, [data, mode]);
 
   const handleNavigate = () => {
     router.push('/analytics/overview');
@@ -25,6 +52,13 @@ export default function CashflowLineChart({ data }: Props) {
     }
   };
 
+  const handleToggleClick = (event: MouseEvent<HTMLButtonElement>, nextMode: ChartMode) => {
+    event.stopPropagation();
+    setMode(nextMode);
+  };
+
+  const title = mode === 'running' ? 'Running Cashflow' : 'Cumulative Cashflow';
+
   return (
     <div
       className="p-4 rounded-2xl card cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-base)]"
@@ -34,8 +68,39 @@ export default function CashflowLineChart({ data }: Props) {
       onClick={handleNavigate}
       onKeyDown={handleKeyDown}
     >
+      <div className="mb-4 flex items-center justify-between gap-4">
+        <h3 className="text-lg font-semibold text-[var(--text-primary)]">{title}</h3>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={(event) => handleToggleClick(event, 'running')}
+            className={`flex h-10 w-10 items-center justify-center rounded-full border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-base)] ${
+              mode === 'running'
+                ? 'border-transparent bg-[var(--bg-elevated)] text-[var(--text-primary)] shadow-sm'
+                : 'border-[var(--border)] bg-transparent text-[var(--text-secondary)] hover:bg-[var(--hover)]'
+            }`}
+            aria-label="Show running cashflow"
+            aria-pressed={mode === 'running'}
+          >
+            <RunningLineIcon className="h-5 w-5" />
+          </button>
+          <button
+            type="button"
+            onClick={(event) => handleToggleClick(event, 'cumulative')}
+            className={`flex h-10 w-10 items-center justify-center rounded-full border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-base)] ${
+              mode === 'cumulative'
+                ? 'border-transparent bg-[var(--bg-elevated)] text-[var(--text-primary)] shadow-sm'
+                : 'border-[var(--border)] bg-transparent text-[var(--text-secondary)] hover:bg-[var(--hover)]'
+            }`}
+            aria-label="Show cumulative cashflow"
+            aria-pressed={mode === 'cumulative'}
+          >
+            <CumulativeLineIcon className="h-5 w-5" />
+          </button>
+        </div>
+      </div>
       <ResponsiveContainer width="100%" height={300}>
-        <LineChart data={data} margin={{ top: 16, right: 48, bottom: 0, left: 32 }}>
+        <LineChart data={chartData} margin={{ top: 16, right: 48, bottom: 0, left: 32 }}>
           <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
           <XAxis
             dataKey="date"
@@ -61,5 +126,51 @@ export default function CashflowLineChart({ data }: Props) {
         </LineChart>
       </ResponsiveContainer>
     </div>
+  );
+}
+
+function RunningLineIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      stroke="currentColor"
+      strokeWidth={1.8}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <polyline points="3 16 7.5 11 12 14 16 7 21 13" />
+      <circle cx="7.5" cy="11" r="1.2" fill="currentColor" />
+      <circle cx="12" cy="14" r="1.2" fill="currentColor" />
+      <circle cx="16" cy="7" r="1.2" fill="currentColor" />
+      <circle cx="21" cy="13" r="1.2" fill="currentColor" />
+    </svg>
+  );
+}
+
+function CumulativeLineIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      stroke="currentColor"
+      strokeWidth={1.8}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M3 17h18" strokeOpacity={0.4} />
+      <path d="M3 12h18" strokeOpacity={0.4} />
+      <path d="M3 7h18" strokeOpacity={0.4} />
+      <path
+        d="M4 16L8 12L12 13L16 9L20 8V16H4Z"
+        fill="currentColor"
+        fillOpacity={0.15}
+        stroke="currentColor"
+      />
+    </svg>
   );
 }


### PR DESCRIPTION
## Summary
- add a header with chart mode toggle buttons to the cashflow line chart
- compute cumulative cashflow series and switch the graph between running and cumulative modes
- update the chart title to reflect the active cashflow mode and add custom icons for the toggle buttons

## Testing
- npm run lint *(fails: ESLint 9 requires eslint.config.js when dependencies cannot be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d4c7c50ea4832c81f0912df33d07e4