### PR TITLE
feat: build tenant CRM workspace

### DIFF
--- a/app/tenants/page.tsx
+++ b/app/tenants/page.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { TenantDetailPanel } from '../../components/tenants/TenantDetail';
+import { TenantListPanel } from '../../components/tenants/TenantList';
+import type { TenantListFilters, TenantListItem, TenantListQuery } from '../../lib/api/tenants';
+import { useTenants } from '../../lib/api/tenants';
+
+function useDebouncedValue<T>(value: T, delay: number) {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const handle = window.setTimeout(() => setDebounced(value), delay);
+    return () => window.clearTimeout(handle);
+  }, [value, delay]);
+  return debounced;
+}
+
+export default function TenantsPage() {
+  const [selectedTenant, setSelectedTenant] = useState<string | undefined>();
+  const [search, setSearch] = useState('');
+  const [filters, setFilters] = useState<TenantListFilters>({
+    statuses: [],
+    arrearsOnly: false,
+    nextInspectionInDays: null,
+  });
+  const debouncedSearch = useDebouncedValue(search, 300);
+
+  const query: TenantListQuery = useMemo(
+    () => ({ search: debouncedSearch, filters }),
+    [debouncedSearch, filters]
+  );
+
+  const tenantsQuery = useTenants(query);
+
+  const handleSelect = useCallback((tenant: TenantListItem | undefined) => {
+    setSelectedTenant(tenant?.id);
+  }, []);
+
+  useEffect(() => {
+    if (!selectedTenant && tenantsQuery.data?.length) {
+      setSelectedTenant(tenantsQuery.data[0].id);
+    }
+  }, [selectedTenant, tenantsQuery.data]);
+
+  const { leftWidth, onDragStart } = useSplitPane(32);
+
+  return (
+    <div className="flex h-full min-h-[calc(100vh-4rem)] flex-col bg-background text-foreground">
+      <header className="border-b border-border/60 bg-surface">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+          <div>
+            <h1 className="text-xl font-semibold">Tenant CRM</h1>
+            <p className="text-sm text-muted-foreground">
+              Manage tenants, communications, tasks, and files in a single workspace.
+            </p>
+          </div>
+          <HelpTooltip />
+        </div>
+      </header>
+      <main className="flex-1 overflow-hidden">
+        <div className="flex h-full w-full overflow-hidden">
+          <div
+            className="h-full min-w-[18rem] max-w-[32rem] overflow-hidden border-r border-border/60 bg-surface/50"
+            style={{ width: `${leftWidth}%` }}
+          >
+            <TenantListPanel
+              tenants={tenantsQuery.data ?? []}
+              isLoading={tenantsQuery.isLoading}
+              isError={Boolean(tenantsQuery.error)}
+              onRetry={() => tenantsQuery.refetch()}
+              selectedTenantId={selectedTenant}
+              onSelect={handleSelect}
+              search={search}
+              onSearchChange={setSearch}
+              filters={filters}
+              onFiltersChange={setFilters}
+            />
+          </div>
+          <div
+            role="separator"
+            tabIndex={0}
+            onMouseDown={(event) => onDragStart(event.nativeEvent)}
+            onKeyDown={(event) => {
+              if (event.key === 'ArrowLeft') {
+                event.preventDefault();
+                onDragStart(undefined, -4);
+              } else if (event.key === 'ArrowRight') {
+                event.preventDefault();
+                onDragStart(undefined, 4);
+              }
+            }}
+            aria-orientation="vertical"
+            className="flex w-2 cursor-col-resize items-center justify-center bg-transparent outline-none"
+          >
+            <div className="h-16 w-[3px] rounded-full bg-border" />
+          </div>
+          <div className="flex-1 overflow-hidden bg-surface">
+            <TenantDetailPanel tenantId={selectedTenant} />
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function HelpTooltip() {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        className="flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-surface/80 text-sm font-medium text-muted-foreground transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+        aria-label="Tenant CRM help"
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        ?
+      </button>
+      {open ? (
+        <div className="absolute right-0 z-20 mt-2 w-72 rounded-lg border border-border/60 bg-surface/95 p-4 text-sm shadow-lg">
+          <p className="font-semibold text-foreground">Need a hand?</p>
+          <p className="mt-1 text-muted-foreground">
+            Search tenants, use <kbd className="rounded border px-1">/</kbd> shortcuts in notes, and press
+            <kbd className="ml-1 rounded border px-1">Ctrl</kbd>+<kbd className="rounded border px-1">K</kbd> to jump to
+            search. Contact support if something feels off.
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function useSplitPane(initialPercentage: number) {
+  const [leftWidth, setLeftWidth] = useState(initialPercentage);
+
+  const onDragStart = useCallback((event?: MouseEvent, deltaFromKey?: number) => {
+    if (typeof deltaFromKey === 'number') {
+      setLeftWidth((prev) => clamp(prev + deltaFromKey, 18, 60));
+      return;
+    }
+    if (!event) return;
+    const startX = event.clientX;
+    const handleMove = (move: MouseEvent) => {
+      const delta = move.clientX - startX;
+      const percentage = (delta / window.innerWidth) * 100;
+      setLeftWidth((prev) => clamp(prev + percentage, 18, 60));
+    };
+    const handleUp = () => {
+      window.removeEventListener('mousemove', handleMove);
+      window.removeEventListener('mouseup', handleUp);
+    };
+    window.addEventListener('mousemove', handleMove);
+    window.addEventListener('mouseup', handleUp);
+  }, []);
+
+  return { leftWidth, onDragStart };
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+

--- a/components/tenants/FilesTab.tsx
+++ b/components/tenants/FilesTab.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useRef, type ChangeEvent } from 'react';
+
+import { useFiles, useUploadFile } from '../../lib/api/tenants';
+import { useToast } from '../ui/use-toast';
+
+interface FilesTabProps {
+  tenantId: string;
+}
+
+export function FilesTab({ tenantId }: FilesTabProps) {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const filesQuery = useFiles(tenantId);
+  const uploadMutation = useUploadFile();
+  const { toast } = useToast();
+
+  async function handleUpload(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    const type = file.name.toLowerCase().includes('lease') ? 'Lease' : 'General';
+    await uploadMutation.mutateAsync(
+      { tenantId, file, type },
+      {
+        onSuccess: () => toast({ title: 'File uploaded' }),
+        onError: () => toast({ title: 'Upload failed', variant: 'destructive' }),
+      }
+    );
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  }
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <div className="flex items-center justify-between border-b border-border/60 bg-surface px-6 py-4">
+        <div>
+          <h3 className="text-sm font-semibold text-foreground">Tenant documents</h3>
+          <p className="text-xs text-muted-foreground">Store leases, inspection reports, and handover files.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="application/pdf,image/*"
+            onChange={handleUpload}
+            className="text-xs text-muted-foreground"
+          />
+        </div>
+      </div>
+      <div className="flex-1 overflow-y-auto px-6 py-4">
+        {filesQuery.isLoading ? (
+          <div className="space-y-2">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <div key={index} className="h-16 animate-pulse rounded-lg border border-border/50 bg-muted/30" />
+            ))}
+          </div>
+        ) : !filesQuery.data?.length ? (
+          <div className="flex h-full flex-col items-center justify-center text-center text-sm text-muted-foreground">
+            <p className="font-medium text-foreground">No files uploaded.</p>
+            <p>Add leases, IDs, inspection reports, or photos.</p>
+          </div>
+        ) : (
+          <table className="min-w-full text-left text-sm">
+            <thead className="sticky top-0 bg-surface text-xs uppercase tracking-wide text-muted-foreground">
+              <tr className="border-b border-border/60">
+                <th className="px-3 py-2 font-medium">Name</th>
+                <th className="px-3 py-2 font-medium">Type</th>
+                <th className="px-3 py-2 font-medium">Uploaded</th>
+                <th className="px-3 py-2 font-medium">Preview</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filesQuery.data.map((file) => (
+                <tr key={file.id} className="border-b border-border/50">
+                  <td className="px-3 py-2 text-foreground">{file.name}</td>
+                  <td className="px-3 py-2 text-muted-foreground">{file.type}</td>
+                  <td className="px-3 py-2 text-muted-foreground">
+                    {new Date(file.uploadedAt).toLocaleDateString(undefined, {
+                      month: 'short',
+                      day: 'numeric',
+                      year: 'numeric',
+                    })}
+                  </td>
+                  <td className="px-3 py-2">
+                    {file.url ? (
+                      <a
+                        href={file.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="rounded-md border border-border/60 px-3 py-1 text-xs font-medium text-foreground transition hover:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                      >
+                        Open
+                      </a>
+                    ) : (
+                      <span className="text-xs text-muted-foreground">Preview unavailable</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/components/tenants/NotesTab.tsx
+++ b/components/tenants/NotesTab.tsx
@@ -1,0 +1,403 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import {
+  type Note,
+  type NoteInput,
+  useCreateNote,
+  useDeleteNote,
+  useNotes,
+  useUpdateNote,
+} from '../../lib/api/tenants';
+import { useToast } from '../ui/use-toast';
+
+const TAG_OPTIONS: Array<{ value: NoteInput['tags'][number]; label: string }> = [
+  { value: 'general', label: 'General' },
+  { value: 'maintenance', label: 'Maintenance' },
+  { value: 'arrears', label: 'Arrears' },
+  { value: 'inspection', label: 'Inspection' },
+  { value: 'comms', label: 'Comms' },
+];
+
+interface NotesTabProps {
+  tenantId: string;
+  tenantName: string;
+}
+
+type NoteFilter = NoteInput['tags'][number] | 'all';
+
+export function NotesTab({ tenantId, tenantName }: NotesTabProps) {
+  const notesQuery = useNotes(tenantId);
+  const createNote = useCreateNote();
+  const updateNote = useUpdateNote();
+  const deleteNote = useDeleteNote();
+  const { toast } = useToast();
+
+  const [body, setBody] = useState('');
+  const [tags, setTags] = useState<NoteInput['tags']>(['general']);
+  const [followUpAt, setFollowUpAt] = useState<string | null>(null);
+  const [filterTag, setFilterTag] = useState<NoteFilter>('all');
+  const [filterText, setFilterText] = useState('');
+  const [editingNote, setEditingNote] = useState<Note | null>(null);
+
+  const timezone = useMemo(() => Intl.DateTimeFormat().resolvedOptions().timeZone, []);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+        event.preventDefault();
+        if (editingNote) {
+          handleUpdate(editingNote.id);
+        } else {
+          handleSubmit();
+        }
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [editingNote, body, tags, followUpAt]);
+
+  const filteredNotes = useMemo(() => {
+    const items = notesQuery.data ?? [];
+    return items.filter((note) => {
+      const matchesTag = filterTag === 'all' || note.tags.includes(filterTag);
+      const matchesText = filterText
+        ? note.body.toLowerCase().includes(filterText.toLowerCase())
+        : true;
+      return matchesTag && matchesText;
+    });
+  }, [filterTag, filterText, notesQuery.data]);
+
+  function resetComposer() {
+    setBody('');
+    setTags(['general']);
+    setFollowUpAt(null);
+    setEditingNote(null);
+  }
+
+  function parseCommands(text: string, currentTags: NoteInput['tags'], currentFollowUp: string | null) {
+    const tokens = text.split(/\s+/);
+    const uniqueTags = new Set(currentTags);
+    let reminder: string | null = currentFollowUp;
+    for (const token of tokens) {
+      switch (token.toLowerCase()) {
+        case '/maint':
+          uniqueTags.add('maintenance');
+          break;
+        case '/arrears':
+          uniqueTags.add('arrears');
+          break;
+        case '/inspect':
+          uniqueTags.add('inspection');
+          break;
+        default:
+          if (token.startsWith('/followup')) {
+            const [, arg] = token.split(':');
+            const amount = Number(arg?.replace(/[^0-9]/g, ''));
+            if (!Number.isNaN(amount)) {
+              reminder = new Date(Date.now() + amount * 24 * 60 * 60 * 1000)
+                .toISOString()
+                .slice(0, 16);
+            }
+          }
+          break;
+      }
+    }
+    const parsedTags = Array.from(uniqueTags);
+    return { tags: parsedTags, followUp: reminder };
+  }
+
+  async function handleSubmit() {
+    if (!body.trim()) {
+      toast({ title: 'Add a note body before submitting', variant: 'destructive' });
+      return;
+    }
+    const parsed = parseCommands(body, tags, followUpAt);
+    setTags(parsed.tags);
+    setFollowUpAt(parsed.followUp);
+
+    const payload: NoteInput = {
+      tenantId,
+      body,
+      tags: parsed.tags,
+      followUpAt: parsed.followUp ? new Date(parsed.followUp).toISOString() : null,
+    };
+    await createNote.mutateAsync(payload, {
+      onSuccess: () => {
+        toast({ title: 'Note added', description: `Saved for ${tenantName}` });
+        resetComposer();
+      },
+      onError: () => {
+        toast({ title: 'Failed to add note', variant: 'destructive' });
+      },
+    });
+  }
+
+  async function handleUpdate(noteId: string) {
+    if (!editingNote) return;
+    const parsed = parseCommands(body, tags, followUpAt);
+    setTags(parsed.tags);
+    setFollowUpAt(parsed.followUp);
+    const payload: Partial<NoteInput> = {
+      tenantId,
+      body,
+      tags: parsed.tags,
+      followUpAt: parsed.followUp ? new Date(parsed.followUp).toISOString() : undefined,
+    };
+    await updateNote.mutateAsync(
+      { id: noteId, input: payload },
+      {
+        onSuccess: () => {
+          toast({ title: 'Note updated' });
+          resetComposer();
+        },
+        onError: () => toast({ title: 'Failed to update note', variant: 'destructive' }),
+      }
+    );
+  }
+
+  async function handleDelete(note: Note) {
+    await deleteNote.mutateAsync(
+      { id: note.id, tenantId },
+      {
+        onSuccess: () => toast({ title: 'Note deleted' }),
+        onError: () => toast({ title: 'Failed to delete note', variant: 'destructive' }),
+      }
+    );
+  }
+
+  const composerLabel = editingNote ? 'Update note' : 'Add note';
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <div className="border-b border-border/60 bg-background/40 px-6 py-4">
+        <label className="block text-sm font-semibold text-foreground" htmlFor="note-body">
+          Smart note
+        </label>
+        <textarea
+          id="note-body"
+          value={body}
+          onChange={(event) => {
+            const nextBody = event.target.value;
+            setBody(nextBody);
+            const parsed = parseCommands(nextBody, tags, followUpAt);
+            setTags(parsed.tags);
+            setFollowUpAt(parsed.followUp);
+          }}
+          placeholder="Capture call summaries, visit outcomes, or reminders… Try /arrears or !tomorrow 9am."
+          className="mt-2 h-32 w-full rounded-lg border border-border/60 bg-surface px-3 py-2 text-sm text-foreground shadow-sm outline-none focus:border-primary focus:ring-2 focus:ring-primary/60"
+        />
+        <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+          <TagSelector value={tags} onChange={setTags} />
+          <div className="flex items-center gap-2">
+            <label htmlFor="followUp" className="text-xs font-medium text-muted-foreground">
+              Reminder
+            </label>
+            <input
+              id="followUp"
+              type="datetime-local"
+              value={followUpAt ?? ''}
+              onChange={(event) => setFollowUpAt(event.target.value || null)}
+              className="rounded-md border border-border/60 bg-surface px-2 py-1 text-xs text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            />
+            <span className="rounded bg-surface/80 px-2 py-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+              {timezone}
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={editingNote ? () => handleUpdate(editingNote.id) : handleSubmit}
+            className="ml-auto inline-flex items-center rounded-md bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+          >
+            {composerLabel} (⌘⏎)
+          </button>
+          {editingNote ? (
+            <button
+              type="button"
+              onClick={resetComposer}
+              className="rounded-md border border-border/60 px-3 py-1 text-xs font-medium text-muted-foreground hover:border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            >
+              Cancel edit
+            </button>
+          ) : null}
+        </div>
+      </div>
+      <div className="flex items-center gap-3 border-b border-border/60 bg-surface/70 px-6 py-3 text-xs">
+        <div className="flex items-center gap-2">
+          <label className="text-xs font-semibold text-muted-foreground">Tag</label>
+          <select
+            value={filterTag}
+            onChange={(event) => setFilterTag(event.target.value as NoteFilter)}
+            className="rounded-md border border-border/60 bg-surface px-2 py-1 text-xs text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+          >
+            <option value="all">All</option>
+            {TAG_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="relative flex-1">
+          <input
+            value={filterText}
+            onChange={(event) => setFilterText(event.target.value)}
+            placeholder="Filter notes"
+            className="w-full rounded-md border border-border/60 bg-surface px-3 py-1.5 text-xs text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+          />
+        </div>
+      </div>
+      <div className="flex-1 overflow-y-auto px-6 py-4">
+        {notesQuery.isLoading ? (
+          <NoteSkeleton />
+        ) : filteredNotes.length === 0 ? (
+          <div className="flex h-full flex-col items-center justify-center text-center text-sm text-muted-foreground">
+            <p className="font-medium text-foreground">No notes yet.</p>
+            <p>Add your first note and set a follow-up.</p>
+          </div>
+        ) : (
+          <ul className="space-y-4">
+            {filteredNotes.map((note) => (
+              <li key={note.id} className="rounded-lg border border-border/60 bg-background/60 p-4 shadow-sm">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <p className="text-xs text-muted-foreground">{formatDateTime(note.createdAt)}</p>
+                    <article
+                      className="prose prose-sm mt-2 max-w-none text-foreground prose-p:mt-0 prose-p:mb-2 dark:prose-invert"
+                      dangerouslySetInnerHTML={{ __html: renderMarkdown(note.body) }}
+                    />
+                  </div>
+                  <div className="flex flex-col items-end gap-2">
+                    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium ${tagClass(note.tags[0])}`}>
+                      {note.tags[0] ?? 'general'}
+                    </span>
+                    <div className="flex gap-2 text-xs">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setBody(note.body);
+                          setTags(note.tags);
+                          setFollowUpAt(note.followUpAt ?? null);
+                          setEditingNote(note);
+                        }}
+                        className="rounded border border-border/60 px-2 py-1 text-xs text-muted-foreground hover:border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleDelete(note)}
+                        className="rounded border border-border/60 px-2 py-1 text-xs text-muted-foreground hover:border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TagSelector({ value, onChange }: { value: NoteInput['tags']; onChange: (tags: NoteInput['tags']) => void }) {
+  const [draft, setDraft] = useState('');
+  function addTag(tag: NoteInput['tags'][number]) {
+    if (!value.includes(tag)) {
+      onChange([...value, tag]);
+    }
+    setDraft('');
+  }
+  return (
+    <div className="flex items-center gap-2 rounded-md border border-border/60 bg-surface px-2 py-1">
+      <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">Tags</span>
+      <div className="flex flex-wrap gap-1">
+        {value.map((tag) => (
+          <button
+            key={tag}
+            type="button"
+            onClick={() => onChange(value.filter((item) => item !== tag))}
+            className={`${tagClass(tag)} inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px]`}
+          >
+            {tag}
+            <span aria-hidden>×</span>
+          </button>
+        ))}
+      </div>
+      <div className="relative">
+        <input
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          list="note-tags"
+          placeholder="Add"
+          className="w-20 bg-transparent text-xs text-foreground outline-none placeholder:text-muted-foreground"
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' && draft) {
+              event.preventDefault();
+              addTag(draft as NoteInput['tags'][number]);
+            }
+          }}
+        />
+        <datalist id="note-tags">
+          {TAG_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </datalist>
+      </div>
+    </div>
+  );
+}
+
+function formatDateTime(value: string) {
+  const date = new Date(value);
+  return `${date.toLocaleDateString()} ${date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+}
+
+function renderMarkdown(body: string) {
+  const escapeHtml = (text: string) => text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  let result = escapeHtml(body);
+  result = result.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>');
+  result = result.replace(/_(.*?)_/g, '<em>$1</em>');
+  result = result.replace(/`([^`]+)`/g, '<code>$1</code>');
+  result = result.replace(/\n/g, '<br />');
+  return result;
+}
+
+function tagClass(tag?: string) {
+  switch (tag) {
+    case 'maintenance':
+      return 'bg-blue-500/10 text-blue-400 border border-blue-500/30';
+    case 'arrears':
+      return 'bg-rose-500/10 text-rose-400 border border-rose-500/30';
+    case 'inspection':
+      return 'bg-amber-500/10 text-amber-400 border border-amber-500/30';
+    case 'comms':
+      return 'bg-purple-500/10 text-purple-400 border border-purple-500/30';
+    case 'general':
+    default:
+      return 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/30';
+  }
+}
+
+function NoteSkeleton() {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: 3 }).map((_, index) => (
+        <div key={index} className="animate-pulse rounded-lg border border-border/50 bg-muted/30 p-4">
+          <div className="h-3 w-1/3 rounded bg-muted" />
+          <div className="mt-3 space-y-2">
+            <div className="h-3 w-full rounded bg-muted/80" />
+            <div className="h-3 w-2/3 rounded bg-muted/60" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/components/tenants/PreferencesTab.tsx
+++ b/components/tenants/PreferencesTab.tsx
@@ -1,0 +1,209 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { z } from 'zod';
+
+import { type TenantPreferences, usePreferences, useSavePreferences } from '../../lib/api/tenants';
+import { useToast } from '../ui/use-toast';
+
+const preferencesSchema = z.object({
+  email: z.boolean(),
+  sms: z.boolean(),
+  push: z.boolean(),
+  quietHoursStart: z.union([z.string().min(1), z.literal('')]),
+  quietHoursEnd: z.union([z.string().min(1), z.literal('')]),
+  bestContactTime: z.union([z.string().min(1), z.literal('')]),
+});
+
+type PreferencesFormValues = z.infer<typeof preferencesSchema>;
+
+interface PreferencesTabProps {
+  tenantId: string;
+}
+
+export function PreferencesTab({ tenantId }: PreferencesTabProps) {
+  const { toast } = useToast();
+  const preferencesQuery = usePreferences(tenantId);
+  const savePreferences = useSavePreferences();
+
+  const [values, setValues] = useState<PreferencesFormValues>({
+    email: true,
+    sms: true,
+    push: false,
+    quietHoursStart: '',
+    quietHoursEnd: '',
+    bestContactTime: '',
+  });
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (preferencesQuery.data) {
+      setValues(mapToForm(preferencesQuery.data));
+      setErrors({});
+    }
+  }, [preferencesQuery.data]);
+
+  const handleChange = (field: keyof PreferencesFormValues, value: string | boolean) => {
+    setValues((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const parsed = preferencesSchema.safeParse(values);
+    if (!parsed.success) {
+      const fieldErrors: Record<string, string> = {};
+      parsed.error.issues.forEach((issue) => {
+        const path = issue.path[0];
+        if (typeof path === 'string') {
+          fieldErrors[path] = issue.message;
+        }
+      });
+      setErrors(fieldErrors);
+      return;
+    }
+
+    setErrors({});
+    const payload: TenantPreferences = {
+      email: parsed.data.email,
+      sms: parsed.data.sms,
+      push: parsed.data.push,
+      quietHoursStart: parsed.data.quietHoursStart || null,
+      quietHoursEnd: parsed.data.quietHoursEnd || null,
+      bestContactTime: parsed.data.bestContactTime || null,
+    };
+
+    await savePreferences.mutateAsync(
+      { tenantId, data: payload },
+      {
+        onSuccess: () => toast({ title: 'Preferences saved' }),
+        onError: () => toast({ title: 'Failed to save preferences', variant: 'destructive' }),
+      }
+    );
+  };
+
+  if (preferencesQuery.isLoading) {
+    return (
+      <div className="space-y-4 p-6">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <div key={index} className="h-20 animate-pulse rounded-lg border border-border/50 bg-muted/30" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6 px-6 py-6">
+      <fieldset className="rounded-lg border border-border/60 bg-background/40 p-4">
+        <legend className="px-1 text-sm font-semibold text-foreground">Communication channels</legend>
+        <div className="mt-3 grid gap-3 sm:grid-cols-3">
+          <label className="flex items-center gap-2 text-sm text-foreground">
+            <input
+              type="checkbox"
+              checked={values.email}
+              onChange={(event) => handleChange('email', event.target.checked)}
+              className="h-4 w-4 rounded border border-border/70"
+            />
+            Email
+          </label>
+          <label className="flex items-center gap-2 text-sm text-foreground">
+            <input
+              type="checkbox"
+              checked={values.sms}
+              onChange={(event) => handleChange('sms', event.target.checked)}
+              className="h-4 w-4 rounded border border-border/70"
+            />
+            SMS
+          </label>
+          <label className="flex items-center gap-2 text-sm text-foreground">
+            <input
+              type="checkbox"
+              checked={values.push}
+              onChange={(event) => handleChange('push', event.target.checked)}
+              className="h-4 w-4 rounded border border-border/70"
+            />
+            Push
+          </label>
+        </div>
+      </fieldset>
+
+      <fieldset className="rounded-lg border border-border/60 bg-background/40 p-4">
+        <legend className="px-1 text-sm font-semibold text-foreground">Quiet hours</legend>
+        <div className="mt-3 grid gap-4 sm:grid-cols-2">
+          <div>
+            <label className="block text-xs font-semibold uppercase tracking-wide text-muted-foreground" htmlFor="quiet-start">
+              Start
+            </label>
+            <input
+              id="quiet-start"
+              type="time"
+              value={values.quietHoursStart ?? ''}
+              onChange={(event) => handleChange('quietHoursStart', event.target.value)}
+              className="mt-1 w-full rounded-md border border-border/60 bg-surface px-3 py-2 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            />
+            {errors.quietHoursStart ? (
+              <p className="mt-1 text-xs text-destructive">{errors.quietHoursStart}</p>
+            ) : null}
+          </div>
+          <div>
+            <label className="block text-xs font-semibold uppercase tracking-wide text-muted-foreground" htmlFor="quiet-end">
+              End
+            </label>
+            <input
+              id="quiet-end"
+              type="time"
+              value={values.quietHoursEnd ?? ''}
+              onChange={(event) => handleChange('quietHoursEnd', event.target.value)}
+              className="mt-1 w-full rounded-md border border-border/60 bg-surface px-3 py-2 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            />
+            {errors.quietHoursEnd ? (
+              <p className="mt-1 text-xs text-destructive">{errors.quietHoursEnd}</p>
+            ) : null}
+          </div>
+        </div>
+      </fieldset>
+
+      <fieldset className="rounded-lg border border-border/60 bg-background/40 p-4">
+        <legend className="px-1 text-sm font-semibold text-foreground">Best contact time</legend>
+        <div className="mt-3 grid gap-4 sm:grid-cols-2">
+          <div>
+            <label className="block text-xs font-semibold uppercase tracking-wide text-muted-foreground" htmlFor="best-time">
+              Preferred time
+            </label>
+            <input
+              id="best-time"
+              type="time"
+              value={values.bestContactTime ?? ''}
+              onChange={(event) => handleChange('bestContactTime', event.target.value)}
+              className="mt-1 w-full rounded-md border border-border/60 bg-surface px-3 py-2 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            />
+            {errors.bestContactTime ? (
+              <p className="mt-1 text-xs text-destructive">{errors.bestContactTime}</p>
+            ) : null}
+          </div>
+        </div>
+      </fieldset>
+
+      <div className="flex justify-end">
+        <button
+          type="submit"
+          disabled={savePreferences.isPending}
+          className="inline-flex items-center rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:opacity-70"
+        >
+          {savePreferences.isPending ? 'Saving…' : 'Save preferences'}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function mapToForm(preferences: TenantPreferences): PreferencesFormValues {
+  return {
+    email: preferences.email,
+    sms: preferences.sms,
+    push: preferences.push,
+    quietHoursStart: preferences.quietHoursStart ?? '',
+    quietHoursEnd: preferences.quietHoursEnd ?? '',
+    bestContactTime: preferences.bestContactTime ?? '',
+  };
+}
+

--- a/components/tenants/TenantDetail.tsx
+++ b/components/tenants/TenantDetail.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import { NotesTab } from './NotesTab';
+import { PreferencesTab } from './PreferencesTab';
+import { TimelineTab } from './TimelineTab';
+import { FilesTab } from './FilesTab';
+import { useTenant } from '../../lib/api/tenants';
+
+const TABS = ['overview', 'notes', 'timeline', 'preferences', 'files'] as const;
+type TabKey = (typeof TABS)[number];
+
+interface TenantDetailPanelProps {
+  tenantId?: string;
+}
+
+const TAB_LABELS: Record<TabKey, string> = {
+  overview: 'Overview',
+  notes: 'Notes',
+  timeline: 'Timeline',
+  preferences: 'Preferences',
+  files: 'Files',
+};
+
+export function TenantDetailPanel({ tenantId }: TenantDetailPanelProps) {
+  const [activeTab, setActiveTab] = useStickyTab();
+  const tenantQuery = useTenant(tenantId);
+
+  useEffect(() => {
+    if (tenantQuery.data && tenantId) {
+      document.title = `${tenantQuery.data.name} • Tenant CRM`;
+    }
+  }, [tenantId, tenantQuery.data]);
+
+  if (!tenantId) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 text-center text-muted-foreground">
+        <p className="text-lg font-semibold text-foreground">Select a tenant</p>
+        <p className="max-w-sm text-sm">
+          Choose a tenant from the list to view their details, notes, timeline, preferences, and files.
+        </p>
+      </div>
+    );
+  }
+
+  if (tenantQuery.isLoading) {
+    return <TenantDetailSkeleton />;
+  }
+
+  if (tenantQuery.isError || !tenantQuery.data) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 text-center text-sm">
+        <p className="text-lg font-semibold text-foreground">Unable to load tenant</p>
+        <p className="text-muted-foreground">Something went wrong fetching the tenant details.</p>
+        <button
+          type="button"
+          onClick={() => tenantQuery.refetch()}
+          className="rounded-md border border-border/70 px-3 py-1 text-sm font-medium text-foreground transition hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  const tenant = tenantQuery.data;
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <div className="border-b border-border/60 bg-surface px-6 py-4">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="min-w-0">
+            <h2 className="truncate text-lg font-semibold text-foreground">{tenant.name}</h2>
+            <p className="truncate text-sm text-muted-foreground">
+              {tenant.email || tenant.phone ? [tenant.email, tenant.phone].filter(Boolean).join(' • ') : 'No contact details'}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {['Call', 'Email', 'SMS', 'New Note', 'New Task', 'Maintenance Job'].map((label) => (
+              <button
+                key={label}
+                type="button"
+                className="rounded-md border border-border/70 bg-surface px-3 py-1 text-xs font-medium text-foreground transition hover:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+      <div className="flex h-12 items-center justify-between border-b border-border/60 bg-surface px-4">
+        <nav className="flex items-center gap-2" role="tablist" aria-label="Tenant detail tabs">
+          {TABS.map((tab) => (
+            <button
+              key={tab}
+              role="tab"
+              type="button"
+              aria-selected={activeTab === tab}
+              onClick={() => setActiveTab(tab)}
+              className={`rounded-md px-3 py-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary ${
+                activeTab === tab
+                  ? 'bg-primary/10 text-primary'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {TAB_LABELS[tab]}
+            </button>
+          ))}
+        </nav>
+      </div>
+      <div className="flex-1 overflow-y-auto bg-surface">
+        {activeTab === 'overview' ? <OverviewTab tenant={tenant} /> : null}
+        {activeTab === 'notes' ? <NotesTab tenantId={tenant.id} tenantName={tenant.name} /> : null}
+        {activeTab === 'timeline' ? <TimelineTab tenantId={tenant.id} /> : null}
+        {activeTab === 'preferences' ? <PreferencesTab tenantId={tenant.id} /> : null}
+        {activeTab === 'files' ? <FilesTab tenantId={tenant.id} /> : null}
+      </div>
+    </div>
+  );
+}
+
+function useStickyTab(): [TabKey, (tab: TabKey) => void] {
+  const [tab, setTab] = useState<TabKey>(() => {
+    if (typeof window === 'undefined') return 'overview';
+    const stored = window.localStorage.getItem('tenant-crm:last-tab') as TabKey | null;
+    return stored && TABS.includes(stored) ? stored : 'overview';
+  });
+
+  const update = (next: TabKey) => {
+    setTab(next);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem('tenant-crm:last-tab', next);
+    }
+  };
+
+  return [tab, update];
+}
+
+function OverviewTab({ tenant }: { tenant: { name: string; email?: string; phone?: string; address?: string; lastInteractionAt?: string | undefined } }) {
+  const lastInteraction = useMemo(() =>
+    tenant.lastInteractionAt ? timeAgo(tenant.lastInteractionAt) : 'No recent activity',
+  [tenant.lastInteractionAt]);
+
+  return (
+    <div className="space-y-6 px-6 py-6 text-sm text-foreground">
+      <section className="grid gap-4 rounded-lg border border-border/60 bg-background/40 p-4">
+        <div>
+          <h3 className="text-sm font-semibold text-foreground">Primary details</h3>
+          <dl className="mt-2 grid grid-cols-1 gap-3 text-sm text-muted-foreground md:grid-cols-2">
+            <div>
+              <dt className="text-xs uppercase tracking-wide">Email</dt>
+              <dd className="text-sm text-foreground">{tenant.email ?? '—'}</dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase tracking-wide">Phone</dt>
+              <dd className="text-sm text-foreground">{tenant.phone ?? '—'}</dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase tracking-wide">Address</dt>
+              <dd className="text-sm text-foreground">{tenant.address ?? '—'}</dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase tracking-wide">Last touchpoint</dt>
+              <dd className="text-sm text-foreground">{lastInteraction}</dd>
+            </div>
+          </dl>
+        </div>
+      </section>
+      <section className="rounded-lg border border-border/60 bg-background/40 p-4">
+        <h3 className="text-sm font-semibold text-foreground">Guided actions</h3>
+        <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+          <li>Review arrears status and follow up on outstanding balances.</li>
+          <li>Log upcoming inspections and set reminders with / commands.</li>
+          <li>Upload lease agreements and inspection reports for quick access.</li>
+        </ul>
+      </section>
+    </div>
+  );
+}
+
+function timeAgo(value: string) {
+  const now = Date.now();
+  const then = new Date(value).getTime();
+  const diff = now - then;
+  const minutes = Math.round(diff / (1000 * 60));
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'} ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+  const days = Math.round(hours / 24);
+  if (days < 30) return `${days} day${days === 1 ? '' : 's'} ago`;
+  const months = Math.round(days / 30);
+  if (months < 12) return `${months} month${months === 1 ? '' : 's'} ago`;
+  const years = Math.round(months / 12);
+  return `${years} year${years === 1 ? '' : 's'} ago`;
+}
+
+function TenantDetailSkeleton() {
+  return (
+    <div className="flex h-full flex-col">
+      <div className="border-b border-border/60 bg-surface px-6 py-4">
+        <div className="flex animate-pulse flex-col gap-3">
+          <div className="h-4 w-48 rounded bg-muted" />
+          <div className="h-3 w-64 rounded bg-muted/80" />
+        </div>
+      </div>
+      <div className="border-b border-border/60 px-6 py-3">
+        <div className="h-8 w-72 animate-pulse rounded bg-muted/60" />
+      </div>
+      <div className="flex-1 space-y-3 overflow-hidden p-6">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <div key={index} className="h-32 animate-pulse rounded-lg border border-border/50 bg-muted/40" />
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/components/tenants/TenantList.tsx
+++ b/components/tenants/TenantList.tsx
@@ -1,0 +1,340 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+
+import type { TenantListFilters, TenantListItem } from '../../lib/api/tenants';
+
+type TenantListPanelProps = {
+  tenants: TenantListItem[];
+  selectedTenantId?: string;
+  onSelect: (tenant?: TenantListItem) => void;
+  isLoading?: boolean;
+  isError?: boolean;
+  onRetry?: () => void;
+  search: string;
+  onSearchChange: (value: string) => void;
+  filters: TenantListFilters;
+  onFiltersChange: (filters: TenantListFilters) => void;
+};
+
+const STATUS_LABELS: Record<TenantListItem['status'], string> = {
+  A_GRADE: 'A-Grade',
+  WATCHLIST: 'Watchlist',
+  PROSPECT: 'Prospect',
+};
+
+export function TenantListPanel({
+  tenants,
+  selectedTenantId,
+  onSelect,
+  isLoading,
+  isError,
+  onRetry,
+  search,
+  onSearchChange,
+  filters,
+  onFiltersChange,
+}: TenantListPanelProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    if (!tenants.length) return;
+    const index = tenants.findIndex((item) => item.id === selectedTenantId);
+    setActiveIndex(index === -1 ? 0 : index);
+  }, [selectedTenantId, tenants]);
+
+  const itemHeight = 84;
+  const overscan = 6;
+  const [scrollTop, setScrollTop] = useState(0);
+  const [containerHeight, setContainerHeight] = useState(400);
+
+  useEffect(() => {
+    const container = scrollRef.current;
+    if (!container || typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      setContainerHeight(entry.contentRect.height);
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
+
+  const visibleItems = useMemo(() => {
+    if (!tenants.length) return [] as Array<{ index: number; offset: number }>;
+    const start = Math.max(Math.floor(scrollTop / itemHeight) - overscan, 0);
+    const end = Math.min(
+      tenants.length,
+      Math.ceil((scrollTop + containerHeight) / itemHeight) + overscan
+    );
+    const rows = [] as Array<{ index: number; offset: number }>;
+    for (let index = start; index < end; index += 1) {
+      rows.push({ index, offset: index * itemHeight });
+    }
+    return rows;
+  }, [containerHeight, overscan, scrollTop, tenants.length]);
+
+  const ensureVisible = (index: number) => {
+    const container = scrollRef.current;
+    if (!container) return;
+    const top = index * itemHeight;
+    const bottom = top + itemHeight;
+    if (top < container.scrollTop) {
+      container.scrollTo({ top: top - itemHeight, behavior: 'smooth' });
+    } else if (bottom > container.scrollTop + container.clientHeight) {
+      container.scrollTo({ top: bottom - container.clientHeight + itemHeight, behavior: 'smooth' });
+    }
+  };
+
+  useEffect(() => {
+    if (!listRef.current) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.metaKey || event.ctrlKey) {
+        if (event.key.toLowerCase() === 'k') {
+          event.preventDefault();
+          const searchInput = listRef.current?.querySelector<HTMLInputElement>('input[data-tenant-search="true"]');
+          searchInput?.focus();
+        }
+        return;
+      }
+      if (!tenants.length) return;
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        setActiveIndex((prev) => {
+          const next = Math.min(prev + 1, tenants.length - 1);
+          ensureVisible(next);
+          const tenant = tenants[next];
+          onSelect(tenant);
+          return next;
+        });
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        setActiveIndex((prev) => {
+          const next = Math.max(prev - 1, 0);
+          ensureVisible(next);
+          const tenant = tenants[next];
+          onSelect(tenant);
+          return next;
+        });
+      } else if (event.key === 'Enter') {
+        event.preventDefault();
+        const tenant = tenants[activeIndex];
+        if (tenant) {
+          onSelect(tenant);
+        }
+      } else if (event.key.length === 1 && !event.altKey) {
+        const searchInput = listRef.current?.querySelector<HTMLInputElement>('input[data-tenant-search="true"]');
+        if (document.activeElement !== searchInput) {
+          searchInput?.focus();
+          searchInput?.select();
+        }
+      }
+    };
+
+    const node = listRef.current;
+    node?.addEventListener('keydown', handleKeyDown);
+    return () => node?.removeEventListener('keydown', handleKeyDown);
+  }, [activeIndex, onSelect, tenants, ensureVisible]);
+
+  useEffect(() => {
+    if (!scrollRef.current) return;
+    const scrollElement = scrollRef.current;
+    if (!scrollElement.contains(document.activeElement)) {
+      scrollElement.focus();
+    }
+  }, []);
+
+  const statusFilters = useMemo(
+    () =>
+      (['A_GRADE', 'WATCHLIST', 'PROSPECT'] as Array<TenantListItem['status']>).map((status) => ({
+        value: status,
+        active: filters.statuses.includes(status),
+        label: STATUS_LABELS[status],
+      })),
+    [filters.statuses]
+  );
+
+  const toggleStatus = (status: TenantListItem['status']) => {
+    const next = filters.statuses.includes(status)
+      ? filters.statuses.filter((item) => item !== status)
+      : [...filters.statuses, status];
+    onFiltersChange({ ...filters, statuses: next });
+  };
+
+  return (
+    <section ref={listRef} className="flex h-full flex-col" aria-label="Tenant list">
+      <div className="flex items-center gap-2 border-b border-border/60 bg-surface/80 px-4 py-3">
+        <div className="relative flex-1">
+          <input
+            data-tenant-search="true"
+            value={search}
+            onChange={(event) => onSearchChange(event.target.value)}
+            placeholder="Search tenants by name, email, or phone"
+            className="w-full rounded-md border border-border/60 bg-surface px-3 py-2 text-sm text-foreground shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/70"
+            aria-label="Search tenants"
+          />
+          <kbd className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 rounded border border-border/70 px-1 text-[10px] text-muted-foreground">
+            ⌘K
+          </kbd>
+        </div>
+      </div>
+      <div className="flex flex-wrap gap-2 border-b border-border/50 px-4 py-3 text-xs font-medium text-muted-foreground">
+        {statusFilters.map((status) => (
+          <FilterChip key={status.value} active={status.active} onClick={() => toggleStatus(status.value)}>
+            {status.label}
+          </FilterChip>
+        ))}
+        <FilterChip active={filters.arrearsOnly} onClick={() => onFiltersChange({ ...filters, arrearsOnly: !filters.arrearsOnly })}>
+          Arrears
+        </FilterChip>
+        <FilterChip
+          active={Boolean(filters.nextInspectionInDays)}
+          onClick={() =>
+            onFiltersChange({
+              ...filters,
+              nextInspectionInDays: filters.nextInspectionInDays ? null : 30,
+            })
+          }
+        >
+          Next inspection &lt; 30d
+        </FilterChip>
+      </div>
+      <div
+        ref={scrollRef}
+        role="listbox"
+        tabIndex={0}
+        aria-activedescendant={selectedTenantId}
+        className="relative flex-1 overflow-y-auto focus:outline-none"
+        onScroll={(event) => setScrollTop(event.currentTarget.scrollTop)}
+      >
+        {isLoading ? (
+          <ListSkeleton />
+        ) : isError ? (
+          <div className="flex h-full flex-col items-center justify-center gap-3 px-4 text-center text-sm">
+            <p className="font-medium text-foreground">Unable to load tenants</p>
+            <p className="text-muted-foreground">Check your connection and try again.</p>
+            <button
+              type="button"
+              onClick={onRetry}
+              className="rounded-md border border-border/70 px-3 py-1 text-sm font-medium text-foreground transition hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            >
+              Retry
+            </button>
+          </div>
+        ) : tenants.length === 0 ? (
+          <div className="flex h-full flex-col items-center justify-center px-6 text-center text-sm text-muted-foreground">
+            <p className="font-medium text-foreground">No tenants match.</p>
+            <p>Clear filters or add a tenant.</p>
+          </div>
+        ) : (
+          <div style={{ height: tenants.length * itemHeight }} className="relative">
+            {visibleItems.map((row) => {
+              const tenant = tenants[row.index];
+              const isActive = tenant.id === selectedTenantId;
+              return (
+                <div
+                  key={tenant.id}
+                  role="option"
+                  aria-selected={isActive}
+                  id={tenant.id}
+                  className="absolute left-0 right-0"
+                  style={{ transform: `translateY(${row.offset}px)` }}
+                >
+                  <TenantListRow
+                    tenant={tenant}
+                    active={isActive}
+                    onClick={() => onSelect(tenant)}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function TenantListRow({ tenant, active, onClick }: { tenant: TenantListItem; active: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`group flex w-full items-center gap-3 border-b border-border/40 px-4 py-3 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary ${
+        active ? 'bg-primary/10' : 'hover:bg-surface/60'
+      }`}
+    >
+      <div className="flex h-10 w-10 flex-none items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary">
+        {tenant.avatarUrl ? (
+          <img src={tenant.avatarUrl} alt={tenant.name} className="h-full w-full rounded-full object-cover" />
+        ) : (
+          tenant.name
+            .split(' ')
+            .slice(0, 2)
+            .map((part) => part[0]?.toUpperCase())
+            .join('')
+        )}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-start justify-between gap-2">
+          <p className="truncate text-sm font-semibold text-foreground">{tenant.name}</p>
+          {tenant.hasOverdue ? <span className="mt-1 h-2 w-2 flex-none rounded-full bg-destructive" aria-hidden /> : null}
+        </div>
+        <p className="truncate text-xs text-muted-foreground">
+          {tenant.email || tenant.phone || 'No contact details'}
+        </p>
+        <div className="mt-1 flex flex-wrap gap-1">
+          <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium ${statusClass(tenant.status)}`}>
+            {STATUS_LABELS[tenant.status]}
+          </span>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+function statusClass(status: TenantListItem['status']) {
+  switch (status) {
+    case 'A_GRADE':
+      return 'bg-emerald-500/10 text-emerald-400 ring-1 ring-emerald-500/30';
+    case 'WATCHLIST':
+      return 'bg-amber-500/10 text-amber-400 ring-1 ring-amber-500/30';
+    case 'PROSPECT':
+    default:
+      return 'bg-blue-500/10 text-blue-400 ring-1 ring-blue-500/30';
+  }
+}
+
+function FilterChip({ active, children, onClick }: { active: boolean; children: ReactNode; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`inline-flex items-center rounded-full border px-2 py-1 text-[11px] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary ${
+        active
+          ? 'border-primary bg-primary/10 text-primary'
+          : 'border-border/60 bg-surface/80 text-muted-foreground hover:border-border'
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function ListSkeleton() {
+  return (
+    <div className="space-y-2 p-4">
+      {Array.from({ length: 6 }).map((_, index) => (
+        <div key={index} className="flex animate-pulse items-center gap-3 rounded-lg border border-border/40 bg-surface/60 px-4 py-3">
+          <div className="h-10 w-10 rounded-full bg-muted" />
+          <div className="flex-1 space-y-2">
+            <div className="h-3 w-1/2 rounded bg-muted" />
+            <div className="h-2 w-1/3 rounded bg-muted/80" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/components/tenants/TimelineTab.tsx
+++ b/components/tenants/TimelineTab.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { useEffect, useMemo, useRef } from 'react';
+
+import { type TimelineEvent, useTimeline } from '../../lib/api/tenants';
+
+interface TimelineTabProps {
+  tenantId: string;
+}
+
+const ICONS: Record<TimelineEvent['type'], string> = {
+  note: '📝',
+  payment: '💳',
+  job: '🛠️',
+  message: '💬',
+  lease: '📄',
+};
+
+export function TimelineTab({ tenantId }: TimelineTabProps) {
+  const timelineQuery = useTimeline(tenantId);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  const events = useMemo(() => timelineQuery.data?.pages.flatMap((page) => page.items ?? []) ?? [], [
+    timelineQuery.data,
+  ]);
+
+  useEffect(() => {
+    if (!sentinelRef.current) return;
+    const observer = new IntersectionObserver((entries) => {
+      const [entry] = entries;
+      if (entry.isIntersecting && timelineQuery.hasNextPage && !timelineQuery.isFetchingNextPage) {
+        timelineQuery.fetchNextPage();
+      }
+    });
+    observer.observe(sentinelRef.current);
+    return () => observer.disconnect();
+  }, [timelineQuery]);
+
+  const grouped = useMemo(() => groupEvents(events), [events]);
+
+  if (timelineQuery.isLoading) {
+    return (
+      <div className="space-y-3 p-6">
+        {Array.from({ length: 5 }).map((_, index) => (
+          <div key={index} className="flex items-center gap-3 rounded-lg border border-border/50 bg-muted/20 p-4">
+            <div className="h-10 w-10 animate-pulse rounded-full bg-muted/70" />
+            <div className="flex-1 space-y-2">
+              <div className="h-3 w-32 rounded bg-muted/80" />
+              <div className="h-3 w-48 rounded bg-muted/60" />
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (!events.length) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center text-center text-sm text-muted-foreground">
+        <p className="font-medium text-foreground">Nothing here yet.</p>
+        <p>Timeline updates as you log notes, payments, jobs, and communications.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 overflow-y-auto px-6 py-6">
+      {grouped.map((group) => (
+        <section key={group.date} aria-label={group.date} className="space-y-3">
+          <h3 className="sticky top-0 z-10 bg-surface/95 py-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {group.date}
+          </h3>
+          <ol className="space-y-3">
+            {group.items.map((event) => (
+              <li key={event.id} className="relative rounded-lg border border-border/60 bg-background/60 p-4">
+                <div className="absolute -left-5 top-5 flex h-8 w-8 items-center justify-center rounded-full bg-surface shadow">
+                  <span aria-hidden>{ICONS[event.type]}</span>
+                </div>
+                <div className="ml-6 text-sm text-foreground">
+                  <header className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+                    <span className="font-medium capitalize">{event.type}</span>
+                    <span>{timeAgo(event.at)}</span>
+                  </header>
+                  <p className="mt-2 text-sm text-foreground">{describeEvent(event)}</p>
+                </div>
+              </li>
+            ))}
+          </ol>
+        </section>
+      ))}
+      <div ref={sentinelRef} className="h-8" />
+      {timelineQuery.isFetchingNextPage ? (
+        <div className="flex items-center justify-center pb-6 text-xs text-muted-foreground">Loading…</div>
+      ) : null}
+    </div>
+  );
+}
+
+function groupEvents(events: TimelineEvent[]) {
+  const formatter = new Intl.DateTimeFormat(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+  const map = new Map<string, TimelineEvent[]>();
+  for (const event of events) {
+    const key = formatter.format(new Date(event.at));
+    if (!map.has(key)) {
+      map.set(key, []);
+    }
+    map.get(key)!.push(event);
+  }
+  return Array.from(map.entries()).map(([date, items]) => ({ date, items: items.sort((a, b) => (a.at > b.at ? -1 : 1)) }));
+}
+
+function timeAgo(value: string) {
+  const now = Date.now();
+  const then = new Date(value).getTime();
+  const diff = now - then;
+  const minutes = Math.round(diff / (1000 * 60));
+  if (minutes <= 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  const weeks = Math.round(days / 7);
+  if (weeks < 4) return `${weeks}w ago`;
+  const months = Math.round(days / 30);
+  return `${months}mo ago`;
+}
+
+function describeEvent(event: TimelineEvent) {
+  switch (event.type) {
+    case 'note':
+      return event.snippet;
+    case 'payment':
+      return `Payment ${event.status === 'posted' ? 'posted' : 'late'} for $${event.amount.toFixed(2)}`;
+    case 'job':
+      return `${event.title} (${event.status})`;
+    case 'message':
+      return `${event.direction === 'in' ? 'Received' : 'Sent'} ${event.channel.toUpperCase()} message`;
+    case 'lease':
+      return `Lease ${event.event}`;
+    default:
+      return '';
+  }
+}
+

--- a/lib/api/tenants.ts
+++ b/lib/api/tenants.ts
@@ -1,0 +1,602 @@
+import { useCallback, useMemo } from 'react';
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient, type QueryKey } from '@tanstack/react-query';
+
+import { api } from '../api';
+
+export type TenantListItem = {
+  id: string;
+  name: string;
+  email?: string;
+  phone?: string;
+  status: 'A_GRADE' | 'WATCHLIST' | 'PROSPECT';
+  hasOverdue?: boolean;
+  avatarUrl?: string | null;
+};
+
+export type TenantListFilters = {
+  statuses: Array<TenantListItem['status']>;
+  arrearsOnly: boolean;
+  nextInspectionInDays?: number | null;
+};
+
+export type NoteInput = {
+  tenantId: string;
+  body: string;
+  tags: Array<'general' | 'maintenance' | 'arrears' | 'inspection' | 'comms'>;
+  followUpAt?: string | null;
+};
+
+export type Note = NoteInput & {
+  id: string;
+  createdAt: string;
+  updatedAt?: string;
+  author: string;
+};
+
+export type TimelineEvent =
+  | { type: 'note'; id: string; at: string; tag?: string; snippet: string }
+  | { type: 'payment'; id: string; at: string; amount: number; status: 'posted' | 'late' }
+  | { type: 'job'; id: string; at: string; title: string; status: 'open' | 'scheduled' | 'closed' }
+  | { type: 'message'; id: string; at: string; channel: 'email' | 'sms' | 'call'; direction: 'in' | 'out' }
+  | { type: 'lease'; id: string; at: string; event: 'start' | 'renewal' | 'end' };
+
+export type TenantDetail = {
+  id: string;
+  name: string;
+  email?: string;
+  phone?: string;
+  statuses: Array<TenantListItem['status']>;
+  address?: string;
+  lastInteractionAt?: string;
+  bestContactTime?: string | null;
+};
+
+export type TenantPreferences = {
+  email: boolean;
+  sms: boolean;
+  push: boolean;
+  quietHoursStart?: string | null;
+  quietHoursEnd?: string | null;
+  bestContactTime?: string | null;
+};
+
+export type TenantFile = {
+  id: string;
+  tenantId: string;
+  name: string;
+  type: string;
+  uploadedAt: string;
+  url?: string;
+};
+
+const globalEnv =
+  (typeof globalThis !== 'undefined' && (globalThis as any).process?.env) as
+    | Record<string, string | undefined>
+    | undefined;
+
+const windowMock = typeof window !== 'undefined' ? (window as any).__MOCK_MODE__ : undefined;
+
+const MOCK_MODE =
+  windowMock === true ||
+  globalEnv?.NEXT_PUBLIC_MOCK_MODE === 'true' ||
+  globalEnv?.MOCK_MODE === 'true' ||
+  (!globalEnv && !windowMock);
+
+type MockStore = {
+  tenants: TenantDetail[];
+  notes: Note[];
+  timeline: Record<string, TimelineEvent[]>;
+  preferences: Record<string, TenantPreferences>;
+  files: TenantFile[];
+  notifications: Array<{ id: string; tenantId: string; at: string; body: string }>;
+};
+
+const mockStore: MockStore = createInitialMockStore();
+
+function createInitialMockStore(): MockStore {
+  const baseTenants: TenantDetail[] = [
+    {
+      id: 'tnt_alice',
+      name: 'Alice Tenant',
+      email: 'alice@example.com',
+      phone: '+61 400 111 222',
+      statuses: ['A_GRADE'],
+      address: '12 Sunset Way, Carlton',
+      lastInteractionAt: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(),
+      bestContactTime: '09:00',
+    },
+    {
+      id: 'tnt_bob',
+      name: 'Bob Renter',
+      email: 'bob@example.com',
+      phone: '+61 400 333 444',
+      statuses: ['WATCHLIST'],
+      address: '88 Harbour Street, Southbank',
+      lastInteractionAt: new Date(Date.now() - 1000 * 60 * 90).toISOString(),
+    },
+    {
+      id: 'tnt_charlie',
+      name: 'Charlie Prospect',
+      email: 'charlie@example.com',
+      phone: '+61 400 555 999',
+      statuses: ['PROSPECT'],
+      address: 'Prospect - 17 Green Lane',
+      lastInteractionAt: new Date(Date.now() - 1000 * 60 * 60 * 6).toISOString(),
+    },
+  ];
+
+  const now = new Date();
+  const toISO = (d: Date) => d.toISOString();
+
+  const notes: Note[] = [
+    {
+      id: 'note_alice_1',
+      tenantId: 'tnt_alice',
+      body: 'Tenant called to confirm maintenance access window next Tuesday.',
+      tags: ['maintenance'],
+      followUpAt: null,
+      createdAt: toISO(new Date(now.getTime() - 1000 * 60 * 25)),
+      author: 'Ava Property Manager',
+    },
+    {
+      id: 'note_bob_1',
+      tenantId: 'tnt_bob',
+      body: 'Sent arrears reminder, agreed to make payment Friday.',
+      tags: ['arrears'],
+      followUpAt: toISO(new Date(now.getTime() + 1000 * 60 * 60 * 48)),
+      createdAt: toISO(new Date(now.getTime() - 1000 * 60 * 60 * 4)),
+      author: 'Jordan Field Agent',
+    },
+  ];
+
+  const timeline: MockStore['timeline'] = {
+    tnt_alice: [
+      { type: 'payment', id: 'pay_1', at: toISO(new Date(now.getTime() - 1000 * 60 * 60 * 24)), amount: 520, status: 'posted' },
+      { type: 'message', id: 'msg_1', at: toISO(new Date(now.getTime() - 1000 * 60 * 55)), channel: 'sms', direction: 'out' },
+    ],
+    tnt_bob: [
+      { type: 'payment', id: 'pay_2', at: toISO(new Date(now.getTime() - 1000 * 60 * 60 * 48)), amount: 450, status: 'late' },
+      { type: 'message', id: 'msg_2', at: toISO(new Date(now.getTime() - 1000 * 60 * 60 * 6)), channel: 'email', direction: 'out' },
+    ],
+    tnt_charlie: [
+      { type: 'lease', id: 'lease_1', at: toISO(new Date(now.getTime() - 1000 * 60 * 60 * 24 * 5)), event: 'start' },
+    ],
+  };
+
+  for (const note of notes) {
+    timeline[note.tenantId] = timeline[note.tenantId] || [];
+    timeline[note.tenantId].push({
+      type: 'note',
+      id: note.id,
+      at: note.createdAt,
+      tag: note.tags[0],
+      snippet: note.body.slice(0, 120),
+    });
+  }
+
+  const preferences: MockStore['preferences'] = {
+    tnt_alice: {
+      email: true,
+      sms: true,
+      push: false,
+      quietHoursStart: '21:00',
+      quietHoursEnd: '07:00',
+      bestContactTime: '09:00',
+    },
+    tnt_bob: { email: true, sms: false, push: false, bestContactTime: '14:00' },
+    tnt_charlie: { email: true, sms: true, push: true },
+  };
+
+  const files: TenantFile[] = [
+    {
+      id: 'file1',
+      tenantId: 'tnt_alice',
+      name: 'Lease Agreement.pdf',
+      type: 'Lease',
+      uploadedAt: toISO(new Date(now.getTime() - 1000 * 60 * 60 * 24 * 40)),
+      url: '#',
+    },
+    {
+      id: 'file2',
+      tenantId: 'tnt_bob',
+      name: 'Condition Report.jpg',
+      type: 'Inspection',
+      uploadedAt: toISO(new Date(now.getTime() - 1000 * 60 * 60 * 24 * 2)),
+    },
+  ];
+
+  return {
+    tenants: baseTenants,
+    notes,
+    timeline,
+    preferences,
+    files,
+    notifications: [],
+  };
+}
+
+function nextId(prefix: string) {
+  return `${prefix}_${Math.random().toString(36).slice(2, 9)}`;
+}
+
+export type TenantListQuery = {
+  search?: string;
+  filters: TenantListFilters;
+};
+
+async function requestTenants(query: TenantListQuery): Promise<TenantListItem[]> {
+  if (!MOCK_MODE) {
+    const searchParams = new URLSearchParams();
+    if (query.search) searchParams.set('search', query.search);
+    if (query.filters.statuses.length) {
+      searchParams.set('status', query.filters.statuses.join(','));
+    }
+    if (query.filters.arrearsOnly) searchParams.set('arrearsOnly', 'true');
+    if (query.filters.nextInspectionInDays) {
+      searchParams.set('nextInspectionInDays', String(query.filters.nextInspectionInDays));
+    }
+    return api<TenantListItem[]>(`/tenants?${searchParams.toString()}`);
+  }
+
+  const { search, filters } = query;
+  const normalized = search?.trim().toLowerCase();
+  const matchesSearch = (tenant: TenantDetail) => {
+    if (!normalized) return true;
+    return [tenant.name, tenant.email, tenant.phone]
+      .filter(Boolean)
+      .some((field) => field!.toLowerCase().includes(normalized));
+  };
+
+  const matchesStatus = (tenant: TenantDetail) => {
+    if (!filters.statuses.length) return true;
+    return filters.statuses.every((status) => tenant.statuses.includes(status));
+  };
+
+  const results = mockStore.tenants
+    .filter(matchesSearch)
+    .filter(matchesStatus)
+    .map<TenantListItem>((tenant) => ({
+      id: tenant.id,
+      name: tenant.name,
+      email: tenant.email,
+      phone: tenant.phone,
+      status: tenant.statuses[0] ?? 'PROSPECT',
+      hasOverdue: tenant.statuses.includes('WATCHLIST'),
+      avatarUrl: null,
+    }));
+
+  if (filters.arrearsOnly) {
+    return results.filter((tenant) => tenant.status === 'WATCHLIST');
+  }
+
+  return results;
+}
+
+async function requestTenant(id: string): Promise<TenantDetail | undefined> {
+  if (!MOCK_MODE) {
+    return api<TenantDetail>(`/tenants/${id}`);
+  }
+  return mockStore.tenants.find((tenant) => tenant.id === id);
+}
+
+async function requestNotes(tenantId: string): Promise<Note[]> {
+  if (!MOCK_MODE) {
+    return api<Note[]>(`/tenants/${tenantId}/notes`);
+  }
+  return mockStore.notes
+    .filter((note) => note.tenantId === tenantId)
+    .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+}
+
+async function requestTimeline(tenantId: string, cursor?: string) {
+  if (!MOCK_MODE) {
+    const searchParams = new URLSearchParams();
+    if (cursor) searchParams.set('cursor', cursor);
+    return api<{ items: TimelineEvent[]; nextCursor?: string }>(
+      `/tenants/${tenantId}/timeline?${searchParams.toString()}`
+    );
+  }
+
+  const events = [...(mockStore.timeline[tenantId] ?? [])].sort((a, b) =>
+    a.at > b.at ? -1 : 1
+  );
+
+  const startIndex = cursor ? events.findIndex((ev) => ev.id === cursor) + 1 : 0;
+  const pageItems = events.slice(startIndex, startIndex + 20);
+  const next = startIndex + 20 < events.length ? events[startIndex + 19]?.id : undefined;
+  return {
+    items: pageItems,
+    nextCursor: next,
+  };
+}
+
+async function requestPreferences(tenantId: string) {
+  if (!MOCK_MODE) {
+    return api<TenantPreferences>(`/tenants/${tenantId}/preferences`);
+  }
+  return mockStore.preferences[tenantId] ?? {
+    email: true,
+    sms: true,
+    push: false,
+  };
+}
+
+async function savePreferences(tenantId: string, prefs: TenantPreferences) {
+  if (!MOCK_MODE) {
+    return api<TenantPreferences>(`/tenants/${tenantId}/preferences`, {
+      method: 'PUT',
+      body: JSON.stringify(prefs),
+    });
+  }
+  mockStore.preferences[tenantId] = { ...prefs };
+  return mockStore.preferences[tenantId];
+}
+
+async function requestFiles(tenantId: string) {
+  if (!MOCK_MODE) {
+    return api<TenantFile[]>(`/tenants/${tenantId}/files`);
+  }
+  return mockStore.files
+    .filter((file) => file.tenantId === tenantId)
+    .sort((a, b) => (a.uploadedAt > b.uploadedAt ? -1 : 1));
+}
+
+async function uploadFile(tenantId: string, file: File, type: string) {
+  if (!MOCK_MODE) {
+    const form = new FormData();
+    form.set('file', file);
+    form.set('type', type);
+    return api<TenantFile>(`/tenants/${tenantId}/files`, {
+      method: 'POST',
+      body: form,
+    });
+  }
+  const entry: TenantFile = {
+    id: nextId('file'),
+    tenantId,
+    name: file.name,
+    type,
+    uploadedAt: new Date().toISOString(),
+  };
+  mockStore.files.unshift(entry);
+  return entry;
+}
+
+async function createNote(input: NoteInput): Promise<Note> {
+  if (!MOCK_MODE) {
+    return api<Note>(`/tenants/${input.tenantId}/notes`, {
+      method: 'POST',
+      body: JSON.stringify(input),
+    });
+  }
+  const note: Note = {
+    ...input,
+    id: nextId('note'),
+    createdAt: new Date().toISOString(),
+    author: 'You',
+  };
+  mockStore.notes.unshift(note);
+  mockStore.timeline[input.tenantId] = mockStore.timeline[input.tenantId] ?? [];
+  mockStore.timeline[input.tenantId].unshift({
+    type: 'note',
+    id: note.id,
+    at: note.createdAt,
+    tag: input.tags[0],
+    snippet: input.body.slice(0, 120),
+  });
+
+  if (input.followUpAt) {
+    mockStore.notifications.push({
+      id: nextId('notification'),
+      tenantId: input.tenantId,
+      at: input.followUpAt,
+      body: `Reminder for ${input.tenantId}: ${input.body.slice(0, 60)}`,
+    });
+  }
+
+  return note;
+}
+
+async function updateNote(noteId: string, input: Partial<NoteInput>): Promise<Note> {
+  if (!MOCK_MODE) {
+    return api<Note>(`/notes/${noteId}`, {
+      method: 'PATCH',
+      body: JSON.stringify(input),
+    });
+  }
+  const note = mockStore.notes.find((n) => n.id === noteId);
+  if (!note) {
+    throw new Error('Note not found');
+  }
+  Object.assign(note, input, { updatedAt: new Date().toISOString() });
+
+  const tenantTimeline = mockStore.timeline[note.tenantId] ?? [];
+  const timelineEntry = tenantTimeline.find((entry) => entry.type === 'note' && entry.id === noteId);
+  if (timelineEntry && timelineEntry.type === 'note') {
+    timelineEntry.snippet = note.body.slice(0, 120);
+    timelineEntry.tag = note.tags[0];
+  }
+
+  return note;
+}
+
+async function deleteNote(noteId: string) {
+  if (!MOCK_MODE) {
+    await api<void>(`/notes/${noteId}`, { method: 'DELETE' });
+    return;
+  }
+  const index = mockStore.notes.findIndex((note) => note.id === noteId);
+  if (index !== -1) {
+    const [removed] = mockStore.notes.splice(index, 1);
+    const events = mockStore.timeline[removed.tenantId];
+    if (events) {
+      mockStore.timeline[removed.tenantId] = events.filter((entry) => entry.id !== noteId);
+    }
+  }
+}
+
+export function useTenants(query: TenantListQuery) {
+  return useQuery({
+    queryKey: ['tenants', query],
+    queryFn: () => requestTenants(query),
+    staleTime: 1000 * 60 * 5,
+  });
+}
+
+export function useTenant(id?: string) {
+  return useQuery({
+    queryKey: ['tenant', id],
+    queryFn: () => (id ? requestTenant(id) : undefined),
+    enabled: Boolean(id),
+    staleTime: 1000 * 60 * 5,
+  });
+}
+
+export function useNotes(tenantId?: string) {
+  return useQuery({
+    queryKey: ['tenant', tenantId, 'notes'],
+    queryFn: () => (tenantId ? requestNotes(tenantId) : []),
+    enabled: Boolean(tenantId),
+  });
+}
+
+export function useCreateNote() {
+  const queryClient = useQueryClient();
+  return useMutation<Note, Error, NoteInput, { previousNotes?: Note[] }>({
+    mutationFn: createNote,
+    onMutate: async (input: NoteInput) => {
+      await queryClient.cancelQueries({ queryKey: ['tenant', input.tenantId, 'notes'] });
+      const previousNotes = queryClient.getQueryData<Note[]>(['tenant', input.tenantId, 'notes']);
+      const optimistic: Note = {
+        ...input,
+        id: nextId('note_tmp'),
+        createdAt: new Date().toISOString(),
+        author: 'You',
+      };
+      queryClient.setQueryData<Note[]>(['tenant', input.tenantId, 'notes'], (old = []) => [
+        optimistic,
+        ...old,
+      ]);
+      return { previousNotes };
+    },
+    onError: (_error: unknown, input: NoteInput, context?: { previousNotes?: Note[] }) => {
+      if (context?.previousNotes) {
+        queryClient.setQueryData(['tenant', input.tenantId, 'notes'], context.previousNotes);
+      }
+    },
+    onSuccess: (note: Note) => {
+      queryClient.invalidateQueries({ queryKey: ['tenant', note.tenantId, 'notes'] });
+      queryClient.invalidateQueries({ queryKey: ['tenant', note.tenantId, 'timeline'] });
+    },
+  });
+}
+
+export function useUpdateNote() {
+  const queryClient = useQueryClient();
+  type UpdateVariables = { id: string; input: Partial<NoteInput> & { tenantId: string } };
+  return useMutation<Note, Error, UpdateVariables, { previous?: Note[] }>({
+    mutationFn: ({ id, input }: UpdateVariables) => updateNote(id, input),
+    onMutate: async ({ id, input }: UpdateVariables) => {
+      const notesQueryKey: QueryKey = ['tenant', input.tenantId, 'notes'];
+      await queryClient.cancelQueries({ queryKey: notesQueryKey });
+      const previous = queryClient.getQueryData<Note[]>(notesQueryKey);
+      queryClient.setQueryData<Note[]>(notesQueryKey, (old = []) =>
+        old.map((note) => (note.id === id ? { ...note, ...input } : note))
+      );
+      return { previous };
+    },
+    onError: (_err: unknown, vars: UpdateVariables, context?: { previous?: Note[] }) => {
+      const key: QueryKey = ['tenant', vars.input.tenantId, 'notes'];
+      if (context?.previous) {
+        queryClient.setQueryData(key, context.previous);
+      }
+    },
+    onSuccess: (note: Note) => {
+      queryClient.invalidateQueries({ queryKey: ['tenant', note.tenantId, 'notes'] });
+      queryClient.invalidateQueries({ queryKey: ['tenant', note.tenantId, 'timeline'] });
+    },
+  });
+}
+
+export function useDeleteNote() {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, { id: string; tenantId: string }, { previous?: Note[] }>({
+    mutationFn: ({ id }: { id: string; tenantId: string }) => deleteNote(id),
+    onMutate: async ({ id, tenantId }: { id: string; tenantId: string }) => {
+      const key: QueryKey = ['tenant', tenantId, 'notes'];
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<Note[]>(key);
+      queryClient.setQueryData<Note[]>(key, (old = []) => old.filter((note) => note.id !== id));
+      return { previous };
+    },
+    onError: (_err: unknown, vars: { id: string; tenantId: string }, context?: { previous?: Note[] }) => {
+      const key: QueryKey = ['tenant', vars.tenantId, 'notes'];
+      if (context?.previous) {
+        queryClient.setQueryData(key, context.previous);
+      }
+    },
+    onSuccess: (_result: void, vars: { id: string; tenantId: string }) => {
+      queryClient.invalidateQueries({ queryKey: ['tenant', vars.tenantId, 'notes'] });
+      queryClient.invalidateQueries({ queryKey: ['tenant', vars.tenantId, 'timeline'] });
+    },
+  });
+}
+
+export function useTimeline(tenantId?: string) {
+  return useInfiniteQuery<{ items: TimelineEvent[]; nextCursor?: string }>({
+    queryKey: ['tenant', tenantId, 'timeline'],
+    enabled: Boolean(tenantId),
+    queryFn: ({ pageParam }: { pageParam?: string }) =>
+      tenantId ? requestTimeline(tenantId, pageParam) : { items: [] },
+    getNextPageParam: (lastPage: { nextCursor?: string }) => lastPage?.nextCursor,
+  });
+}
+
+export function usePreferences(tenantId?: string) {
+  const query = useQuery({
+    queryKey: ['tenant', tenantId, 'preferences'],
+    enabled: Boolean(tenantId),
+    queryFn: () => (tenantId ? requestPreferences(tenantId) : undefined),
+  });
+
+  return query;
+}
+
+export function useSavePreferences() {
+  const queryClient = useQueryClient();
+  return useMutation<
+    TenantPreferences,
+    Error,
+    { tenantId: string; data: TenantPreferences },
+    unknown
+  >({
+    mutationFn: ({ tenantId, data }) => savePreferences(tenantId, data),
+    onSuccess: (_result: TenantPreferences, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['tenant', variables.tenantId, 'preferences'] });
+    },
+  });
+}
+
+export function useFiles(tenantId?: string) {
+  return useQuery({
+    queryKey: ['tenant', tenantId, 'files'],
+    enabled: Boolean(tenantId),
+    queryFn: () => (tenantId ? requestFiles(tenantId) : []),
+  });
+}
+
+export function useUploadFile() {
+  const queryClient = useQueryClient();
+  return useMutation<
+    TenantFile,
+    Error,
+    { tenantId: string; file: File; type: string },
+    unknown
+  >({
+    mutationFn: ({ tenantId, file, type }) => uploadFile(tenantId, file, type),
+    onSuccess: (_data: TenantFile, vars) => {
+      queryClient.invalidateQueries({ queryKey: ['tenant', vars.tenantId, 'files'] });
+    },
+  });
+}
+


### PR DESCRIPTION
## Summary
- add a tenant CRM page with a resizable layout, keyboard shortcuts, and contextual help
- implement virtualized tenant list, timeline, notes, preferences, and files tabs with optimistic UX
- introduce tenant API hooks backed by mock data and query caching

## Testing
- npm run lint *(fails: ESLint configuration missing in repository)*
- npx tsc --noEmit *(fails: dependencies cannot be installed in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68dc7afca2ec832c85f7eb3af9341f80