### PR TITLE
Add backlog task for action button transitions

### DIFF
--- a/app/api/store.ts
+++ b/app/api/store.ts
@@ -1502,6 +1502,19 @@ const initialReminders: Reminder[] = [
 
 const initialTasks: TaskDto[] = [
   {
+    id: 'task-action-button-transitions',
+    title: 'Action Button Transitions',
+    description:
+      'Backlog change request to smooth the appearance and disappearance of action button popups.',
+    cadence: 'Immediate',
+    properties: [],
+    status: 'todo',
+    priority: 'normal',
+    tags: ['change-request', 'backlog'],
+    createdAt: '2025-09-26T12:51:00.000Z',
+    updatedAt: '2025-09-26T12:51:00.000Z',
+  },
+  {
     id: 'task1',
     title: 'Fix leaking tap',
     cadence: 'Immediate',


### PR DESCRIPTION
## Summary
- add a backlog change request task describing smoother action button popups

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9d608e930832c8397a48cddf329c0