### PR TITLE
Ensure dashboard date range uses local calendar days

### DIFF
--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -35,8 +35,9 @@ export async function GET(req: Request) {
   seedIfEmpty();
 
   const url = new URL(req.url);
-  const from = url.searchParams.get('from') ?? '1970-01-01';
   const to = url.searchParams.get('to') ?? new Date().toISOString().split('T')[0];
+  const defaultFrom = `${to.slice(0, 7)}-01`;
+  const from = url.searchParams.get('from') ?? defaultFrom;
 
   const activeProperties = properties.filter(isActiveProperty);
   const activePropertyIds = new Set(activeProperties.map((property) => property.id));
@@ -72,7 +73,7 @@ export async function GET(req: Request) {
     }));
 
   const yearStart = to.slice(0, 4) + '-01-01';
-  const monthStart = to.slice(0, 7) + '-01';
+  const monthStart = defaultFrom;
   const fyStart = getAustralianFinancialYearStart(to);
 
   const sumIncome = (start: string, end: string) =>

--- a/components/dashboard/DashboardPage.tsx
+++ b/components/dashboard/DashboardPage.tsx
@@ -16,7 +16,12 @@ import type { DashboardDTO, PortfolioSummary, PropertyCardData } from '../../typ
 
 // Use the first day of the current month to show month-to-date data.
 const startOfMonth = (d: Date) => new Date(d.getFullYear(), d.getMonth(), 1);
-const formatISODate = (d: Date) => d.toISOString().split('T')[0];
+const formatISODate = (d: Date) => {
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
 const getAustralianFinancialYearBounds = (date: Date) => {
   const month = date.getMonth();
   const year = date.getFullYear();


### PR DESCRIPTION
## Summary
- format dashboard API query dates using calendar components instead of toISOString to avoid timezone truncation

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68dc7905c274832c8413d53fe84d9dab