### PR TITLE
Fix property API store import paths

### DIFF
--- a/app/api/properties/[id]/archive/route.ts
+++ b/app/api/properties/[id]/archive/route.ts
@@ -1,4 +1,4 @@
-import { properties } from '../../store';
+import { properties } from '../../../store';
 
 export async function POST(
   _req: Request,

--- a/app/api/properties/[id]/unarchive/route.ts
+++ b/app/api/properties/[id]/unarchive/route.ts
@@ -1,4 +1,4 @@
-import { properties } from '../../store';
+import { properties } from '../../../store';
 
 export async function POST(
   _req: Request,


### PR DESCRIPTION
## Summary
- point the archive and unarchive property API routes to the correct store module path

## Testing
- npm run build *(fails: `next` command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db161b5af0832c85ca345e36ec81af