### PR TITLE
feat: scaffold tenant crm directory and mock apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ PropTechTest is a lightweight, dashboard-first property management prototype for
 - **Rent review** calculator and notice generation within each property.
 - **Settings** for notification preferences.
 - **Tasks** module with Kanban, Calendar and Gantt views.
+- **Tenant CRM** directory with property-scoped notes, communication log, and notification preferences.
 
 ## Navigation
 
@@ -125,6 +126,22 @@ Mock API routes are available to hide or restore properties:
 - `POST /api/properties/:id/unarchive` restores an archived property.
 
 Archived properties are excluded from listings unless `includeArchived=true` is specified.
+
+### Tenant CRM endpoints
+
+The mock API exposes a lightweight Tenant CRM surface compatible with the in-app directory, profile page, and property tabs:
+
+- `GET /api/tenants` — paginated tenant directory with filtering by `search`, `tag`, `riskFlag`, `propertyId`.
+- `POST /api/tenants` — create a tenant.
+- `GET /api/tenants/:id` — tenant profile with tenancy summaries, arrears snapshot and latest contact.
+- `PATCH /api/tenants/:id` — update tenant metadata.
+- `DELETE /api/tenants/:id` — archive tenants without active tenancies.
+- `GET|POST /api/tenant-notes` — list and create timeline notes.
+- `PATCH /api/tenant-notes/:id` — update note tags/body/pin state.
+- `GET|POST /api/comm-log` — retrieve and log communication events.
+- `GET|PUT /api/notification-preferences/:tenantId` — manage per-tenant delivery channels.
+
+When `MOCK_MODE=true` these routes operate on in-memory collections seeded from `app/api/tenant-crm/store.ts`. All responses are validated with Zod schemas shared between client and server (`lib/tenant-crm/schemas.ts`).
 
 ### Property P&L summary endpoint
 

--- a/app/(app)/tenants/[tenantId]/page.tsx
+++ b/app/(app)/tenants/[tenantId]/page.tsx
@@ -1,0 +1,17 @@
+import TenantProfile from '../../../../components/tenant-crm/TenantProfile';
+
+interface TenantProfilePageProps {
+  params: { tenantId: string };
+}
+
+export function generateMetadata({ params }: TenantProfilePageProps) {
+  return { title: `Tenant · ${params.tenantId}` };
+}
+
+export default function TenantProfilePage({ params }: TenantProfilePageProps) {
+  return (
+    <div className="space-y-6">
+      <TenantProfile tenantId={params.tenantId} />
+    </div>
+  );
+}

--- a/app/(app)/tenants/page.tsx
+++ b/app/(app)/tenants/page.tsx
@@ -1,0 +1,19 @@
+import TenantCRM from '../../../components/TenantCRM';
+
+export const metadata = {
+  title: 'Tenant CRM',
+};
+
+export default function TenantDirectoryPage() {
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground">Tenant CRM</h1>
+        <p className="text-sm text-muted-foreground">
+          Manage tenant notes, contact history, and preferences from a central directory.
+        </p>
+      </header>
+      <TenantCRM />
+    </div>
+  );
+}

--- a/app/api/comm-log/route.ts
+++ b/app/api/comm-log/route.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod';
+
+import { logEvent } from '../../../lib/log';
+import { commLogStore, nextId } from '../tenant-crm/store';
+import {
+  zCommLogCreate,
+  zCommLogEntry,
+  zCommLogListResponse,
+} from '../../../lib/tenant-crm/schemas';
+
+const querySchema = z.object({
+  tenantId: z.string().optional(),
+  type: z.string().optional(),
+  dateFrom: z.string().optional(),
+  dateTo: z.string().optional(),
+  page: z.coerce.number().int().nonnegative().default(0),
+  pageSize: z.coerce.number().int().positive().max(100).default(20),
+});
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const parsed = querySchema.safeParse(Object.fromEntries(url.searchParams));
+  if (!parsed.success) {
+    return new Response(JSON.stringify(parsed.error.format()), { status: 400 });
+  }
+
+  const { tenantId, type, dateFrom, dateTo, page, pageSize } = parsed.data;
+  const filtered = commLogStore
+    .filter((entry) => {
+      if (tenantId && entry.tenantId !== tenantId) return false;
+      if (type && entry.type !== type) return false;
+      if (dateFrom && entry.when < dateFrom) return false;
+      if (dateTo && entry.when > dateTo) return false;
+      return true;
+    })
+    .sort((a, b) => (a.when < b.when ? 1 : -1));
+
+  const start = page * pageSize;
+  const items = filtered.slice(start, start + pageSize);
+
+  const payload = zCommLogListResponse.parse({
+    items,
+    pageInfo: { page, pageSize, total: filtered.length },
+  });
+
+  return Response.json(payload);
+}
+
+export async function POST(req: Request) {
+  const json = await req.json().catch(() => null);
+  const parsed = zCommLogCreate.safeParse(json);
+  if (!parsed.success) {
+    return new Response(JSON.stringify(parsed.error.format()), { status: 400 });
+  }
+
+  const entry = zCommLogEntry.parse({
+    id: nextId('comm'),
+    attachments: [],
+    ...parsed.data,
+  });
+
+  commLogStore.unshift(entry);
+  logEvent('comm_logged', { tenantId: entry.tenantId, type: entry.type });
+  return new Response(JSON.stringify(entry), { status: 201 });
+}

--- a/app/api/notification-preferences/[tenantId]/route.ts
+++ b/app/api/notification-preferences/[tenantId]/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+
+import { logEvent } from '../../../../../lib/log';
+import {
+  notificationPreferenceStore,
+  nextId,
+} from '../../../tenant-crm/store';
+import {
+  zNotificationPreference,
+} from '../../../../../lib/tenant-crm/schemas';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { tenantId: string } }
+) {
+  const pref = notificationPreferenceStore.find(
+    (item) => item.tenantId === params.tenantId
+  );
+
+  if (!pref) {
+    return NextResponse.json(null);
+  }
+
+  return NextResponse.json(zNotificationPreference.parse(pref));
+}
+
+export async function PUT(
+  req: Request,
+  { params }: { params: { tenantId: string } }
+) {
+  const raw = (await req.json().catch(() => null)) ?? {};
+  if (typeof raw !== 'object' || raw === null) {
+    return NextResponse.json({ message: 'Invalid payload' }, { status: 400 });
+  }
+  const parsed = zNotificationPreference.safeParse({
+    ...raw,
+    tenantId: params.tenantId,
+    id: (raw as { id?: string }).id ?? nextId('notifPref'),
+  });
+
+  if (!parsed.success) {
+    return NextResponse.json(parsed.error.format(), { status: 400 });
+  }
+
+  const index = notificationPreferenceStore.findIndex(
+    (item) => item.tenantId === params.tenantId
+  );
+
+  if (index === -1) {
+    notificationPreferenceStore.push(parsed.data);
+  } else {
+    notificationPreferenceStore[index] = parsed.data;
+  }
+
+  logEvent('notif_prefs_updated', { tenantId: params.tenantId });
+  return NextResponse.json(parsed.data);
+}

--- a/app/api/tenant-crm/route.ts
+++ b/app/api/tenant-crm/route.ts
@@ -1,12 +1,13 @@
-import { tenantNotes } from '../store';
+import { tenantNotesStore } from './store';
 import { logEvent } from '../../../lib/log';
 
 export async function GET(req: Request) {
   const url = new URL(req.url);
   const propertyId = url.searchParams.get('propertyId');
-  const notes = tenantNotes.filter(
-    (n) => !propertyId || n.propertyId === propertyId
-  );
+  const notes = tenantNotesStore.filter((n) => {
+    if (propertyId && n.propertyId !== propertyId) return false;
+    return true;
+  });
   return Response.json(notes);
 }
 
@@ -15,10 +16,13 @@ export async function POST(req: Request) {
   const note = {
     id: Math.random().toString(36).slice(2),
     propertyId,
-    text,
+    tenantId: 'unknown',
     createdAt: new Date().toISOString(),
+    createdByUserId: 'system',
+    body: text,
+    tags: [],
   };
-  tenantNotes.push(note);
-  logEvent('note_add', { propertyId });
+  tenantNotesStore.unshift(note);
+  logEvent('tenant_note_created', { propertyId });
   return Response.json(note);
 }

--- a/app/api/tenant-crm/store.ts
+++ b/app/api/tenant-crm/store.ts
@@ -1,0 +1,112 @@
+import { randomUUID } from 'crypto';
+
+import type {
+  CommLogEntry,
+  NotificationPreference,
+  Tenant,
+  TenantNote,
+  Tenancy,
+} from '../../../lib/tenant-crm/schemas';
+
+const now = () => new Date().toISOString();
+
+const tNow = now();
+
+export const tenantDirectory: Tenant[] = [
+  {
+    id: 'tenant1',
+    fullName: 'Alice Tenant',
+    email: 'alice@example.com',
+    phone: '+61 400 111 222',
+    altContacts: [
+      { name: 'Bob Support', phone: '+61 400 333 444' },
+    ],
+    tags: ['A-grade'],
+    currentPropertyId: '1',
+    currentTenancyId: 'tenancy1',
+    riskFlags: [],
+    createdAt: tNow,
+    updatedAt: tNow,
+  },
+  {
+    id: 'tenant2',
+    fullName: 'Bob Renter',
+    email: 'bob@example.com',
+    phone: '+61 400 555 666',
+    tags: ['watchlist'],
+    currentPropertyId: '2',
+    currentTenancyId: 'tenancy2',
+    riskFlags: ['arrears'],
+    createdAt: tNow,
+    updatedAt: tNow,
+  },
+  {
+    id: 'tenant3',
+    fullName: 'Charlie Prospect',
+    tags: ['prospect'],
+    createdAt: tNow,
+    updatedAt: tNow,
+  },
+];
+
+export const tenancySummaries: Tenancy[] = [
+  {
+    id: 'tenancy1',
+    tenantId: 'tenant1',
+    propertyId: '1',
+    leaseId: 'lease1',
+    startDate: '2024-01-01',
+    rentCents: 120000,
+    frequency: 'MONTHLY',
+    status: 'ACTIVE',
+    bondCents: 400000,
+  },
+  {
+    id: 'tenancy2',
+    tenantId: 'tenant2',
+    propertyId: '2',
+    leaseId: 'lease2',
+    startDate: '2023-12-01',
+    rentCents: 95000,
+    frequency: 'MONTHLY',
+    status: 'ACTIVE',
+  },
+];
+
+export const tenantNotesStore: TenantNote[] = [
+  {
+    id: 'note1',
+    tenantId: 'tenant1',
+    tenancyId: 'tenancy1',
+    propertyId: '1',
+    createdAt: now(),
+    createdByUserId: 'user1',
+    body: 'Tenant called to confirm maintenance access.',
+    tags: ['maintenance'],
+  },
+];
+
+export const commLogStore: CommLogEntry[] = [
+  {
+    id: 'comm1',
+    tenantId: 'tenant2',
+    tenancyId: 'tenancy2',
+    type: 'CALL',
+    direction: 'OUT',
+    when: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
+    subject: 'Follow up rent',
+    body: 'Discussed outstanding rent, agreed to pay Friday.',
+  },
+];
+
+export const notificationPreferenceStore: NotificationPreference[] = [
+  {
+    id: 'pref1',
+    tenantId: 'tenant1',
+    channels: { email: true, sms: true, push: false },
+  },
+];
+
+export function nextId(prefix: string) {
+  return `${prefix}_${randomUUID()}`;
+}

--- a/app/api/tenant-notes/[id]/route.ts
+++ b/app/api/tenant-notes/[id]/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+
+import { logEvent } from '../../../../lib/log';
+import { tenantNotesStore } from '../../tenant-crm/store';
+import {
+  zTenantNote,
+  zTenantNoteUpdate,
+} from '../../../../lib/tenant-crm/schemas';
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const note = tenantNotesStore.find((item) => item.id === params.id);
+  if (!note) {
+    return NextResponse.json({ message: 'Not found' }, { status: 404 });
+  }
+
+  const json = await req.json().catch(() => null);
+  const parsed = zTenantNoteUpdate.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json(parsed.error.format(), { status: 400 });
+  }
+
+  Object.assign(note, parsed.data);
+  const payload = zTenantNote.parse(note);
+  logEvent('tenant_note_updated', { noteId: note.id });
+  return NextResponse.json(payload);
+}

--- a/app/api/tenant-notes/route.ts
+++ b/app/api/tenant-notes/route.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod';
+
+import { logEvent } from '../../../lib/log';
+import {
+  tenantNotesStore,
+  nextId,
+} from '../tenant-crm/store';
+import {
+  zTenantNote,
+  zTenantNoteCreate,
+  zTenantNoteListResponse,
+} from '../../../lib/tenant-crm/schemas';
+
+const querySchema = z.object({
+  tenantId: z.string().optional(),
+  propertyId: z.string().optional(),
+  tag: z.string().optional(),
+  page: z.coerce.number().int().nonnegative().default(0),
+  pageSize: z.coerce.number().int().positive().max(100).default(20),
+});
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const parsed = querySchema.safeParse(Object.fromEntries(url.searchParams));
+  if (!parsed.success) {
+    return new Response(JSON.stringify(parsed.error.format()), { status: 400 });
+  }
+
+  const { tenantId, propertyId, tag, page, pageSize } = parsed.data;
+  const filtered = tenantNotesStore
+    .filter((note) => {
+      if (tenantId && note.tenantId !== tenantId) return false;
+      if (propertyId && note.propertyId !== propertyId) return false;
+      if (tag && !note.tags?.includes(tag)) return false;
+      return true;
+    })
+    .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+
+  const start = page * pageSize;
+  const items = filtered.slice(start, start + pageSize);
+
+  const payload = zTenantNoteListResponse.parse({
+    items,
+    pageInfo: { page, pageSize, total: filtered.length },
+  });
+
+  return Response.json(payload);
+}
+
+export async function POST(req: Request) {
+  const json = await req.json().catch(() => null);
+  const parsed = zTenantNoteCreate.safeParse(json);
+  if (!parsed.success) {
+    return new Response(JSON.stringify(parsed.error.format()), { status: 400 });
+  }
+
+  const note = zTenantNote.parse({
+    id: nextId('tenantNote'),
+    createdAt: new Date().toISOString(),
+    tags: [],
+    attachments: [],
+    pinned: false,
+    ...parsed.data,
+  });
+
+  tenantNotesStore.unshift(note);
+  logEvent('tenant_note_created', { tenantId: note.tenantId });
+  return new Response(JSON.stringify(note), { status: 201 });
+}

--- a/app/api/tenants/[id]/route.ts
+++ b/app/api/tenants/[id]/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from 'next/server';
+
+import { logEvent } from '../../../../lib/log';
+import {
+  commLogStore,
+  tenantDirectory,
+  tenancySummaries,
+} from '../../tenant-crm/store';
+import {
+  zCommLogEntry,
+  zTenant,
+  zTenantDetailResponse,
+  zTenantUpdate,
+} from '../../../../lib/tenant-crm/schemas';
+
+function findTenant(id: string) {
+  return tenantDirectory.find((tenant) => tenant.id === id);
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const tenant = findTenant(params.id);
+  if (!tenant) {
+    return NextResponse.json({ message: 'Not found' }, { status: 404 });
+  }
+
+  const tenancies = tenancySummaries.filter((t) => t.tenantId === tenant.id);
+  const latestContact = commLogStore
+    .filter((entry) => entry.tenantId === tenant.id)
+    .sort((a, b) => (a.when < b.when ? 1 : -1))[0];
+
+  const payload = zTenantDetailResponse.parse({
+    tenant,
+    tenancies,
+    latestArrears: tenant.riskFlags?.includes('arrears')
+      ? { days: 14, balanceCents: 6500 }
+      : null,
+    lastContact: latestContact ? zCommLogEntry.parse(latestContact) : null,
+  });
+
+  return NextResponse.json(payload);
+}
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const json = await req.json().catch(() => null);
+  const parsed = zTenantUpdate.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json(parsed.error.format(), { status: 400 });
+  }
+
+  const tenant = findTenant(params.id);
+  if (!tenant) {
+    return NextResponse.json({ message: 'Not found' }, { status: 404 });
+  }
+
+  Object.assign(tenant, parsed.data, { updatedAt: new Date().toISOString() });
+  const updated = zTenant.parse(tenant);
+  logEvent('tenant_updated', { tenantId: updated.id });
+  return NextResponse.json(updated);
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const tenantIndex = tenantDirectory.findIndex((t) => t.id === params.id);
+  if (tenantIndex === -1) {
+    return NextResponse.json({ message: 'Not found' }, { status: 404 });
+  }
+
+  const tenant = tenantDirectory[tenantIndex];
+  const hasActiveTenancy = tenancySummaries.some(
+    (t) => t.tenantId === tenant.id && t.status === 'ACTIVE'
+  );
+
+  if (hasActiveTenancy) {
+    return NextResponse.json(
+      { message: 'Tenant has active tenancy' },
+      { status: 409 }
+    );
+  }
+
+  tenantDirectory.splice(tenantIndex, 1);
+  logEvent('tenant_deleted', { tenantId: params.id });
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/tenants/route.ts
+++ b/app/api/tenants/route.ts
@@ -1,0 +1,86 @@
+import { z } from 'zod';
+
+import { logEvent } from '../../../lib/log';
+import {
+  tenantDirectory,
+  nextId,
+} from '../tenant-crm/store';
+import {
+  zTenant,
+  zTenantCreate,
+  zTenantDirectoryResponse,
+} from '../../../lib/tenant-crm/schemas';
+
+const querySchema = z.object({
+  search: z.string().optional(),
+  tag: z.string().optional(),
+  riskFlag: z.string().optional(),
+  propertyId: z.string().optional(),
+  page: z.coerce.number().int().nonnegative().default(0),
+  pageSize: z.coerce.number().int().positive().max(100).default(20),
+});
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const parsed = querySchema.safeParse(Object.fromEntries(url.searchParams));
+  if (!parsed.success) {
+    return new Response(JSON.stringify(parsed.error.format()), { status: 400 });
+  }
+
+  const { page, pageSize, search, tag, riskFlag, propertyId } = parsed.data;
+
+  const filtered = tenantDirectory.filter((tenant) => {
+    if (propertyId && tenant.currentPropertyId !== propertyId) return false;
+    if (tag && !tenant.tags?.includes(tag)) return false;
+    if (riskFlag && !tenant.riskFlags?.includes(riskFlag as any)) return false;
+    if (search) {
+      const value = search.toLowerCase();
+      const match =
+        tenant.fullName.toLowerCase().includes(value) ||
+        tenant.email?.toLowerCase().includes(value) ||
+        tenant.phone?.toLowerCase().includes(value);
+      if (!match) return false;
+    }
+    return true;
+  });
+
+  const start = page * pageSize;
+  const items = filtered.slice(start, start + pageSize);
+
+  const result = zTenantDirectoryResponse.parse({
+    items,
+    pageInfo: {
+      page,
+      pageSize,
+      total: filtered.length,
+    },
+  });
+
+  return Response.json(result);
+}
+
+export async function POST(req: Request) {
+  const json = await req.json().catch(() => null);
+  const parsed = zTenantCreate.safeParse(json);
+
+  if (!parsed.success) {
+    return new Response(JSON.stringify(parsed.error.format()), { status: 400 });
+  }
+
+  const id = nextId('tenant');
+  const timestamp = new Date().toISOString();
+  const tenant = zTenant.parse({
+    id,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    tags: [],
+    altContacts: [],
+    riskFlags: [],
+    ...parsed.data,
+  });
+
+  tenantDirectory.push(tenant);
+  logEvent('tenant_created', { tenantId: id, propertyId: tenant.currentPropertyId });
+
+  return new Response(JSON.stringify(tenant), { status: 201 });
+}

--- a/components/TenantCRM.tsx
+++ b/components/TenantCRM.tsx
@@ -1,67 +1,193 @@
 "use client";
 
-import { useState } from "react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { listTenantNotes, addTenantNote } from "../lib/api";
-import { logEvent } from "../lib/log";
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  createTenantNote,
+  fetchTenants,
+  listTenantNotes,
+} from "../lib/api";
+import type {
+  Tenant as TenantDto,
+  TenantNote as TenantNoteDto,
+} from "../lib/tenant-crm/schemas";
 import { useToast } from "./ui/use-toast";
 
 interface Props {
-  propertyId: string;
+  propertyId?: string;
+}
+
+function cn(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+function useTenantDirectory(propertyId?: string) {
+  return useQuery({
+    queryKey: ["tenants", { propertyId }],
+    queryFn: () => fetchTenants(propertyId ? { propertyId } : undefined),
+  });
 }
 
 export default function TenantCRM({ propertyId }: Props) {
-  const { data: notes = [] } = useQuery({
-    queryKey: ["tenant-notes", propertyId],
-    queryFn: () => listTenantNotes(propertyId),
-  });
-  const [text, setText] = useState("");
-  const queryClient = useQueryClient();
+  const { data, isLoading } = useTenantDirectory(propertyId);
+  const tenants = data?.items ?? [];
+  const [selectedTenantId, setSelectedTenantId] = useState<string | null>(
+    tenants[0]?.id ?? null,
+  );
+
+  useEffect(() => {
+    if (!selectedTenantId && tenants.length > 0) {
+      setSelectedTenantId(tenants[0].id);
+    }
+  }, [selectedTenantId, tenants]);
+
   const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const { data: notesData, isLoading: isLoadingNotes } = useQuery({
+    enabled: Boolean(selectedTenantId),
+    queryKey: ["tenant-notes", { tenantId: selectedTenantId }],
+    queryFn: () =>
+      listTenantNotes({ tenantId: selectedTenantId ?? undefined }).then(
+        (response) => response.items,
+      ),
+  });
+
+  const [noteBody, setNoteBody] = useState("");
+
   const mutation = useMutation({
-    mutationFn: (note: string) => addTenantNote(propertyId, note),
+    mutationFn: async () => {
+      if (!selectedTenantId) throw new Error("Select a tenant before adding notes");
+      const payload = {
+        tenantId: selectedTenantId,
+        propertyId,
+        createdByUserId: "demo-user",
+        body: noteBody.trim(),
+      };
+      return createTenantNote(payload);
+    },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["tenant-notes", propertyId] });
-      setText("");
+      setNoteBody("");
+      queryClient.invalidateQueries({
+        queryKey: ["tenant-notes", { tenantId: selectedTenantId }],
+      });
       toast({ title: "Note saved" });
-      logEvent("note_add", { propertyId });
+    },
+    onError: (error: Error) => {
+      toast({ title: "Failed to save note", description: error.message, variant: "destructive" });
     },
   });
 
+  const selectedTenant: TenantDto | undefined = useMemo(() => {
+    if (!tenants.length) return undefined;
+    if (selectedTenantId) {
+      return tenants.find((tenant) => tenant.id === selectedTenantId) ?? tenants[0];
+    }
+    return tenants[0];
+  }, [tenants, selectedTenantId]);
+
+  const notes: TenantNoteDto[] = notesData ?? [];
+
   return (
-    <div className="space-y-2">
-      <div className="flex gap-2">
-        <input
-          className="border p-1 flex-1 bg-white dark:bg-gray-800 dark:border-gray-700 dark:text-white"
-          placeholder="Add note"
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-        />
-        <button
-          className="bg-blue-600 text-white px-2 py-1 rounded disabled:opacity-50 dark:bg-blue-700"
-          onClick={() => mutation.mutate(text)}
-          disabled={!text.trim()}
-        >
-          Add
-        </button>
-        <button
-          className="border px-2 py-1 rounded bg-white dark:bg-gray-800 dark:border-gray-700 dark:text-white"
-          disabled
-        >
-          Send Template
-        </button>
-      </div>
-      <ul className="space-y-1">
-        {notes.map((n) => (
-          <li
-            key={n.id}
-            className="border p-2 bg-white dark:bg-gray-800 dark:border-gray-700"
-          >
-            {n.text}
-          </li>
-        ))}
-        {notes.length === 0 && <li>No notes</li>}
-      </ul>
+    <div className="grid gap-6 md:grid-cols-3">
+      <section className="md:col-span-1">
+        <h2 className="text-sm font-medium text-muted-foreground">Tenants</h2>
+        <div className="mt-2 space-y-1 rounded-md border bg-background">
+          {isLoading && <div className="p-4 text-sm text-muted-foreground">Loading tenants…</div>}
+          {!isLoading && tenants.length === 0 && (
+            <div className="p-4 text-sm text-muted-foreground">No tenants found.</div>
+          )}
+          {!isLoading &&
+            tenants.map((tenant) => (
+              <button
+                key={tenant.id}
+                type="button"
+                onClick={() => setSelectedTenantId(tenant.id)}
+                className={cn(
+                  "w-full px-4 py-3 text-left text-sm hover:bg-muted focus:outline-none focus-visible:ring",
+                  selectedTenantId === tenant.id && "bg-muted",
+                )}
+              >
+                <div className="font-medium text-foreground">{tenant.fullName}</div>
+                <div className="text-xs text-muted-foreground">
+                  {[tenant.email, tenant.phone].filter(Boolean).join(" · ") || "No contact details"}
+                </div>
+                {tenant.tags?.length ? (
+                  <div className="mt-1 flex flex-wrap gap-1">
+                    {tenant.tags.map((tag) => (
+                      <span
+                        key={tag}
+                        className="rounded-full bg-muted-foreground/10 px-2 py-0.5 text-[11px] uppercase tracking-wide text-muted-foreground"
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
+              </button>
+            ))}
+        </div>
+      </section>
+
+      <section className="md:col-span-2">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-foreground">Notes</h2>
+            <p className="text-sm text-muted-foreground">
+              {selectedTenant ? selectedTenant.fullName : "Select a tenant to view their notes."}
+            </p>
+          </div>
+        </div>
+        <div className="mt-4 space-y-4">
+          <div className="rounded-md border bg-background p-4">
+            <label className="block text-sm font-medium text-foreground" htmlFor="tenant-note">
+              Add a note
+            </label>
+            <textarea
+              id="tenant-note"
+              className="mt-2 h-24 w-full rounded-md border bg-transparent p-2 text-sm"
+              placeholder="Capture call summaries, visit outcomes, or reminders…"
+              value={noteBody}
+              onChange={(event) => setNoteBody(event.target.value)}
+            />
+            <div className="mt-3 flex justify-end">
+              <button
+                type="button"
+                onClick={() => mutation.mutate()}
+                disabled={!noteBody.trim() || !selectedTenantId || mutation.isPending}
+                className="inline-flex items-center rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
+              >
+                {mutation.isPending ? "Saving…" : "Save note"}
+              </button>
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            {isLoadingNotes && (
+              <div className="rounded-md border bg-background p-4 text-sm text-muted-foreground">
+                Loading timeline…
+              </div>
+            )}
+            {!isLoadingNotes && notes.length === 0 && (
+              <div className="rounded-md border bg-background p-4 text-sm text-muted-foreground">
+                No notes yet for this tenant.
+              </div>
+            )}
+            {!isLoadingNotes &&
+              notes.map((note) => (
+                <article key={note.id} className="rounded-md border bg-background p-4">
+                  <header className="flex items-center justify-between text-xs text-muted-foreground">
+                    <span>{new Date(note.createdAt).toLocaleString()}</span>
+                    {note.tags?.length ? (
+                      <span>{note.tags.join(', ')}</span>
+                    ) : null}
+                  </header>
+                  <p className="mt-2 whitespace-pre-wrap text-sm text-foreground">{note.body}</p>
+                </article>
+              ))}
+          </div>
+        </div>
+      </section>
     </div>
   );
 }

--- a/components/tenant-crm/TenantProfile.tsx
+++ b/components/tenant-crm/TenantProfile.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import {
+  getNotificationPreferences,
+  getTenant,
+  listCommLog,
+  listTenantNotes,
+} from "../../lib/api";
+
+interface TenantProfileProps {
+  tenantId: string;
+}
+
+export default function TenantProfile({ tenantId }: TenantProfileProps) {
+  const { data: tenantResponse, isLoading } = useQuery({
+    queryKey: ["tenant", tenantId],
+    queryFn: () => getTenant(tenantId),
+  });
+
+  const { data: notesResponse } = useQuery({
+    enabled: Boolean(tenantId),
+    queryKey: ["tenant-notes", { tenantId }],
+    queryFn: () => listTenantNotes({ tenantId }),
+  });
+
+  const { data: commsResponse } = useQuery({
+    enabled: Boolean(tenantId),
+    queryKey: ["tenant-comm", { tenantId }],
+    queryFn: () => listCommLog({ tenantId }),
+  });
+
+  const { data: prefsResponse } = useQuery({
+    enabled: Boolean(tenantId),
+    queryKey: ["tenant-notification", { tenantId }],
+    queryFn: () => getNotificationPreferences(tenantId),
+  });
+
+  if (isLoading) {
+    return <div className="rounded-md border bg-background p-4 text-sm text-muted-foreground">Loading tenant…</div>;
+  }
+
+  if (!tenantResponse) {
+    return <div className="rounded-md border bg-background p-4 text-sm text-muted-foreground">Tenant not found.</div>;
+  }
+
+  const { tenant, tenancies, latestArrears, lastContact } = tenantResponse;
+  const notes = notesResponse?.items ?? [];
+  const communications = commsResponse?.items ?? [];
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-md border bg-background p-6">
+        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold text-foreground">{tenant.fullName}</h1>
+            <p className="text-sm text-muted-foreground">
+              {tenant.email || tenant.phone ? [tenant.email, tenant.phone].filter(Boolean).join(" · ") : "No contact details"}
+            </p>
+            {tenant.tags?.length ? (
+              <div className="mt-2 flex flex-wrap gap-2">
+                {tenant.tags.map((tag) => (
+                  <span key={tag} className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+          </div>
+          {latestArrears ? (
+            <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm">
+              <div className="font-semibold text-destructive">Arrears</div>
+              <div className="text-destructive">
+                {`Balance ${(latestArrears.balanceCents / 100).toLocaleString('en-AU', {
+                  style: 'currency',
+                  currency: 'AUD',
+                })} · ${latestArrears.days} days`}
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <div className="rounded-md border bg-background p-4">
+          <h2 className="text-sm font-semibold text-foreground">Tenancies</h2>
+          <ul className="mt-3 space-y-2 text-sm">
+            {tenancies.length === 0 && (
+              <li className="text-muted-foreground">No tenancy history recorded.</li>
+            )}
+            {tenancies.map((tenancy) => (
+              <li key={tenancy.id} className="rounded border border-muted p-3">
+                <div className="font-medium text-foreground">Property {tenancy.propertyId}</div>
+                <div className="text-muted-foreground">
+                  {tenancy.startDate} → {tenancy.endDate ?? 'Current'}
+                </div>
+                <div className="text-muted-foreground">
+                  {`Rent ${(tenancy.rentCents / 100).toLocaleString('en-AU', {
+                    style: 'currency',
+                    currency: 'AUD',
+                  })} · ${tenancy.frequency}`}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="rounded-md border bg-background p-4">
+          <h2 className="text-sm font-semibold text-foreground">Notification preferences</h2>
+          {prefsResponse ? (
+            <dl className="mt-3 space-y-2 text-sm">
+              <div className="flex items-center justify-between">
+                <dt>Email</dt>
+                <dd>{prefsResponse.channels.email ? 'Enabled' : 'Disabled'}</dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt>SMS</dt>
+                <dd>{prefsResponse.channels.sms ? 'Enabled' : 'Disabled'}</dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt>Push</dt>
+                <dd>{prefsResponse.channels.push ? 'Enabled' : 'Disabled'}</dd>
+              </div>
+              {prefsResponse.quietHours ? (
+                <div className="flex items-center justify-between text-muted-foreground">
+                  <dt>Quiet hours</dt>
+                  <dd>
+                    {prefsResponse.quietHours.start} – {prefsResponse.quietHours.end}
+                  </dd>
+                </div>
+              ) : null}
+            </dl>
+          ) : (
+            <p className="mt-3 text-sm text-muted-foreground">Defaults apply.</p>
+          )}
+          {lastContact ? (
+            <div className="mt-4 rounded-md border border-muted p-3 text-xs text-muted-foreground">
+              Last contact {new Date(lastContact.when).toLocaleString()} ({lastContact.type})
+            </div>
+          ) : null}
+        </div>
+      </section>
+
+      <section className="rounded-md border bg-background p-4">
+        <h2 className="text-sm font-semibold text-foreground">Recent notes</h2>
+        <ul className="mt-3 space-y-2 text-sm">
+          {notes.length === 0 && <li className="text-muted-foreground">No notes recorded.</li>}
+          {notes.map((note) => (
+            <li key={note.id} className="rounded border border-muted p-3">
+              <div className="text-xs text-muted-foreground">{new Date(note.createdAt).toLocaleString()}</div>
+              <div className="mt-1 whitespace-pre-wrap text-foreground">{note.body}</div>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="rounded-md border bg-background p-4">
+        <h2 className="text-sm font-semibold text-foreground">Communication log</h2>
+        <ul className="mt-3 space-y-2 text-sm">
+          {communications.length === 0 && (
+            <li className="text-muted-foreground">No interactions logged.</li>
+          )}
+          {communications.map((entry) => (
+            <li key={entry.id} className="rounded border border-muted p-3">
+              <div className="flex items-center justify-between text-xs text-muted-foreground">
+                <span>{new Date(entry.when).toLocaleString()}</span>
+                <span>{entry.type}</span>
+              </div>
+              {entry.subject ? <div className="mt-1 font-medium text-foreground">{entry.subject}</div> : null}
+              {entry.body ? (
+                <p className="mt-1 whitespace-pre-wrap text-muted-foreground">{entry.body}</p>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/lib/tenant-crm/schemas.ts
+++ b/lib/tenant-crm/schemas.ts
@@ -1,0 +1,176 @@
+import { z } from 'zod';
+
+export const zTenantAltContact = z.object({
+  name: z.string().min(1),
+  phone: z.string().optional(),
+  email: z.string().email().optional(),
+});
+
+export const zTenant = z.object({
+  id: z.string(),
+  fullName: z.string().min(1),
+  email: z.string().email().optional(),
+  phone: z.string().optional(),
+  altContacts: z.array(zTenantAltContact).default([]),
+  tags: z.array(z.string()).default([]),
+  currentPropertyId: z.string().nullable().optional(),
+  currentTenancyId: z.string().nullable().optional(),
+  riskFlags: z
+    .array(z.enum(['arrears', 'complaint', 'vulnerable']))
+    .default([])
+    .optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const zTenantCreate = zTenant
+  .omit({ id: true, createdAt: true, updatedAt: true })
+  .extend({
+    fullName: z.string().min(1),
+  })
+  .partial({
+    tags: true,
+    altContacts: true,
+    riskFlags: true,
+    currentPropertyId: true,
+    currentTenancyId: true,
+  });
+
+export const zTenantUpdate = zTenantCreate.partial().extend({
+  fullName: z.string().min(1).optional(),
+});
+
+export const zTenancy = z.object({
+  id: z.string(),
+  propertyId: z.string(),
+  tenantId: z.string(),
+  leaseId: z.string().nullable().optional(),
+  startDate: z.string(),
+  endDate: z.string().nullable().optional(),
+  rentCents: z.number().int().nonnegative(),
+  frequency: z.enum(['WEEKLY', 'FORTNIGHTLY', 'MONTHLY']),
+  status: z.enum(['ACTIVE', 'ENDED', 'PENDING']),
+  bondCents: z.number().int().nullable().optional(),
+});
+
+export const zAttachment = z.object({
+  id: z.string(),
+  name: z.string(),
+  url: z.string(),
+  mime: z.string(),
+});
+
+export const zTenantNote = z.object({
+  id: z.string(),
+  propertyId: z.string().nullable().optional(),
+  tenantId: z.string(),
+  tenancyId: z.string().nullable().optional(),
+  createdByUserId: z.string(),
+  createdAt: z.string(),
+  body: z.string().min(1),
+  tags: z.array(z.string()).default([]),
+  attachments: z.array(zAttachment).optional(),
+  pinned: z.boolean().optional(),
+});
+
+export const zTenantNoteCreate = zTenantNote
+  .omit({ id: true, createdAt: true })
+  .extend({ tenantId: z.string().min(1), createdByUserId: z.string().min(1) });
+
+export const zTenantNoteUpdate = z
+  .object({
+    body: z.string().min(1).optional(),
+    tags: z.array(z.string()).optional(),
+    pinned: z.boolean().optional(),
+    attachments: z.array(zAttachment).optional(),
+  })
+  .strict();
+
+export const zCommLogEntry = z.object({
+  id: z.string(),
+  tenantId: z.string(),
+  tenancyId: z.string().nullable().optional(),
+  type: z.enum(['CALL', 'EMAIL', 'SMS', 'IN_PERSON', 'OTHER']),
+  direction: z.enum(['IN', 'OUT', 'N/A']),
+  when: z.string(),
+  subject: z.string().optional(),
+  body: z.string().optional(),
+  attachments: z.array(zAttachment).optional(),
+  followUpTaskId: z.string().nullable().optional(),
+});
+
+export const zCommLogCreate = zCommLogEntry
+  .omit({ id: true })
+  .extend({ tenantId: z.string().min(1), when: z.string().min(1) });
+
+export const zNotificationChannels = z.object({
+  email: z.boolean(),
+  sms: z.boolean(),
+  push: z.boolean(),
+});
+
+export const zNotificationQuietHours = z.object({
+  start: z.string(),
+  end: z.string(),
+});
+
+export const zNotificationPreference = z.object({
+  id: z.string(),
+  tenantId: z.string(),
+  channels: zNotificationChannels,
+  quietHours: zNotificationQuietHours.optional(),
+});
+
+export const zTenantDirectoryResponse = z.object({
+  items: z.array(zTenant),
+  pageInfo: z.object({
+    page: z.number().int().nonnegative(),
+    pageSize: z.number().int().positive(),
+    total: z.number().int().nonnegative(),
+  }),
+});
+
+export const zTenantDetailResponse = z.object({
+  tenant: zTenant,
+  tenancies: z.array(zTenancy),
+  latestArrears: z
+    .object({
+      days: z.number().int().nonnegative(),
+      balanceCents: z.number().int(),
+    })
+    .nullable()
+    .optional(),
+  lastContact: zCommLogEntry.nullable().optional(),
+});
+
+export const zTenantNoteListResponse = z.object({
+  items: z.array(zTenantNote),
+  pageInfo: z.object({
+    page: z.number().int().nonnegative(),
+    pageSize: z.number().int().positive(),
+    total: z.number().int().nonnegative(),
+  }),
+});
+
+export const zCommLogListResponse = z.object({
+  items: z.array(zCommLogEntry),
+  pageInfo: z.object({
+    page: z.number().int().nonnegative(),
+    pageSize: z.number().int().positive(),
+    total: z.number().int().nonnegative(),
+  }),
+});
+
+export type Tenant = z.infer<typeof zTenant>;
+export type TenantCreate = z.infer<typeof zTenantCreate>;
+export type TenantUpdate = z.infer<typeof zTenantUpdate>;
+export type Tenancy = z.infer<typeof zTenancy>;
+export type TenantNote = z.infer<typeof zTenantNote>;
+export type TenantNoteCreate = z.infer<typeof zTenantNoteCreate>;
+export type CommLogEntry = z.infer<typeof zCommLogEntry>;
+export type CommLogCreate = z.infer<typeof zCommLogCreate>;
+export type NotificationPreference = z.infer<typeof zNotificationPreference>;
+export type TenantDirectoryResponse = z.infer<typeof zTenantDirectoryResponse>;
+export type TenantDetailResponse = z.infer<typeof zTenantDetailResponse>;
+export type TenantNoteListResponse = z.infer<typeof zTenantNoteListResponse>;
+export type CommLogListResponse = z.infer<typeof zCommLogListResponse>;


### PR DESCRIPTION
## Summary
- add shared tenant CRM schemas and an in-memory mock store for tenants, notes, comms, and notification preferences
- expose mock REST handlers for tenant listing, profiles, notes, comms, and notification preferences that honour filters and telemetry
- rebuild the tenant CRM UI into a directory/profile experience and document the new API surface

## Testing
- npm run lint *(fails: ESLint 9 requires eslint.config.js in this repo)*

------
https://chatgpt.com/codex/tasks/task_e_68dbc33fe400832cbb4ea97cd20d07b5