### PR TITLE
Add next key dates section to property hero

### DIFF
--- a/app/(app)/properties/[id]/components/NextKeyDates.tsx
+++ b/app/(app)/properties/[id]/components/NextKeyDates.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useCallback, type KeyboardEventHandler } from "react";
+
+import type { PropertyEvent } from "../../../../../types/property";
+import type { PropertyTabId } from "../tabs";
+import { sortPropertyEvents } from "../lib/sortEvents";
+
+interface NextKeyDatesProps {
+  events: PropertyEvent[];
+  onNavigate: (tabId: PropertyTabId) => void;
+}
+
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  day: "numeric",
+  month: "short",
+  year: "numeric",
+});
+
+const severityStyles: Record<"high" | "med" | "low", string> = {
+  high: "border-red-500 bg-red-50 dark:border-red-500 dark:bg-red-500/10",
+  med: "border-yellow-500 bg-yellow-50 dark:border-yellow-400 dark:bg-yellow-500/10",
+  low: "border-gray-300 bg-gray-50 dark:border-gray-600 dark:bg-gray-500/10",
+};
+
+function formatDate(value?: string) {
+  if (!value) return "—";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "—";
+  return dateFormatter.format(parsed);
+}
+
+export default function NextKeyDates({ events, onNavigate }: NextKeyDatesProps) {
+  const sortedEvents = sortPropertyEvents(events);
+
+  if (!sortedEvents.length) {
+    return null;
+  }
+
+  const handleNavigate = useCallback(() => onNavigate("key-dates"), [onNavigate]);
+
+  const handleKeyDown: KeyboardEventHandler<HTMLDivElement> = useCallback(
+    (event) => {
+      if (event.key === "Enter" || event.key === " " || event.key === "Spacebar") {
+        event.preventDefault();
+        handleNavigate();
+      }
+    },
+    [handleNavigate],
+  );
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={handleNavigate}
+      onKeyDown={handleKeyDown}
+      className="group flex w-full flex-col gap-3 rounded-lg border border-gray-200 bg-gray-50 p-4 text-left transition hover:border-gray-300 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-gray-700 dark:bg-gray-800/40 dark:hover:border-gray-600 dark:hover:bg-gray-800/70 dark:focus-visible:ring-offset-gray-900"
+      aria-label="View next key dates"
+    >
+      <div className="flex items-center justify-between text-sm font-semibold text-gray-900 dark:text-gray-100">
+        <span>Next Key Dates</span>
+        <span className="text-xs font-medium text-blue-600 group-hover:underline">View key dates</span>
+      </div>
+      <div className="-mx-1 overflow-x-auto pb-1">
+        <ol className="mx-1 flex min-w-full gap-3">
+          {sortedEvents.map((event) => {
+            const severityClass = event.severity ? severityStyles[event.severity] : severityStyles.low;
+            return (
+              <li key={`${event.title}-${event.date}`} className="min-w-[180px] flex-1">
+                <div
+                  className={`h-full rounded-md border-l-4 px-4 py-3 text-sm text-gray-900 shadow-sm transition dark:text-gray-100 ${severityClass}`}
+                >
+                  <div className="font-semibold">{event.title}</div>
+                  <div className="text-xs text-gray-600 dark:text-gray-300">{formatDate(event.date)}</div>
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/properties/[id]/components/PropertyHero.tsx
+++ b/app/(app)/properties/[id]/components/PropertyHero.tsx
@@ -5,7 +5,9 @@ import type { KeyboardEvent } from "react";
 import type { PropertySummary } from "../../../../../types/property";
 import { Button } from "../../../../../components/ui/button";
 import { type PropertyTabId } from "../tabs";
+import { sortPropertyEvents } from "../lib/sortEvents";
 import ActionButtons from "./ActionButtons";
+import NextKeyDates from "./NextKeyDates";
 
 interface PropertyHeroProps {
   property: PropertySummary;
@@ -54,7 +56,8 @@ export default function PropertyHero({
   onNavigateToTab,
 }: PropertyHeroProps) {
   const imageSrc = property.imageUrl || "/default-house.svg";
-  const nextEvent = property.events?.[0];
+  const sortedEvents = sortPropertyEvents(property.events);
+  const nextEvent = sortedEvents[0];
 
   const rentDisplay = formatRent(property.rent);
 
@@ -145,6 +148,7 @@ export default function PropertyHero({
             </div>
           ))}
         </dl>
+        <NextKeyDates events={sortedEvents} onNavigate={onNavigateToTab} />
       </div>
       <div className="border-t bg-gray-50 px-6 py-4 dark:border-gray-800 dark:bg-gray-900/60">
         <ActionButtons

--- a/app/(app)/properties/[id]/lib/sortEvents.ts
+++ b/app/(app)/properties/[id]/lib/sortEvents.ts
@@ -1,0 +1,20 @@
+import type { PropertyEvent } from "../../../../../types/property";
+
+export function sortPropertyEvents(events: PropertyEvent[] | undefined): PropertyEvent[] {
+  if (!events?.length) {
+    return [];
+  }
+
+  return events
+    .slice()
+    .sort((a, b) => {
+      const aTime = new Date(a.date ?? "").getTime();
+      const bTime = new Date(b.date ?? "").getTime();
+
+      if (Number.isNaN(aTime) && Number.isNaN(bTime)) return 0;
+      if (Number.isNaN(aTime)) return 1;
+      if (Number.isNaN(bTime)) return -1;
+
+      return aTime - bTime;
+    });
+}

--- a/app/(app)/properties/[id]/page.tsx
+++ b/app/(app)/properties/[id]/page.tsx
@@ -31,6 +31,7 @@ import {
   PROPERTY_TABS,
   type PropertyTabId,
 } from "./tabs";
+import { sortPropertyEvents } from "./lib/sortEvents";
 
 const rentFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 });
 const dateFormatter = new Intl.DateTimeFormat(undefined, {
@@ -190,7 +191,8 @@ export default function PropertyPage() {
 
 function PropertySummaryTile({ property }: { property: PropertySummary }) {
   const rentDisplay = formatRent(property.rent);
-  const nextEvent = property.events?.[0];
+  const sortedEvents = sortPropertyEvents(property.events);
+  const nextEvent = sortedEvents[0];
   let nextEventDisplay = "—";
   if (nextEvent) {
     const nextDate = formatDateValue(nextEvent.date);

--- a/app/api/properties/[id]/route.ts
+++ b/app/api/properties/[id]/route.ts
@@ -20,7 +20,7 @@ export async function GET(
   }
   const events = reminders
     .filter((r) => r.propertyId === params.id)
-    .map((r) => ({ date: r.dueDate, title: r.title }));
+    .map((r) => ({ date: r.dueDate, title: r.title, severity: r.severity }));
   return Response.json({ ...property, events });
 }
 
@@ -41,7 +41,7 @@ export async function PATCH(
   if (body.archived !== undefined) property.archived = body.archived;
   const events = reminders
     .filter((r) => r.propertyId === params.id)
-    .map((r) => ({ date: r.dueDate, title: r.title }));
+    .map((r) => ({ date: r.dueDate, title: r.title, severity: r.severity }));
   return Response.json({ ...property, events });
 }
 

--- a/app/api/properties/route.ts
+++ b/app/api/properties/route.ts
@@ -16,7 +16,7 @@ export async function GET(req: Request) {
     value: p.value,
     events: reminders
       .filter((r) => r.propertyId === p.id)
-      .map((r) => ({ date: r.dueDate, title: r.title })),
+      .map((r) => ({ date: r.dueDate, title: r.title, severity: r.severity })),
   }));
   return Response.json(data);
 }
@@ -38,6 +38,6 @@ export async function POST(req: Request) {
   properties.push(property);
   const events = reminders
     .filter((r) => r.propertyId === id)
-    .map((r) => ({ date: r.dueDate, title: r.title }));
+    .map((r) => ({ date: r.dueDate, title: r.title, severity: r.severity }));
   return Response.json({ ...property, events }, { status: 201 });
 }

--- a/types/property.ts
+++ b/types/property.ts
@@ -1,6 +1,7 @@
 export interface PropertyEvent {
   date: string;
   title: string;
+  severity?: "high" | "med" | "low";
 }
 
 export interface PropertySummary {


### PR DESCRIPTION
## Summary
- create a reusable Next Key Dates strip that links directly to the key dates tab
- surface reminder severity data through the property APIs and types so colours can match existing key date styling
- display sorted upcoming key dates in the property hero and summary card using the new helper

## Testing
- `npm run lint` *(fails: ESLint 9 requires eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d8563ba0832ca3808c2eafa188dd