### PR TITLE
fix: allow completed tasks to keep custom indicators

### DIFF
--- a/components/tasks/TaskCard.tsx
+++ b/components/tasks/TaskCard.tsx
@@ -67,7 +67,8 @@ export default function TaskCard({
         {statusInfo && (
           <span className="inline-flex h-2.5 w-2.5 items-center justify-center">
             <span
-              className={`h-2.5 w-2.5 rounded-full ${statusInfo.color}`}
+              className="h-2.5 w-2.5 rounded-full"
+              style={{ backgroundColor: statusInfo.color }}
               aria-hidden
             />
             <span className="sr-only">{statusInfo.label}</span>

--- a/components/tasks/statusIndicator.ts
+++ b/components/tasks/statusIndicator.ts
@@ -2,34 +2,74 @@ import type { TaskDto } from "../../types/tasks";
 
 export const STATUS_INDICATOR_TAG_PREFIX = "__status_indicator:";
 
-export const STATUS_INDICATOR_OPTIONS = [
-  { value: "todo", label: "To-Do", color: "bg-blue-500" },
-  { value: "doing", label: "Doing", color: "bg-orange-500" },
-  { value: "done", label: "Complete", color: "bg-green-500" },
-] as const;
+export type StatusIndicatorValue = {
+  label: string;
+  color: string;
+};
 
-export type StatusIndicatorValue =
-  (typeof STATUS_INDICATOR_OPTIONS)[number]["value"];
+type StatusIndicatorPreset = Readonly<StatusIndicatorValue>;
 
-const optionByValue = STATUS_INDICATOR_OPTIONS.reduce(
-  (acc, option) => {
-    acc[option.value] = option;
-    return acc;
-  },
-  {} as Record<StatusIndicatorValue, (typeof STATUS_INDICATOR_OPTIONS)[number]>
-);
+const sanitizeLabel = (value?: string) => {
+  const trimmed = (value ?? "").trim();
+  if (!trimmed) return "To-Do";
+  return trimmed;
+};
+
+const expandShortHex = (value: string) =>
+  value
+    .split("")
+    .map((char) => char + char)
+    .join("");
+
+const sanitizeColor = (value?: string) => {
+  if (!value) {
+    return "#3b82f6";
+  }
+
+  const trimmed = value.trim();
+
+  if (/^#([0-9a-f]{3})$/i.test(trimmed)) {
+    return `#${expandShortHex(trimmed.slice(1)).toLowerCase()}`;
+  }
+
+  if (/^#([0-9a-f]{6})$/i.test(trimmed)) {
+    return trimmed.toLowerCase();
+  }
+
+  return "#3b82f6";
+};
+
+export const coerceStatusIndicatorValue = (
+  value?: Partial<StatusIndicatorValue> | null
+): StatusIndicatorValue => ({
+  label: sanitizeLabel(value?.label),
+  color: sanitizeColor(value?.color),
+});
+
+const DEFAULT_INDICATOR = coerceStatusIndicatorValue({
+  label: "To-Do",
+  color: "#3b82f6",
+});
+
+const LEGACY_INDICATOR_OPTIONS: Record<string, StatusIndicatorPreset> = {
+  todo: { label: "To-Do", color: "#3b82f6" },
+  doing: { label: "In Progress", color: "#f97316" },
+  done: { label: "Complete", color: "#22c55e" },
+};
+
+export const STATUS_INDICATOR_PRESETS: StatusIndicatorPreset[] = [
+  LEGACY_INDICATOR_OPTIONS.todo,
+  LEGACY_INDICATOR_OPTIONS.doing,
+  LEGACY_INDICATOR_OPTIONS.done,
+  { label: "Blocked", color: "#ef4444" },
+  { label: "On Hold", color: "#a855f7" },
+  { label: "Needs Review", color: "#0ea5e9" },
+  { label: "Scheduled", color: "#8b5cf6" },
+  { label: "Waiting", color: "#facc15" },
+];
 
 const normalizeString = (value?: string | null) =>
   (value ?? "").trim().toLowerCase();
-
-const isDoneStatus = (status?: string | null) => {
-  const normalized = normalizeString(status);
-  return (
-    normalized === "done" ||
-    normalized === "completed" ||
-    normalized === "complete"
-  );
-};
 
 const isDoingStatus = (status?: string | null) => {
   const normalized = normalizeString(status);
@@ -41,20 +81,6 @@ const isDoingStatus = (status?: string | null) => {
   );
 };
 
-export const isStatusIndicatorValue = (
-  value: string
-): value is StatusIndicatorValue =>
-  STATUS_INDICATOR_OPTIONS.some((option) => option.value === value);
-
-export const coerceStatusIndicatorValue = (
-  value?: string | null
-): StatusIndicatorValue => {
-  if (value && isStatusIndicatorValue(value)) {
-    return value;
-  }
-  return "todo";
-};
-
 export const extractIndicatorFromTags = (
   tags?: string[] | null
 ): StatusIndicatorValue | null => {
@@ -63,27 +89,59 @@ export const extractIndicatorFromTags = (
     tag.startsWith(STATUS_INDICATOR_TAG_PREFIX)
   );
   if (!match) return null;
-  const [, value] = match.split(STATUS_INDICATOR_TAG_PREFIX);
-  return value && isStatusIndicatorValue(value) ? value : null;
+  const [, rawValue] = match.split(STATUS_INDICATOR_TAG_PREFIX);
+  if (!rawValue) return null;
+
+  if (rawValue in LEGACY_INDICATOR_OPTIONS) {
+    return coerceStatusIndicatorValue(LEGACY_INDICATOR_OPTIONS[rawValue]);
+  }
+
+  try {
+    const decoded = decodeURIComponent(rawValue);
+    const parsed = JSON.parse(decoded) as Partial<StatusIndicatorValue>;
+    return coerceStatusIndicatorValue(parsed);
+  } catch (error) {
+    console.warn("Failed to parse status indicator tag", error);
+    return null;
+  }
 };
 
 export const deriveIndicatorForTask = (
   task: Pick<TaskDto, "status" | "tags">
 ): StatusIndicatorValue => {
-  if (isDoneStatus(task.status)) {
-    return "done";
-  }
-
   const tagged = extractIndicatorFromTags(task.tags);
   if (tagged) {
     return tagged;
   }
 
   if (isDoingStatus(task.status)) {
-    return "doing";
+    return coerceStatusIndicatorValue(LEGACY_INDICATOR_OPTIONS.doing);
   }
 
-  return "todo";
+  const normalized = normalizeString(task.status);
+  if (
+    normalized &&
+    normalized !== "done" &&
+    normalized in LEGACY_INDICATOR_OPTIONS
+  ) {
+    return coerceStatusIndicatorValue(
+      LEGACY_INDICATOR_OPTIONS[normalized as keyof typeof LEGACY_INDICATOR_OPTIONS]
+    );
+  }
+
+  if (typeof task.status === "string" && task.status.trim()) {
+    const label = task.status
+      .split(/[_-]+/)
+      .filter(Boolean)
+      .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+      .join(" ");
+    return coerceStatusIndicatorValue({
+      label,
+      color: "#6b7280",
+    });
+  }
+
+  return DEFAULT_INDICATOR;
 };
 
 export const mergeIndicatorIntoTags = (
@@ -94,9 +152,13 @@ export const mergeIndicatorIntoTags = (
     (tag) => !tag.startsWith(STATUS_INDICATOR_TAG_PREFIX)
   ) ?? [];
 
-  return [...base, `${STATUS_INDICATOR_TAG_PREFIX}${indicator}`];
+  const serialized = encodeURIComponent(
+    JSON.stringify(coerceStatusIndicatorValue(indicator))
+  );
+
+  return [...base, `${STATUS_INDICATOR_TAG_PREFIX}${serialized}`];
 };
 
 export const getIndicatorPresentation = (
   indicator: StatusIndicatorValue
-) => optionByValue[indicator];
+): StatusIndicatorValue => coerceStatusIndicatorValue(indicator);


### PR DESCRIPTION
## Summary
- stop forcing the "Complete" status preset when tasks have a done status so users can retain custom indicators in the completed column
- continue to honor legacy presets for other statuses and any explicit indicator tags

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e3a8bb64832caf4951d98e0d228e