### PR TITLE
feat: build analytics overview dashboard

### DIFF
--- a/app/(app)/analytics/overview/components/ChartCashflow.tsx
+++ b/app/(app)/analytics/overview/components/ChartCashflow.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { forwardRef, useMemo, useState } from 'react';
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  Brush,
+} from 'recharts';
+import { formatValue } from './KpiCard';
+
+type Bucket = {
+  label: string;
+  income: number;
+  expenses: number;
+  net: number;
+};
+
+type Props = {
+  data: Bucket[];
+  onBrushChange?: (range: { from: string; to: string }) => void;
+};
+
+const SERIES = [
+  { key: 'income' as const, label: 'Income', colour: 'var(--chart-2)' },
+  { key: 'expenses' as const, label: 'Expenses', colour: 'var(--chart-5)' },
+  { key: 'net' as const, label: 'Net', colour: 'var(--chart-1)' },
+];
+
+function formatCurrency(value: number) {
+  return formatValue(value, 'currency');
+}
+
+const ChartCashflow = forwardRef<HTMLDivElement, Props>(({ data, onBrushChange }, ref) => {
+  const [activeKeys, setActiveKeys] = useState(() => new Set(SERIES.map((item) => item.key)));
+
+  const handleLegendClick = (key: typeof SERIES[number]['key']) => {
+    setActiveKeys((current) => {
+      const next = new Set(current);
+      if (next.has(key)) {
+        if (next.size > 1) {
+          next.delete(key);
+        }
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
+
+  const lines = useMemo(() => SERIES.filter((item) => activeKeys.has(item.key)), [activeKeys]);
+
+  return (
+    <div ref={ref} className="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4 shadow-sm" role="img" aria-label="Cashflow over time">
+      <h3 className="text-sm font-medium text-gray-800 dark:text-gray-100">Cashflow Over Time</h3>
+      <div className="mt-4 h-72">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data} margin={{ left: 0, right: 16, top: 8, bottom: 8 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--chart-grid, rgba(148, 163, 184, 0.3))" />
+            <XAxis dataKey="label" tick={{ fontSize: 12 }} minTickGap={16} />
+            <YAxis
+              tick={{ fontSize: 12 }}
+              tickFormatter={(value) => formatCurrency(value as number)}
+              width={90}
+            />
+            <Tooltip
+              contentStyle={{ borderRadius: 12, borderColor: 'var(--chart-1)' }}
+              formatter={(value: number, name) => [formatCurrency(value), name]}
+              labelFormatter={(label) => `Period: ${label}`}
+            />
+            <Legend
+              onClick={(entry) => handleLegendClick(entry.dataKey as typeof SERIES[number]['key'])}
+              wrapperStyle={{ fontSize: 12 }}
+            />
+            {lines.map((series) => (
+              <Line
+                key={series.key}
+                type="monotone"
+                dataKey={series.key}
+                stroke={series.colour}
+                strokeWidth={2}
+                dot={false}
+                isAnimationActive={false}
+              />
+            ))}
+            <Brush
+              travellerWidth={12}
+              height={24}
+              stroke="var(--chart-1)"
+              onChange={(range) => {
+                if (!range || range.startIndex === undefined || range.endIndex === undefined) return;
+                const fromBucket = data[range.startIndex];
+                const toBucket = data[range.endIndex];
+                if (!fromBucket || !toBucket) return;
+                onBrushChange?.({ from: fromBucket.label, to: toBucket.label });
+              }}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+});
+
+ChartCashflow.displayName = 'ChartCashflow';
+
+export default ChartCashflow;

--- a/app/(app)/analytics/overview/components/ChartExpenseDonut.tsx
+++ b/app/(app)/analytics/overview/components/ChartExpenseDonut.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { forwardRef } from 'react';
+import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip, Legend } from 'recharts';
+
+type Item = {
+  category: string;
+  value: number;
+};
+
+type Props = {
+  data: Item[];
+  total: number;
+  selectedCategory?: string | null;
+  onSelectCategory?: (category: string | null) => void;
+};
+
+const COLOURS = [
+  'var(--chart-1)',
+  'var(--chart-2)',
+  'var(--chart-3)',
+  'var(--chart-4)',
+  'var(--chart-5)',
+  'var(--chart-6)',
+  'var(--chart-7)',
+  'var(--chart-8)',
+];
+
+function formatPercentage(value: number, total: number) {
+  if (total === 0) return '0%';
+  return `${((value / total) * 100).toFixed(1)}%`;
+}
+
+const ChartExpenseDonut = forwardRef<HTMLDivElement, Props>(
+  ({ data, total, selectedCategory, onSelectCategory }, ref),
+) => {
+  return (
+    <div
+      ref={ref}
+      className="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4 shadow-sm"
+      role="img"
+      aria-label="Expense breakdown"
+    >
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-medium text-gray-800 dark:text-gray-100">Expense Breakdown</h3>
+        {selectedCategory && (
+          <button
+            type="button"
+            className="text-xs text-blue-600 hover:underline"
+            onClick={() => onSelectCategory?.(null)}
+          >
+            Clear
+          </button>
+        )}
+      </div>
+      <div className="mt-4 h-72">
+        <ResponsiveContainer width="100%" height="100%">
+          <PieChart>
+            <Pie
+              data={data}
+              dataKey="value"
+              nameKey="category"
+              innerRadius={60}
+              outerRadius={90}
+              paddingAngle={3}
+              onClick={(entry) => {
+                const category = entry.category as string;
+                if (selectedCategory === category) {
+                  onSelectCategory?.(null);
+                } else {
+                  onSelectCategory?.(category);
+                }
+              }}
+            >
+              {data.map((entry, index) => (
+                <Cell
+                  key={entry.category}
+                  fill={COLOURS[index % COLOURS.length]}
+                  opacity={selectedCategory && selectedCategory !== entry.category ? 0.4 : 1}
+                />
+              ))}
+            </Pie>
+            <Tooltip
+              formatter={(value: number, name: string, entry) => {
+                const percentage = formatPercentage(entry.value as number, total);
+                return [`${value.toLocaleString('en-AU', { maximumFractionDigits: 0 })} (${percentage})`, name];
+              }}
+            />
+            <Legend wrapperStyle={{ fontSize: 12 }} />
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+};
+
+ChartExpenseDonut.displayName = 'ChartExpenseDonut';
+
+export default ChartExpenseDonut;

--- a/app/(app)/analytics/overview/components/ChartPropertyCompare.tsx
+++ b/app/(app)/analytics/overview/components/ChartPropertyCompare.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { forwardRef } from 'react';
+import {
+  ResponsiveContainer,
+  BarChart,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  Bar,
+} from 'recharts';
+import { formatValue } from './KpiCard';
+
+type Item = {
+  propertyId: string;
+  propertyLabel: string;
+  net: number;
+};
+
+type Props = {
+  data: Item[];
+  hiddenCount?: number;
+};
+
+const ChartPropertyCompare = forwardRef<HTMLDivElement, Props>(({ data, hiddenCount = 0 }, ref) => {
+  return (
+    <div
+      ref={ref}
+      className="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4 shadow-sm"
+      role="img"
+      aria-label="Net cashflow by property"
+    >
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-medium text-gray-800 dark:text-gray-100">Property Comparison</h3>
+        {hiddenCount > 0 && (
+          <span className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-200">
+            +{hiddenCount}
+          </span>
+        )}
+      </div>
+      <div className="mt-4 h-72">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={data} margin={{ left: 0, right: 16, top: 8, bottom: 8 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--chart-grid, rgba(148, 163, 184, 0.3))" />
+            <XAxis dataKey="propertyLabel" tick={{ fontSize: 12 }} interval={0} angle={-20} height={70} textAnchor="end" />
+            <YAxis tick={{ fontSize: 12 }} tickFormatter={(value) => formatValue(value as number, 'currency')} width={90} />
+            <Tooltip formatter={(value: number) => formatValue(value, 'currency')} />
+            <Legend formatter={() => 'Net cashflow'} wrapperStyle={{ fontSize: 12 }} />
+            <Bar dataKey="net" fill="var(--chart-2)" radius={[6, 6, 0, 0]} isAnimationActive={false} />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+});
+
+ChartPropertyCompare.displayName = 'ChartPropertyCompare';
+
+export default ChartPropertyCompare;

--- a/app/(app)/analytics/overview/components/DateRangePicker.tsx
+++ b/app/(app)/analytics/overview/components/DateRangePicker.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { formatDate, startOfFinancialYear } from '../lib/urlState';
+
+type DateRangeValue = {
+  from: string;
+  to: string;
+};
+
+type PresetKey = 'this_month' | 'last_3_months' | 'fytd' | 'last_fy' | 'custom';
+
+const PRESETS: { key: PresetKey; label: string }[] = [
+  { key: 'this_month', label: 'This Month' },
+  { key: 'last_3_months', label: 'Last 3 Months' },
+  { key: 'fytd', label: 'FYTD' },
+  { key: 'last_fy', label: 'Last FY' },
+];
+
+type Props = {
+  value: DateRangeValue;
+  onChange: (value: DateRangeValue, preset?: PresetKey) => void;
+};
+
+function computePresetRange(key: PresetKey, today = new Date()): DateRangeValue {
+  const end = new Date(today);
+  switch (key) {
+    case 'this_month': {
+      const from = new Date(end.getFullYear(), end.getMonth(), 1);
+      return { from: formatDate(from), to: formatDate(end) };
+    }
+    case 'last_3_months': {
+      const from = new Date(end.getFullYear(), end.getMonth() - 2, 1);
+      return { from: formatDate(from), to: formatDate(end) };
+    }
+    case 'fytd': {
+      const from = startOfFinancialYear(end);
+      return { from: formatDate(from), to: formatDate(end) };
+    }
+    case 'last_fy': {
+      const fyStart = startOfFinancialYear(end);
+      const start = new Date(fyStart.getFullYear() - 1, fyStart.getMonth(), fyStart.getDate());
+      const finish = new Date(fyStart.getTime() - 24 * 60 * 60 * 1000);
+      return { from: formatDate(start), to: formatDate(finish) };
+    }
+    default:
+      return { from: formatDate(end), to: formatDate(end) };
+  }
+}
+
+function isSameRange(a: DateRangeValue, b: DateRangeValue) {
+  return a.from === b.from && a.to === b.to;
+}
+
+export function DateRangePicker({ value, onChange }: Props) {
+  const [customFrom, setCustomFrom] = useState<string>(value.from);
+  const [customTo, setCustomTo] = useState<string>(value.to);
+
+  const activePreset = useMemo(() => {
+    for (const preset of PRESETS) {
+      const range = computePresetRange(preset.key);
+      if (isSameRange(range, value)) return preset.key;
+    }
+    return undefined;
+  }, [value]);
+
+  const handlePresetClick = (key: PresetKey) => {
+    const range = computePresetRange(key);
+    setCustomFrom(range.from);
+    setCustomTo(range.to);
+    onChange(range, key);
+  };
+
+  const handleCustomChange = (next: DateRangeValue) => {
+    const fromDate = new Date(next.from);
+    const toDate = new Date(next.to);
+    if (Number.isNaN(fromDate.getTime()) || Number.isNaN(toDate.getTime())) return;
+    if (fromDate > toDate) return;
+    onChange(next, 'custom');
+  };
+
+  return (
+    <div className="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4 shadow-sm space-y-3" data-testid="date-range-picker">
+      <div className="flex flex-wrap gap-2" role="group" aria-label="Date range presets">
+        {PRESETS.map((preset) => {
+          const isActive = preset.key === activePreset;
+          return (
+            <button
+              key={preset.key}
+              type="button"
+              onClick={() => handlePresetClick(preset.key)}
+              className={`px-3 py-1.5 rounded-full text-sm border transition ${
+                isActive
+                  ? 'bg-blue-600 text-white border-blue-600'
+                  : 'border-gray-200 dark:border-gray-700 hover:border-blue-500'
+              }`}
+            >
+              {preset.label}
+            </button>
+          );
+        })}
+      </div>
+      <div className="flex flex-col gap-2 text-sm" aria-label="Custom date range">
+        <div className="flex items-center gap-2">
+          <label className="w-16 text-gray-600 dark:text-gray-300" htmlFor="overview-from">
+            From
+          </label>
+          <input
+            id="overview-from"
+            type="date"
+            value={customFrom}
+            onChange={(event) => {
+              const next = event.target.value;
+              setCustomFrom(next);
+              handleCustomChange({ from: next, to: customTo });
+            }}
+            className="flex-1 rounded-md border border-gray-200 dark:border-gray-700 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <label className="w-16 text-gray-600 dark:text-gray-300" htmlFor="overview-to">
+            To
+          </label>
+          <input
+            id="overview-to"
+            type="date"
+            value={customTo}
+            onChange={(event) => {
+              const next = event.target.value;
+              setCustomTo(next);
+              handleCustomChange({ from: customFrom, to: next });
+            }}
+            className="flex-1 rounded-md border border-gray-200 dark:border-gray-700 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default DateRangePicker;

--- a/app/(app)/analytics/overview/components/ExportButtons.tsx
+++ b/app/(app)/analytics/overview/components/ExportButtons.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useState } from 'react';
+import { toPng } from 'html-to-image';
+
+export type CsvSection = {
+  label: string;
+  headers: string[];
+  rows: (string | number)[][];
+};
+
+export type ChartRef = {
+  id: string;
+  label: string;
+  element: HTMLElement | null;
+};
+
+type Props = {
+  csvSections: CsvSection[];
+  charts: ChartRef[];
+  fileName?: string;
+};
+
+function buildCsv(sections: CsvSection[]) {
+  const lines: string[] = [];
+  sections.forEach((section, index) => {
+    if (index > 0) lines.push('');
+    lines.push(section.label);
+    lines.push(section.headers.join(','));
+    section.rows.forEach((row) => {
+      lines.push(row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(','));
+    });
+  });
+  return lines.join('\n');
+}
+
+export function ExportButtons({ csvSections, charts, fileName = 'analytics-overview' }: Props) {
+  const [selectedChartId, setSelectedChartId] = useState(charts[0]?.id ?? '');
+  const hasCharts = charts.some((chart) => chart.element);
+
+  const handleExportCsv = () => {
+    if (!csvSections.length) return;
+    const csvContent = buildCsv(csvSections);
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `${fileName}.csv`;
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleExportPng = async () => {
+    if (!hasCharts) return;
+    const chart = charts.find((item) => item.id === selectedChartId) ?? charts[0];
+    if (!chart?.element) return;
+    const dataUrl = await toPng(chart.element, { pixelRatio: 2 });
+    const link = document.createElement('a');
+    link.href = dataUrl;
+    link.download = `${fileName}-${chart.id}.png`;
+    link.click();
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4 shadow-sm">
+      <div className="flex items-center gap-2 text-sm">
+        <label htmlFor="export-chart" className="text-gray-600 dark:text-gray-300">
+          Chart
+        </label>
+        <select
+          id="export-chart"
+          value={selectedChartId}
+          onChange={(event) => setSelectedChartId(event.target.value)}
+          disabled={!hasCharts}
+          className="rounded-md border border-gray-200 dark:border-gray-700 bg-transparent px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {charts.map((chart) => (
+            <option key={chart.id} value={chart.id}>
+              {chart.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          className="rounded-full border border-gray-200 dark:border-gray-700 px-4 py-2 text-sm font-medium text-gray-700 hover:border-blue-500 hover:text-blue-600 dark:text-gray-200 disabled:cursor-not-allowed disabled:opacity-60"
+          onClick={handleExportCsv}
+          disabled={!csvSections.length}
+        >
+          Export CSV
+        </button>
+        <button
+          type="button"
+          className="rounded-full border border-gray-200 dark:border-gray-700 px-4 py-2 text-sm font-medium text-gray-700 hover:border-blue-500 hover:text-blue-600 dark:text-gray-200 disabled:cursor-not-allowed disabled:opacity-60"
+          onClick={handleExportPng}
+          disabled={!hasCharts}
+        >
+          Export PNG
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default ExportButtons;

--- a/app/(app)/analytics/overview/components/KpiCard.tsx
+++ b/app/(app)/analytics/overview/components/KpiCard.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+type Props = {
+  title: string;
+  value: number | null | undefined;
+  format?: 'currency' | 'percentage' | 'number';
+  precision?: number;
+  subtitle?: string;
+  tooltip?: string;
+};
+
+const currencyFormatter = new Intl.NumberFormat('en-AU', {
+  style: 'currency',
+  currency: 'AUD',
+  maximumFractionDigits: 0,
+});
+
+export function formatValue(
+  value: number,
+  format: Props['format'] = 'number',
+  precision = 1,
+) {
+  switch (format) {
+    case 'currency':
+      return currencyFormatter.format(value);
+    case 'percentage':
+      return `${value.toFixed(precision)}%`;
+    default:
+      return value.toLocaleString('en-AU', {
+        maximumFractionDigits: precision,
+      });
+  }
+}
+
+export function KpiCard({ title, value, format = 'number', precision = 1, subtitle, tooltip }: Props) {
+  const display =
+    value === null || value === undefined ? '—' : formatValue(value, format, precision);
+  return (
+    <div
+      className="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4 shadow-sm"
+      role="status"
+      aria-live="polite"
+      title={tooltip}
+    >
+      <p className="text-sm text-gray-500 dark:text-gray-400">{title}</p>
+      <p className="mt-2 text-2xl font-semibold text-gray-900 dark:text-gray-50" data-testid={`kpi-${title.replace(/\s+/g, '-').toLowerCase()}`}>
+        {display}
+      </p>
+      {subtitle && <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">{subtitle}</p>}
+    </div>
+  );
+}
+
+export default KpiCard;

--- a/app/(app)/analytics/overview/components/PropertyMultiSelect.tsx
+++ b/app/(app)/analytics/overview/components/PropertyMultiSelect.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+type PropertyOption = {
+  id: string;
+  address: string;
+  imageUrl?: string;
+};
+
+type Props = {
+  properties: PropertyOption[];
+  selected: string[];
+  onChange: (next: string[]) => void;
+};
+
+export function PropertyMultiSelect({ properties, selected, onChange }: Props) {
+  const [search, setSearch] = useState('');
+  const options = useMemo(() => {
+    if (!search.trim()) return properties;
+    const lower = search.toLowerCase();
+    return properties.filter((property) => property.address.toLowerCase().includes(lower));
+  }, [properties, search]);
+
+  const toggle = (id: string) => {
+    if (selected.includes(id)) {
+      onChange(selected.filter((value) => value !== id));
+    } else {
+      onChange([...selected, id]);
+    }
+  };
+
+  const isAllSelected = selected.length === 0;
+
+  return (
+    <div className="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4 shadow-sm space-y-3" data-testid="property-filter">
+      <div className="flex items-center justify-between gap-2">
+        <h3 className="text-sm font-medium text-gray-800 dark:text-gray-100">Properties</h3>
+        <button
+          type="button"
+          className="text-xs text-blue-600 hover:underline"
+          onClick={() => onChange([])}
+        >
+          Clear
+        </button>
+      </div>
+      <div>
+        <label htmlFor="property-search" className="sr-only">
+          Search properties
+        </label>
+        <input
+          id="property-search"
+          type="search"
+          placeholder="Search properties"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          className="w-full rounded-md border border-gray-200 dark:border-gray-700 bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </div>
+      <div className="max-h-52 overflow-y-auto space-y-2" role="listbox" aria-label="Select properties">
+        <button
+          type="button"
+          onClick={() => onChange([])}
+          className={`flex w-full items-center gap-3 rounded-lg border px-3 py-2 text-left text-sm transition ${
+            isAllSelected
+              ? 'border-blue-500 bg-blue-50 text-blue-700 dark:bg-blue-900/30'
+              : 'border-gray-200 dark:border-gray-700 hover:border-blue-400'
+          }`}
+        >
+          <span className="flex h-8 w-8 items-center justify-center rounded-full bg-blue-100 text-blue-600 text-xs font-medium">
+            All
+          </span>
+          <span>All properties</span>
+        </button>
+        {options.map((property) => {
+          const checked = selected.includes(property.id);
+          return (
+            <label
+              key={property.id}
+              className={`flex items-center gap-3 rounded-lg border px-3 py-2 text-sm transition cursor-pointer ${
+                checked
+                  ? 'border-blue-500 bg-blue-50 text-blue-700 dark:bg-blue-900/30'
+                  : 'border-gray-200 dark:border-gray-700 hover:border-blue-400'
+              }`}
+            >
+              <input
+                type="checkbox"
+                checked={checked}
+                onChange={() => toggle(property.id)}
+                className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              />
+              <span className="flex h-9 w-9 items-center justify-center rounded-full bg-gray-100 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-200">
+                {property.address
+                  .split(' ')
+                  .slice(0, 2)
+                  .map((segment) => segment.charAt(0))
+                  .join('') || 'P'}
+              </span>
+              <span className="flex-1 text-gray-800 dark:text-gray-100">{property.address}</span>
+            </label>
+          );
+        })}
+        {options.length === 0 && (
+          <p className="text-sm text-gray-500">No properties found</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default PropertyMultiSelect;

--- a/app/(app)/analytics/overview/components/UpcomingList.tsx
+++ b/app/(app)/analytics/overview/components/UpcomingList.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+type UpcomingItem = {
+  type: 'lease' | 'insurance' | 'smokeAlarm' | 'inspection';
+  label: string;
+  dueOn: string;
+  propertyLabel: string;
+};
+
+type Props = {
+  items: UpcomingItem[];
+  onItemClick?: (item: UpcomingItem) => void;
+};
+
+const badgeStyles: Record<UpcomingItem['type'], string> = {
+  lease: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-200',
+  insurance: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-200',
+  smokeAlarm: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-200',
+  inspection: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-200',
+};
+
+function formatDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+export function UpcomingList({ items, onItemClick }: Props) {
+  return (
+    <div className="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4 shadow-sm" role="region" aria-label="Upcoming obligations">
+      <h3 className="text-sm font-medium text-gray-800 dark:text-gray-100">Upcoming Obligations</h3>
+      <ul className="mt-4 space-y-3 text-sm">
+        {items.length === 0 && (
+          <li className="text-gray-500">No upcoming items in this range.</li>
+        )}
+        {items.map((item) => (
+          <li key={`${item.type}-${item.label}-${item.dueOn}`}>
+            <button
+              type="button"
+              onClick={() => onItemClick?.(item)}
+              className="w-full rounded-xl border border-transparent px-3 py-2 text-left transition hover:border-blue-300 hover:bg-blue-50/60 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${badgeStyles[item.type]}`}>
+                      {item.type === 'smokeAlarm' ? 'Smoke alarm' : item.type.charAt(0).toUpperCase() + item.type.slice(1)}
+                    </span>
+                    <span className="text-xs text-gray-500">{formatDate(item.dueOn)}</span>
+                  </div>
+                  <p className="font-medium text-gray-800 dark:text-gray-100">{item.label}</p>
+                  <p className="text-xs text-gray-500">{item.propertyLabel}</p>
+                </div>
+              </div>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default UpcomingList;

--- a/app/(app)/analytics/overview/hooks/useAnalytics.ts
+++ b/app/(app)/analytics/overview/hooks/useAnalytics.ts
@@ -1,0 +1,147 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type { OverviewState } from '../lib/urlState';
+
+type BaseParams = Pick<OverviewState, 'from' | 'to' | 'propertyIds'>;
+
+type KpiResponse = {
+  netCashflow: number;
+  grossYield: number | null;
+  occupancyRate: number | null;
+  onTimeCollection: number | null;
+};
+
+type CashflowBucket = {
+  label: string;
+  income: number;
+  expenses: number;
+  net: number;
+};
+
+type CashflowResponse = {
+  buckets: CashflowBucket[];
+  granularity: 'month' | 'week';
+};
+
+type ExpenseBreakdownResponse = {
+  total: number;
+  items: { category: string; value: number }[];
+};
+
+type PropertySeriesResponse = {
+  items: { propertyId: string; propertyLabel: string; net: number }[];
+};
+
+type UpcomingResponse = {
+  items: {
+    type: 'lease' | 'insurance' | 'smokeAlarm' | 'inspection';
+    label: string;
+    dueOn: string;
+    propertyLabel: string;
+  }[];
+};
+
+type PropertySummary = {
+  id: string;
+  address: string;
+  imageUrl?: string;
+  rent: number;
+  leaseStart: string;
+  leaseEnd: string;
+  tenant: string;
+  value?: number;
+};
+
+function buildQuery(params: BaseParams) {
+  const search = new URLSearchParams();
+  search.set('from', params.from);
+  search.set('to', params.to);
+  if (params.propertyIds.length) {
+    search.set('propertyIds', params.propertyIds.join(','));
+  }
+  return search.toString();
+}
+
+async function fetchJson<T>(path: string, params: BaseParams): Promise<T> {
+  const query = buildQuery(params);
+  const url = `${path}?${query}`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error('Failed to fetch analytics data');
+  }
+  return response.json();
+}
+
+export function useOverviewKpis(params: BaseParams, enabled = true) {
+  return useQuery<KpiResponse>({
+    queryKey: ['analytics-kpis', params],
+    queryFn: () => fetchJson('/api/analytics/kpis', params),
+    staleTime: 30_000,
+    enabled,
+  });
+}
+
+export function useCashflowSeries(params: BaseParams, enabled = true) {
+  return useQuery<CashflowResponse>({
+    queryKey: ['analytics-cashflow', params],
+    queryFn: () => fetchJson('/api/analytics/series/cashflow', params),
+    staleTime: 30_000,
+    enabled,
+  });
+}
+
+export function useExpenseBreakdown(params: BaseParams, enabled = true) {
+  return useQuery<ExpenseBreakdownResponse>({
+    queryKey: ['analytics-expense-breakdown', params],
+    queryFn: () => fetchJson('/api/analytics/breakdown/expenses', params),
+    staleTime: 30_000,
+    enabled,
+  });
+}
+
+export function usePropertySeries(params: BaseParams, enabled = true) {
+  return useQuery<PropertySeriesResponse>({
+    queryKey: ['analytics-property-series', params],
+    queryFn: () => fetchJson('/api/analytics/series/by-property', params),
+    staleTime: 30_000,
+    enabled,
+  });
+}
+
+export function useUpcoming(params: BaseParams, enabled = true) {
+  const search = useMemo(() => {
+    const q = new URLSearchParams();
+    q.set('limit', '5');
+    q.set('from', params.from);
+    q.set('to', params.to);
+    if (params.propertyIds.length) {
+      q.set('propertyIds', params.propertyIds.join(','));
+    }
+    return q.toString();
+  }, [params.from, params.to, params.propertyIds]);
+
+  return useQuery<UpcomingResponse>({
+    queryKey: ['analytics-upcoming', params],
+    queryFn: async () => {
+      const response = await fetch(`/api/analytics/upcoming?${search}`);
+      if (!response.ok) throw new Error('Failed to load upcoming obligations');
+      return response.json();
+    },
+    staleTime: 30_000,
+    enabled,
+  });
+}
+
+export function useProperties() {
+  return useQuery<PropertySummary[]>({
+    queryKey: ['analytics-properties'],
+    queryFn: async () => {
+      const response = await fetch('/api/properties');
+      if (!response.ok) throw new Error('Failed to fetch properties');
+      return response.json();
+    },
+    staleTime: 60_000,
+  });
+}

--- a/app/(app)/analytics/overview/lib/urlState.ts
+++ b/app/(app)/analytics/overview/lib/urlState.ts
@@ -1,0 +1,90 @@
+export type OverviewState = {
+  from: string;
+  to: string;
+  propertyIds: string[];
+  expenseCategory?: string | null;
+};
+
+export type OverviewQuery = Pick<OverviewState, 'from' | 'to' | 'propertyIds'>;
+
+export const DATE_FORMATTER = new Intl.DateTimeFormat('en-CA');
+
+export function startOfFinancialYear(baseDate = new Date()): Date {
+  const month = baseDate.getMonth();
+  const year = baseDate.getFullYear();
+  const fyStartMonth = 6; // July (0-indexed)
+  const fyYear = month >= fyStartMonth ? year : year - 1;
+  return new Date(fyYear, fyStartMonth, 1);
+}
+
+export function formatDate(date: Date): string {
+  return DATE_FORMATTER.format(date);
+}
+
+export function defaultState(today = new Date()): OverviewState {
+  const from = startOfFinancialYear(today);
+  return {
+    from: formatDate(from),
+    to: formatDate(today),
+    propertyIds: [],
+  };
+}
+
+export function parseStateFromSearch(search: URLSearchParams, today = new Date()): OverviewState {
+  const fallback = defaultState(today);
+  const from = search.get('from') ?? fallback.from;
+  const to = search.get('to') ?? fallback.to;
+  const propertiesRaw = search.get('properties');
+  const propertyIds = propertiesRaw
+    ? propertiesRaw
+        .split(',')
+        .map((id) => id.trim())
+        .filter(Boolean)
+    : fallback.propertyIds;
+  const category = search.get('category');
+
+  const fromDate = new Date(from);
+  const toDate = new Date(to);
+  if (Number.isNaN(fromDate.getTime()) || Number.isNaN(toDate.getTime())) {
+    return fallback;
+  }
+  if (fromDate > toDate) {
+    return {
+      ...fallback,
+      from: formatDate(toDate),
+      to: formatDate(fromDate),
+      propertyIds,
+      expenseCategory: category ?? undefined,
+    };
+  }
+
+  return {
+    from: formatDate(fromDate),
+    to: formatDate(toDate),
+    propertyIds,
+    expenseCategory: category ?? undefined,
+  };
+}
+
+export function buildSearchParams(state: OverviewState): URLSearchParams {
+  const params = new URLSearchParams();
+  params.set('from', state.from);
+  params.set('to', state.to);
+  if (state.propertyIds.length) {
+    params.set('properties', state.propertyIds.join(','));
+  }
+  if (state.expenseCategory) {
+    params.set('category', state.expenseCategory);
+  }
+  return params;
+}
+
+export function isSameState(a: OverviewState, b: OverviewState) {
+  return (
+    a.from === b.from &&
+    a.to === b.to &&
+    a.expenseCategory === b.expenseCategory &&
+    a.propertyIds.length === b.propertyIds.length &&
+    a.propertyIds.every((id, index) => id === b.propertyIds[index])
+  );
+}

--- a/app/(app)/analytics/overview/page.tsx
+++ b/app/(app)/analytics/overview/page.tsx
@@ -1,13 +1,321 @@
-import Link from 'next/link';
+'use client';
 
-export default function AnalyticsOverview() {
+import { useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
+import dynamic from 'next/dynamic';
+import { useRouter, useSearchParams } from 'next/navigation';
+import DateRangePicker from './components/DateRangePicker';
+import PropertyMultiSelect from './components/PropertyMultiSelect';
+import KpiCard from './components/KpiCard';
+import ExportButtons, { type CsvSection } from './components/ExportButtons';
+import UpcomingList from './components/UpcomingList';
+import {
+  buildSearchParams,
+  defaultState,
+  formatDate,
+  isSameState,
+  parseStateFromSearch,
+  type OverviewState,
+} from './lib/urlState';
+import {
+  useCashflowSeries,
+  useExpenseBreakdown,
+  useOverviewKpis,
+  useProperties,
+  usePropertySeries,
+  useUpcoming,
+} from './hooks/useAnalytics';
+
+const CashflowChart = dynamic(() => import('./components/ChartCashflow'), {
+  ssr: false,
+  loading: () => <ChartPlaceholder title="Cashflow Over Time" />,
+});
+
+const ExpenseDonut = dynamic(() => import('./components/ChartExpenseDonut'), {
+  ssr: false,
+  loading: () => <ChartPlaceholder title="Expense Breakdown" />,
+});
+
+const PropertyCompare = dynamic(() => import('./components/ChartPropertyCompare'), {
+  ssr: false,
+  loading: () => <ChartPlaceholder title="Property Comparison" />,
+});
+
+type ChartRange = { from: string; to: string };
+
+type ChartPlaceholderProps = { title: string };
+
+function ChartPlaceholder({ title }: ChartPlaceholderProps) {
   return (
-    <div className="p-6">
-      <Link href="/analytics" className="text-sm text-blue-600 hover:underline">
-        &larr; Back to Analytics
-      </Link>
-      <h1 className="text-2xl font-semibold mb-4 mt-2">Analytics Overview</h1>
-      <p>Standardised visualisations will appear here.</p>
+    <div className="rounded-2xl border border-dashed border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4 shadow-sm h-72 flex flex-col">
+      <h3 className="text-sm font-medium text-gray-600 dark:text-gray-300">{title}</h3>
+      <div className="flex flex-1 items-center justify-center text-sm text-gray-400">Loading…</div>
     </div>
   );
 }
+
+function toMonthRange(label: string): ChartRange | null {
+  if (!/\d{4}-\d{2}/.test(label)) return null;
+  const [year, month] = label.split('-').map((part) => Number.parseInt(part, 10));
+  if (Number.isNaN(year) || Number.isNaN(month)) return null;
+  const from = new Date(year, month - 1, 1);
+  const to = new Date(year, month, 0);
+  return { from: formatDate(from), to: formatDate(to) };
+}
+
+function buildCsvSections(params: {
+  cashflow?: { buckets: { label: string; income: number; expenses: number; net: number }[] };
+  breakdown?: { items: { category: string; value: number }[] };
+  properties?: { items: { propertyLabel: string; net: number }[] };
+}): CsvSection[] {
+  const sections: CsvSection[] = [];
+  if (params.cashflow && params.cashflow.buckets.length) {
+    sections.push({
+      label: 'Cashflow Series',
+      headers: ['Period', 'Income', 'Expenses', 'Net'],
+      rows: params.cashflow.buckets.map((bucket) => [
+        bucket.label,
+        bucket.income,
+        bucket.expenses,
+        bucket.net,
+      ]),
+    });
+  }
+  if (params.breakdown && params.breakdown.items.length) {
+    sections.push({
+      label: 'Expense Breakdown',
+      headers: ['Category', 'Value'],
+      rows: params.breakdown.items.map((item) => [item.category, item.value]),
+    });
+  }
+  if (params.properties && params.properties.items.length) {
+    sections.push({
+      label: 'Property Comparison',
+      headers: ['Property', 'Net Cashflow'],
+      rows: params.properties.items.map((item) => [item.propertyLabel, item.net]),
+    });
+  }
+  return sections;
+}
+
+function AnalyticsOverviewPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const searchKey = useMemo(() => searchParams.toString(), [searchParams]);
+  const initialFromUrl = useMemo(() => parseStateFromSearch(new URLSearchParams(searchKey)), [searchKey]);
+  const [filters, setFilters] = useState<OverviewState>(initialFromUrl ?? defaultState());
+  const [debouncedFilters, setDebouncedFilters] = useState<OverviewState>(filters);
+
+  useEffect(() => {
+    const handler = setTimeout(() => setDebouncedFilters(filters), 300);
+    return () => clearTimeout(handler);
+  }, [filters]);
+
+  useEffect(() => {
+    if (!isSameState(initialFromUrl, filters)) {
+      setFilters(initialFromUrl);
+      setDebouncedFilters(initialFromUrl);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialFromUrl.from, initialFromUrl.to, initialFromUrl.expenseCategory, initialFromUrl.propertyIds.join(',')]);
+
+  useEffect(() => {
+    const params = buildSearchParams(debouncedFilters).toString();
+    if (params === searchKey) return;
+    router.replace(`?${params}`, { scroll: false });
+  }, [debouncedFilters, router, searchKey]);
+
+  const propertiesQuery = useProperties();
+  const propertyOptions = propertiesQuery.data ?? [];
+  const baseParams = {
+    from: debouncedFilters.from,
+    to: debouncedFilters.to,
+    propertyIds: debouncedFilters.propertyIds,
+  };
+
+  const kpiQuery = useOverviewKpis(baseParams);
+  const cashflowQuery = useCashflowSeries(baseParams);
+  const breakdownQuery = useExpenseBreakdown(baseParams);
+  const propertySeriesQuery = usePropertySeries(baseParams);
+  const upcomingQuery = useUpcoming(baseParams);
+
+  const hasData =
+    (cashflowQuery.data?.buckets.length ?? 0) > 0 ||
+    (breakdownQuery.data?.items.length ?? 0) > 0 ||
+    (propertySeriesQuery.data?.items.length ?? 0) > 0;
+
+  const cashflowRef = useRef<HTMLDivElement>(null);
+  const expenseRef = useRef<HTMLDivElement>(null);
+  const propertyRef = useRef<HTMLDivElement>(null);
+
+  const csvSections = useMemo(
+    () =>
+      buildCsvSections({
+        cashflow: cashflowQuery.data,
+        breakdown: breakdownQuery.data,
+        properties: propertySeriesQuery.data,
+      }),
+    [breakdownQuery.data, cashflowQuery.data, propertySeriesQuery.data],
+  );
+
+  const hiddenPropertyCount = useMemo(() => {
+    if (!propertyOptions.length || debouncedFilters.propertyIds.length === 0) return 0;
+    const activeIds = new Set(propertyOptions.map((property) => property.id));
+    return Array.from(activeIds).filter((id) => !debouncedFilters.propertyIds.includes(id)).length;
+  }, [propertyOptions, debouncedFilters.propertyIds]);
+
+  const charts = [
+    { id: 'cashflow', label: 'Cashflow Over Time', element: cashflowRef.current },
+    { id: 'expenses', label: 'Expense Breakdown', element: expenseRef.current },
+    { id: 'property', label: 'Property Comparison', element: propertyRef.current },
+  ];
+
+  const isLoading =
+    kpiQuery.isLoading ||
+    cashflowQuery.isLoading ||
+    breakdownQuery.isLoading ||
+    propertySeriesQuery.isLoading ||
+    upcomingQuery.isLoading;
+
+  return (
+    <div className="px-4 py-6 sm:px-6 md:px-8">
+      <Link href="/analytics" className="text-sm text-blue-600 hover:underline">
+        &larr; Back to Analytics
+      </Link>
+      <div className="mx-auto mt-4 max-w-[1200px] space-y-6">
+        <div className="grid gap-4 md:gap-6 lg:grid-cols-3">
+          <DateRangePicker
+            value={{ from: filters.from, to: filters.to }}
+            onChange={(range) => setFilters((prev) => ({ ...prev, ...range }))}
+          />
+          <PropertyMultiSelect
+            properties={propertyOptions}
+            selected={filters.propertyIds}
+            onChange={(next) => setFilters((prev) => ({ ...prev, propertyIds: next }))}
+          />
+          <ExportButtons csvSections={csvSections} charts={charts} />
+        </div>
+
+        {filters.expenseCategory && (
+          <div className="flex flex-wrap items-center gap-2 text-sm">
+            <span className="font-medium text-gray-600 dark:text-gray-300">Active filters:</span>
+            <button
+              type="button"
+              className="inline-flex items-center gap-2 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-blue-700 dark:border-blue-800 dark:bg-blue-900/30 dark:text-blue-200"
+              onClick={() => setFilters((prev) => ({ ...prev, expenseCategory: undefined }))}
+            >
+              {filters.expenseCategory}
+              <span aria-hidden>&times;</span>
+            </button>
+          </div>
+        )}
+
+        <div className="grid gap-4 md:gap-6 md:grid-cols-2 xl:grid-cols-4">
+          <KpiCard title="Net Cashflow" value={kpiQuery.data?.netCashflow} format="currency" precision={0} />
+          <KpiCard
+            title="Gross Yield"
+            value={kpiQuery.data?.grossYield ?? undefined}
+            format="percentage"
+            precision={1}
+            tooltip={kpiQuery.data?.grossYield ? undefined : 'Add property values to see gross yield'}
+          />
+          <KpiCard
+            title="Occupancy Rate"
+            value={kpiQuery.data?.occupancyRate ?? undefined}
+            format="percentage"
+            precision={1}
+          />
+          <KpiCard
+            title="On-Time Collection"
+            value={kpiQuery.data?.onTimeCollection ?? undefined}
+            format="percentage"
+            precision={1}
+          />
+        </div>
+
+        {!isLoading && !hasData ? (
+          <div className="rounded-2xl border border-dashed border-gray-300 bg-white p-8 text-center text-sm text-gray-600 shadow-sm dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300">
+            <p className="font-medium">No data for this range.</p>
+            <p className="mt-2">Try adjusting your dates or clearing filters to see more activity.</p>
+            <div className="mt-4 flex justify-center gap-3">
+              <button
+                type="button"
+                className="rounded-full border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:border-blue-500 hover:text-blue-600"
+                onClick={() => setFilters(defaultState())}
+              >
+                FYTD
+              </button>
+              <button
+                type="button"
+                className="rounded-full border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:border-blue-500 hover:text-blue-600"
+                onClick={() => setFilters((prev) => ({ ...prev, propertyIds: [] }))}
+              >
+                Clear filters
+              </button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <div className="grid gap-4 md:gap-6 lg:grid-cols-3">
+              <div className="lg:col-span-2">
+                <CashflowChart
+                  ref={cashflowRef}
+                  data={cashflowQuery.data?.buckets ?? []}
+                  onBrushChange={(range) => {
+                    const monthRange = toMonthRange(range.from);
+                    const monthRangeEnd = toMonthRange(range.to);
+                    if (monthRange && monthRangeEnd) {
+                      setFilters((prev) => ({
+                        ...prev,
+                        from: monthRange.from,
+                        to: monthRangeEnd.to,
+                      }));
+                    }
+                  }}
+                />
+              </div>
+              <div>
+                <ExpenseDonut
+                  ref={expenseRef}
+                  data={breakdownQuery.data?.items ?? []}
+                  total={breakdownQuery.data?.total ?? 0}
+                  selectedCategory={filters.expenseCategory}
+                  onSelectCategory={(category) =>
+                    setFilters((prev) => ({ ...prev, expenseCategory: category ?? undefined }))
+                  }
+                />
+              </div>
+            </div>
+
+            <div className="grid gap-4 md:gap-6 lg:grid-cols-4">
+              <div className="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4 shadow-sm">
+                <h3 className="text-sm font-medium text-gray-800 dark:text-gray-100">Rent vs Market</h3>
+                <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+                  Connect market data to benchmark your rents against the local median.
+                </p>
+                <button
+                  type="button"
+                  className="mt-4 rounded-full border border-blue-200 bg-blue-50 px-4 py-2 text-sm font-medium text-blue-700 hover:border-blue-500 hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-900/30 dark:text-blue-200"
+                >
+                  Connect data
+                </button>
+              </div>
+              <div className="lg:col-span-2">
+                <UpcomingList items={upcomingQuery.data?.items ?? []} />
+              </div>
+              <div className="lg:col-span-1">
+                <PropertyCompare
+                  ref={propertyRef}
+                  data={propertySeriesQuery.data?.items ?? []}
+                  hiddenCount={hiddenPropertyCount}
+                />
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default AnalyticsOverviewPage;

--- a/app/api/analytics/breakdown/expenses/route.ts
+++ b/app/api/analytics/breakdown/expenses/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+import {
+  seedIfEmpty,
+  expenses,
+  properties,
+  isActiveProperty,
+} from '../../../store';
+
+function parseRange(search: URLSearchParams) {
+  const now = new Date();
+  const to = search.get('to');
+  const from = search.get('from');
+  const toDate = to ? new Date(to) : now;
+  const fromDate = from ? new Date(from) : new Date(now.getFullYear(), 0, 1);
+  if (fromDate > toDate) return { from: toDate, to: fromDate };
+  return { from: fromDate, to: toDate };
+}
+
+function parseProperties(search: URLSearchParams, fallback: Set<string>) {
+  const raw = search.get('propertyIds');
+  if (!raw) return fallback;
+  const ids = raw
+    .split(',')
+    .map((id) => id.trim())
+    .filter(Boolean)
+    .filter((id) => fallback.has(id));
+  return new Set(ids.length ? ids : [...fallback]);
+}
+
+export async function GET(req: Request) {
+  seedIfEmpty();
+  const { searchParams } = new URL(req.url);
+  const { from, to } = parseRange(searchParams);
+  const active = new Set(properties.filter(isActiveProperty).map((p) => p.id));
+  const propertyIds = parseProperties(searchParams, active);
+
+  const withinRange = (value: string) => {
+    const d = new Date(value);
+    return d >= from && d <= to;
+  };
+
+  const itemsMap = new Map<string, number>();
+  let total = 0;
+  expenses.forEach((entry) => {
+    if (!propertyIds.has(entry.propertyId)) return;
+    if (!withinRange(entry.date)) return;
+    total += entry.amount;
+    itemsMap.set(entry.category, (itemsMap.get(entry.category) || 0) + entry.amount);
+  });
+
+  const items = Array.from(itemsMap.entries()).map(([category, value]) => ({
+    category,
+    value,
+  }));
+
+  return NextResponse.json({ total, items });
+}

--- a/app/api/analytics/kpis/route.ts
+++ b/app/api/analytics/kpis/route.ts
@@ -1,0 +1,146 @@
+import { NextResponse } from 'next/server';
+import {
+  seedIfEmpty,
+  incomes,
+  expenses,
+  rentLedger,
+  properties,
+  isActiveProperty,
+} from '../../store';
+
+function parseDate(value: string | null, fallback?: Date): Date | undefined {
+  if (!value) return fallback;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? fallback : d;
+}
+
+function getDateRange(search: URLSearchParams) {
+  const fromParam = search.get('from');
+  const toParam = search.get('to');
+  const now = new Date();
+  const to = parseDate(toParam, now)!;
+  const from = parseDate(fromParam, new Date(now.getFullYear(), 0, 1))!;
+  if (from > to) {
+    return { from: to, to: from };
+  }
+  return { from, to };
+}
+
+function getPropertyFilter(search: URLSearchParams) {
+  const raw = search.get('propertyIds');
+  if (!raw) return undefined;
+  const ids = raw.split(',').map((v) => v.trim()).filter(Boolean);
+  return ids.length ? new Set(ids) : undefined;
+}
+
+const DAY = 24 * 60 * 60 * 1000;
+
+function differenceInDaysInclusive(from: Date, to: Date) {
+  return Math.max(0, Math.floor((to.getTime() - from.getTime()) / DAY)) + 1;
+}
+
+function clampDate(date: Date | undefined, fallback: Date) {
+  if (!date) return fallback;
+  return Number.isNaN(date.getTime()) ? fallback : date;
+}
+
+export async function GET(req: Request) {
+  seedIfEmpty();
+  const { searchParams } = new URL(req.url);
+  const { from, to } = getDateRange(searchParams);
+  const propertyFilter = getPropertyFilter(searchParams);
+  const activePropertyIds = new Set(
+    properties.filter(isActiveProperty).map((p) => p.id),
+  );
+
+  const allowedPropertyIds = propertyFilter
+    ? new Set([...propertyFilter].filter((id) => activePropertyIds.has(id)))
+    : activePropertyIds;
+
+  const withinRange = (date: string) => {
+    const d = new Date(date);
+    return d >= from && d <= to;
+  };
+
+  const incomeEntries = [
+    ...incomes,
+    ...rentLedger
+      .filter((r) => r.status === 'paid')
+      .map((r) => ({
+        propertyId: r.propertyId,
+        amount: r.amount,
+        date: r.paidDate || r.dueDate,
+      })),
+  ].filter((entry) => {
+    if (!allowedPropertyIds.has(entry.propertyId)) return false;
+    return withinRange(entry.date);
+  });
+
+  const expenseEntries = expenses.filter((entry) => {
+    if (!allowedPropertyIds.has(entry.propertyId)) return false;
+    return withinRange(entry.date);
+  });
+
+  const totalIncome = incomeEntries.reduce((sum, e) => sum + e.amount, 0);
+  const totalExpenses = expenseEntries.reduce((sum, e) => sum + e.amount, 0);
+  const netCashflow = totalIncome - totalExpenses;
+
+  const consideredProperties = properties.filter(
+    (p) => allowedPropertyIds.has(p.id),
+  );
+  const totalPortfolioValue = consideredProperties.reduce(
+    (sum, p) => sum + (p.value ?? 0),
+    0,
+  );
+  const totalAnnualRent = consideredProperties.reduce(
+    (sum, p) => sum + p.rent * 12,
+    0,
+  );
+  const grossYield = totalPortfolioValue
+    ? (totalAnnualRent / totalPortfolioValue) * 100
+    : null;
+
+  const totalDays = differenceInDaysInclusive(from, to);
+  const portfolioTotalDays = totalDays * consideredProperties.length;
+
+  let occupiedDays = 0;
+  for (const property of consideredProperties) {
+    const leaseStart = clampDate(
+      property.leaseStart ? new Date(property.leaseStart) : undefined,
+      from,
+    );
+    const leaseEnd = clampDate(
+      property.leaseEnd ? new Date(property.leaseEnd) : undefined,
+      to,
+    );
+    if (!property.leaseStart && !property.leaseEnd) continue;
+    const start = leaseStart > from ? leaseStart : from;
+    const end = leaseEnd < to ? leaseEnd : to;
+    if (end < start) continue;
+    occupiedDays += differenceInDaysInclusive(start, end);
+  }
+  const occupancyRate =
+    portfolioTotalDays > 0 ? (occupiedDays / portfolioTotalDays) * 100 : null;
+
+  const rentEntries = rentLedger.filter((entry) => {
+    if (!allowedPropertyIds.has(entry.propertyId)) return false;
+    return withinRange(entry.dueDate);
+  });
+  const onTimeTotal = rentEntries.length;
+  const onTimeCount = rentEntries.filter((entry) => {
+    if (entry.status !== 'paid') return false;
+    const paidDate = entry.paidDate ? new Date(entry.paidDate) : undefined;
+    const dueDate = new Date(entry.dueDate);
+    return paidDate ? paidDate <= dueDate : true;
+  }).length;
+  const onTimeCollection = onTimeTotal
+    ? (onTimeCount / onTimeTotal) * 100
+    : null;
+
+  return NextResponse.json({
+    netCashflow,
+    grossYield,
+    occupancyRate,
+    onTimeCollection,
+  });
+}

--- a/app/api/analytics/series/by-property/route.ts
+++ b/app/api/analytics/series/by-property/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from 'next/server';
+import {
+  seedIfEmpty,
+  incomes,
+  expenses,
+  rentLedger,
+  properties,
+  isActiveProperty,
+} from '../../../store';
+
+function parseRange(search: URLSearchParams) {
+  const now = new Date();
+  const toParam = search.get('to');
+  const fromParam = search.get('from');
+  const to = toParam ? new Date(toParam) : now;
+  const from = fromParam ? new Date(fromParam) : new Date(now.getFullYear(), 0, 1);
+  if (from > to) return { from: to, to: from };
+  return { from, to };
+}
+
+function parseProperties(search: URLSearchParams, fallback: Set<string>) {
+  const raw = search.get('propertyIds');
+  if (!raw) return fallback;
+  const ids = raw
+    .split(',')
+    .map((id) => id.trim())
+    .filter(Boolean)
+    .filter((id) => fallback.has(id));
+  return new Set(ids.length ? ids : [...fallback]);
+}
+
+export async function GET(req: Request) {
+  seedIfEmpty();
+  const { searchParams } = new URL(req.url);
+  const { from, to } = parseRange(searchParams);
+  const active = new Set(properties.filter(isActiveProperty).map((p) => p.id));
+  const propertyIds = parseProperties(searchParams, active);
+
+  const withinRange = (value: string) => {
+    const d = new Date(value);
+    return d >= from && d <= to;
+  };
+
+  const totals = new Map<string, { income: number; expense: number }>();
+  const ensure = (id: string) => {
+    if (!totals.has(id)) {
+      totals.set(id, { income: 0, expense: 0 });
+    }
+    return totals.get(id)!;
+  };
+
+  incomes.forEach((entry) => {
+    if (!propertyIds.has(entry.propertyId)) return;
+    if (!withinRange(entry.date)) return;
+    ensure(entry.propertyId).income += entry.amount;
+  });
+
+  rentLedger
+    .filter((entry) => entry.status === 'paid')
+    .forEach((entry) => {
+      if (!propertyIds.has(entry.propertyId)) return;
+      const date = entry.paidDate || entry.dueDate;
+      if (!withinRange(date)) return;
+      ensure(entry.propertyId).income += entry.amount;
+    });
+
+  expenses.forEach((entry) => {
+    if (!propertyIds.has(entry.propertyId)) return;
+    if (!withinRange(entry.date)) return;
+    ensure(entry.propertyId).expense += entry.amount;
+  });
+
+  const items = Array.from(propertyIds).map((propertyId) => {
+    const totalsForProperty = totals.get(propertyId) ?? { income: 0, expense: 0 };
+    const property = properties.find((p) => p.id === propertyId);
+    return {
+      propertyId,
+      propertyLabel: property?.address ?? `Property ${propertyId}`,
+      net: totalsForProperty.income - totalsForProperty.expense,
+    };
+  });
+
+  return NextResponse.json({ items });
+}

--- a/app/api/analytics/series/cashflow/route.ts
+++ b/app/api/analytics/series/cashflow/route.ts
@@ -1,0 +1,105 @@
+import { NextResponse } from 'next/server';
+import {
+  seedIfEmpty,
+  incomes,
+  expenses,
+  rentLedger,
+  properties,
+  isActiveProperty,
+} from '../../../store';
+
+function parseRange(search: URLSearchParams) {
+  const now = new Date();
+  const toParam = search.get('to');
+  const fromParam = search.get('from');
+  const to = toParam ? new Date(toParam) : now;
+  const from = fromParam ? new Date(fromParam) : new Date(now.getFullYear(), 0, 1);
+  if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) {
+    throw new Error('Invalid date');
+  }
+  if (from > to) return { from: to, to: from };
+  return { from, to };
+}
+
+function parseProperties(search: URLSearchParams, fallback: Set<string>) {
+  const raw = search.get('propertyIds');
+  if (!raw) return fallback;
+  const ids = raw
+    .split(',')
+    .map((id) => id.trim())
+    .filter(Boolean)
+    .filter((id) => fallback.has(id));
+  return new Set(ids.length ? ids : [...fallback]);
+}
+
+function monthKey(date: Date) {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+}
+
+function ensureMaxBuckets(labels: string[]) {
+  if (labels.length <= 400) return labels;
+  const factor = Math.ceil(labels.length / 400);
+  return labels.filter((_, idx) => idx % factor === 0);
+}
+
+export async function GET(req: Request) {
+  seedIfEmpty();
+  const { searchParams } = new URL(req.url);
+  const { from, to } = parseRange(searchParams);
+  const active = new Set(properties.filter(isActiveProperty).map((p) => p.id));
+  const propertyIds = parseProperties(searchParams, active);
+
+  const withinRange = (value: string) => {
+    const d = new Date(value);
+    return d >= from && d <= to;
+  };
+
+  const incomeByMonth = new Map<string, number>();
+  const expenseByMonth = new Map<string, number>();
+
+  const pushIncome = (date: string, amount: number, propertyId: string) => {
+    if (!propertyIds.has(propertyId)) return;
+    if (!withinRange(date)) return;
+    const key = monthKey(new Date(date));
+    incomeByMonth.set(key, (incomeByMonth.get(key) || 0) + amount);
+  };
+
+  const pushExpense = (date: string, amount: number, propertyId: string) => {
+    if (!propertyIds.has(propertyId)) return;
+    if (!withinRange(date)) return;
+    const key = monthKey(new Date(date));
+    expenseByMonth.set(key, (expenseByMonth.get(key) || 0) + amount);
+  };
+
+  incomes.forEach((entry) => {
+    pushIncome(entry.date, entry.amount, entry.propertyId);
+  });
+
+  rentLedger
+    .filter((entry) => entry.status === 'paid')
+    .forEach((entry) => {
+      pushIncome(entry.paidDate || entry.dueDate, entry.amount, entry.propertyId);
+    });
+
+  expenses.forEach((entry) => {
+    pushExpense(entry.date, entry.amount, entry.propertyId);
+  });
+
+  const labels = Array.from(
+    new Set([...incomeByMonth.keys(), ...expenseByMonth.keys()]),
+  ).sort();
+  const filteredLabels = ensureMaxBuckets(labels);
+
+  const buckets = filteredLabels.map((label) => {
+    const income = incomeByMonth.get(label) || 0;
+    const expense = expenseByMonth.get(label) || 0;
+    return {
+      label,
+      income,
+      expenses: expense,
+      net: income - expense,
+    };
+  });
+
+  return NextResponse.json({ buckets, granularity: 'month' as const });
+}

--- a/app/api/analytics/upcoming/route.ts
+++ b/app/api/analytics/upcoming/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from 'next/server';
+import {
+  seedIfEmpty,
+  reminders,
+  properties,
+  isActiveProperty,
+} from '../../store';
+
+function parseProperties(search: URLSearchParams, fallback: Set<string>) {
+  const raw = search.get('propertyIds');
+  if (!raw) return fallback;
+  const ids = raw
+    .split(',')
+    .map((id) => id.trim())
+    .filter(Boolean)
+    .filter((id) => fallback.has(id));
+  return new Set(ids.length ? ids : [...fallback]);
+}
+
+function mapType(type: string, title: string):
+  | 'lease'
+  | 'insurance'
+  | 'smokeAlarm'
+  | 'inspection' {
+  switch (type) {
+    case 'lease_expiry':
+      return 'lease';
+    case 'insurance_renewal':
+      return 'insurance';
+    case 'inspection_due':
+      return 'inspection';
+    default:
+      return /smoke/i.test(title) ? 'smokeAlarm' : 'lease';
+  }
+}
+
+export async function GET(req: Request) {
+  seedIfEmpty();
+  const { searchParams } = new URL(req.url);
+  const limit = Number.parseInt(searchParams.get('limit') ?? '5', 10) || 5;
+  const active = new Set(properties.filter(isActiveProperty).map((p) => p.id));
+  const propertyIds = parseProperties(searchParams, active);
+
+  const today = new Date();
+  const items = reminders
+    .filter((reminder) => propertyIds.has(reminder.propertyId))
+    .filter((reminder) => {
+      const due = new Date(reminder.dueDate);
+      return !Number.isNaN(due.getTime()) && due >= new Date(today.toDateString());
+    })
+    .sort((a, b) => new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime())
+    .slice(0, limit)
+    .map((reminder) => {
+      const property = properties.find((p) => p.id === reminder.propertyId);
+      return {
+        type: mapType(reminder.type, reminder.title),
+        label: reminder.title,
+        dueOn: reminder.dueDate,
+        propertyLabel: property?.address ?? reminder.propertyId,
+      };
+    });
+
+  return NextResponse.json({ items });
+}

--- a/app/api/properties/route.ts
+++ b/app/api/properties/route.ts
@@ -13,6 +13,7 @@ export async function GET(req: Request) {
     rent: p.rent,
     leaseStart: p.leaseStart,
     leaseEnd: p.leaseEnd,
+    value: p.value,
     events: reminders
       .filter((r) => r.propertyId === p.id)
       .map((r) => ({ date: r.dueDate, title: r.title })),
@@ -31,6 +32,7 @@ export async function POST(req: Request) {
     leaseStart: body.leaseStart || '',
     leaseEnd: body.leaseEnd || '',
     rent: typeof body.rent === 'number' ? body.rent : Number(body.rent) || 0,
+    value: typeof body.value === 'number' ? body.value : body.value ? Number(body.value) : undefined,
     archived: body.archived ?? false,
   };
   properties.push(property);

--- a/app/api/store.ts
+++ b/app/api/store.ts
@@ -6,6 +6,7 @@ export type Property = {
   leaseStart: string;
   leaseEnd: string;
   rent: number;
+  value?: number;
   archived?: boolean;
 };
 export type Tenant = { id: string; name: string; propertyId: string };
@@ -86,6 +87,7 @@ const initialProperties: Property[] = [
     leaseStart: '2025-03-01',
     leaseEnd: '2026-02-28',
     rent: 1200,
+    value: 680_000,
   },
   {
     id: '2',
@@ -94,6 +96,7 @@ const initialProperties: Property[] = [
     leaseStart: '2025-04-01',
     leaseEnd: '2026-03-31',
     rent: 950,
+    value: 590_000,
   },
   {
     id: '3',
@@ -102,6 +105,7 @@ const initialProperties: Property[] = [
     leaseStart: '',
     leaseEnd: '',
     rent: 0,
+    value: 520_000,
     archived: true,
   },
 ];
@@ -898,6 +902,14 @@ const initialReminders: Reminder[] = [
     title: 'Inspection due',
     dueDate: '2025-11-05',
     severity: 'low',
+  },
+  {
+    id: 'rem5',
+    propertyId: '2',
+    type: 'custom',
+    title: 'Smoke alarm check',
+    dueDate: '2025-07-30',
+    severity: 'med',
   },
 ];
 

--- a/tests/analytics-overview.test.tsx
+++ b/tests/analytics-overview.test.tsx
@@ -1,0 +1,156 @@
+import { describe, beforeAll, afterAll, beforeEach, afterEach, it, expect, vi } from 'vitest';
+import { cleanup, render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import AnalyticsOverviewPage from '../app/(app)/analytics/overview/page';
+
+const replaceMock = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: replaceMock }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock('next/dynamic', () => ({
+  default: () =>
+    React.forwardRef<HTMLDivElement, any>((props, ref) => (
+      <div ref={ref} data-testid={props['data-testid'] ?? 'chart-stub'} />
+    )),
+}));
+
+const baseResponses = {
+  '/api/properties': [
+    { id: '1', address: '123 Main St', rent: 1200, leaseStart: '2025-03-01', leaseEnd: '2026-02-28', tenant: 'Alice' },
+    { id: '2', address: '456 Oak Ave', rent: 950, leaseStart: '2025-04-01', leaseEnd: '2026-03-31', tenant: 'Bob' },
+  ],
+  '/api/analytics/kpis': {
+    netCashflow: 4200,
+    grossYield: 5.3,
+    occupancyRate: 92,
+    onTimeCollection: 88,
+  },
+  '/api/analytics/series/cashflow': {
+    buckets: [
+      { label: '2025-07', income: 3200, expenses: 1000, net: 2200 },
+      { label: '2025-08', income: 3200, expenses: 1200, net: 2000 },
+    ],
+    granularity: 'month',
+  },
+  '/api/analytics/breakdown/expenses': {
+    total: 2200,
+    items: [
+      { category: 'Repairs', value: 600 },
+      { category: 'Rates', value: 400 },
+    ],
+  },
+  '/api/analytics/series/by-property': {
+    items: [
+      { propertyId: '1', propertyLabel: '123 Main St', net: 1800 },
+      { propertyId: '2', propertyLabel: '456 Oak Ave', net: 1400 },
+    ],
+  },
+  '/api/analytics/upcoming': {
+    items: [
+      { type: 'lease', label: 'Lease expires', dueOn: '2025-10-01', propertyLabel: '123 Main St' },
+    ],
+  },
+};
+
+function setupFetch(overrides: Record<string, any> = {}) {
+  const responses = { ...baseResponses, ...overrides };
+  const fetchMock = vi.fn(async (input: RequestInfo) => {
+    const url = typeof input === 'string' ? input : input.url;
+    const { pathname } = new URL(url, 'http://localhost');
+    const match = responses[pathname];
+    if (match === undefined) {
+      return new Response('Not found', { status: 404 });
+    }
+    const body = typeof match === 'function' ? await match(url) : match;
+    return new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  });
+  global.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
+function renderPage() {
+  const client = new QueryClient();
+  render(
+    <QueryClientProvider client={client}>
+      <AnalyticsOverviewPage />
+    </QueryClientProvider>,
+  );
+}
+
+describe('AnalyticsOverviewPage', () => {
+  beforeAll(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-09-15T10:00:00Z'));
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  beforeEach(() => {
+    replaceMock.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('renders FYTD KPIs with mock API data', async () => {
+    setupFetch();
+    renderPage();
+
+    const netCashflow = await screen.findByTestId('kpi-net-cashflow');
+    expect(netCashflow.textContent).toContain('4,200');
+    expect(screen.getByTestId('kpi-gross-yield').textContent).toContain('5.3');
+    expect(screen.getByTestId('kpi-occupancy-rate').textContent).toContain('92');
+  });
+
+  it('updates queries when selecting a preset', async () => {
+    const fetchMock = setupFetch();
+    renderPage();
+
+    await screen.findByTestId('kpi-net-cashflow');
+    fireEvent.click(screen.getByText('This Month'));
+
+    await waitFor(() => {
+      const calls = fetchMock.mock.calls
+        .map(([request]) => (typeof request === 'string' ? request : request.url))
+        .filter((url) => url.includes('/api/analytics/kpis'));
+      expect(calls[calls.length - 1]).toContain('from=2025-09-01');
+    });
+  });
+
+  it('applies property filters across queries', async () => {
+    const fetchMock = setupFetch();
+    renderPage();
+
+    await screen.findByText('All properties');
+    fireEvent.click(screen.getByLabelText('123 Main St'));
+    fireEvent.click(screen.getByLabelText('456 Oak Ave'));
+
+    await waitFor(() => {
+      const propertyCalls = fetchMock.mock.calls
+        .map(([request]) => (typeof request === 'string' ? request : request.url))
+        .filter((url) => url.includes('/api/analytics/kpis'));
+      expect(propertyCalls[propertyCalls.length - 1]).toContain('propertyIds=1,2');
+    });
+  });
+
+  it('shows zero state when no data available', async () => {
+    setupFetch({
+      '/api/analytics/kpis': { netCashflow: 0, grossYield: null, occupancyRate: null, onTimeCollection: null },
+      '/api/analytics/series/cashflow': { buckets: [], granularity: 'month' },
+      '/api/analytics/breakdown/expenses': { total: 0, items: [] },
+      '/api/analytics/series/by-property': { items: [] },
+      '/api/analytics/upcoming': { items: [] },
+    });
+    renderPage();
+
+    expect(await screen.findByText('No data for this range.')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- implement the Analytics Overview client page with FY presets, property filters, KPI cards, charts and export controls
- add reusable overview components, React Query hooks and URL-state helpers for the analytics experience
- expose analytics API routes for KPIs, cashflow series, expense breakdowns, property comparisons and upcoming obligations plus supporting seed data and tests

## Testing
- `npm run test:unit` *(fails: vitest binary unavailable in environment)*
- `npx vitest run` *(fails: unable to download vitest package due to 403 registry restriction)*

------
https://chatgpt.com/codex/tasks/task_e_68d4c94068cc832c82f76b819a50456e