### PR TITLE
refactor: remove legacy status indicator duplicates

### DIFF
--- a/components/tasks/statusIndicator.ts
+++ b/components/tasks/statusIndicator.ts
@@ -90,21 +90,6 @@ const getLegacyIndicatorPreset = (
   ] ?? null;
 };
 
-const getLegacyIndicatorPreset = (
-  key?: string | null
-): StatusIndicatorPreset | null => {
-  switch (normalizeString(key)) {
-    case "todo":
-      return LEGACY_TODO_PRESET;
-    case "doing":
-      return LEGACY_DOING_PRESET;
-    case "done":
-      return LEGACY_DONE_PRESET;
-    default:
-      return null;
-  }
-};
-
 const isDoneStatus = (status?: string | null) => {
   const normalized = normalizeToLowerCase(status);
   return (
@@ -113,62 +98,6 @@ const isDoneStatus = (status?: string | null) => {
     normalized === "completed"
   );
 };
-
-const expandShortHex = (value: string) =>
-  value
-    .split("")
-    .map((char) => char + char)
-    .join("");
-
-const sanitizeColor = (value?: string) => {
-  if (!value) {
-    return "#3b82f6";
-  }
-
-  const trimmed = value.trim();
-
-  if (/^#([0-9a-f]{3})$/i.test(trimmed)) {
-    return `#${expandShortHex(trimmed.slice(1)).toLowerCase()}`;
-  }
-
-  if (/^#([0-9a-f]{6})$/i.test(trimmed)) {
-    return trimmed.toLowerCase();
-  }
-
-  return "#3b82f6";
-};
-
-export const coerceStatusIndicatorValue = (
-  value?: Partial<StatusIndicatorValue> | null
-): StatusIndicatorValue => ({
-  label: sanitizeLabel(value?.label),
-  color: sanitizeColor(value?.color),
-});
-
-const DEFAULT_INDICATOR = coerceStatusIndicatorValue({
-  label: "To-Do",
-  color: "#3b82f6",
-});
-
-const LEGACY_INDICATOR_OPTIONS: Record<string, StatusIndicatorPreset> = {
-  todo: { label: "To-Do", color: "#3b82f6" },
-  doing: { label: "In Progress", color: "#f97316" },
-  done: { label: "Complete", color: "#22c55e" },
-};
-
-export const STATUS_INDICATOR_PRESETS: StatusIndicatorPreset[] = [
-  LEGACY_INDICATOR_OPTIONS.todo,
-  LEGACY_INDICATOR_OPTIONS.doing,
-  LEGACY_INDICATOR_OPTIONS.done,
-  { label: "Blocked", color: "#ef4444" },
-  { label: "On Hold", color: "#a855f7" },
-  { label: "Needs Review", color: "#0ea5e9" },
-  { label: "Scheduled", color: "#8b5cf6" },
-  { label: "Waiting", color: "#facc15" },
-];
-
-const normalizeString = (value?: string | null) =>
-  (value ?? "").trim().toLowerCase();
 
 const isDoingStatus = (status?: string | null) => {
   const normalized = normalizeToLowerCase(status);


### PR DESCRIPTION
## Summary
- remove the redundant legacy status indicator helpers and presets from the task status indicator module
- rely on the sanitized presets and helpers used by the current implementation

## Testing
- npm run build *(fails: next binary unavailable because dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db129140b4832cb51f48a1f7a90fc3