### PR TITLE
Ensure property creation can register new tenant in CRM

### DIFF
--- a/app/api/properties/route.ts
+++ b/app/api/properties/route.ts
@@ -1,5 +1,81 @@
 import { randomUUID } from 'crypto';
-import { properties, reminders, isActiveProperty } from '../store';
+import { properties, reminders, isActiveProperty, tenants } from '../store';
+import { tenantDirectory, nextId } from '../tenant-crm/store';
+import {
+  zTenant,
+  zTenantCreate,
+  type Tenant as TenantCrm,
+} from '../../../lib/tenant-crm/schemas';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const maybeCreateTenantCrmRecord = (
+  propertyId: string,
+  payload: unknown,
+  tenantName: string
+): TenantCrm | undefined => {
+  if (!payload || typeof payload !== 'object') return undefined;
+
+  const body = payload as Record<string, unknown>;
+
+  if (typeof body.tenantCrmId === 'string' || typeof body.tenantId === 'string') {
+    return undefined;
+  }
+
+  const rawDetails =
+    (isRecord(body.tenantDetails) && body.tenantDetails) ||
+    (isRecord(body.tenantCrm) && body.tenantCrm) ||
+    (isRecord(body.newTenant) && body.newTenant) ||
+    undefined;
+
+  const fallbackName = typeof tenantName === 'string' ? tenantName.trim() : '';
+  const rawFullName =
+    rawDetails && typeof rawDetails['fullName'] === 'string'
+      ? (rawDetails['fullName'] as string).trim()
+      : undefined;
+  const fullName = rawFullName || fallbackName;
+
+  if (!fullName) return undefined;
+
+  if (tenantDirectory.some((tenant) => tenant.currentPropertyId === propertyId)) {
+    return undefined;
+  }
+
+  const parsed = zTenantCreate.safeParse({
+    ...(rawDetails ?? {}),
+    fullName,
+    currentPropertyId:
+      rawDetails && typeof rawDetails['currentPropertyId'] === 'string'
+        ? (rawDetails['currentPropertyId'] as string)
+        : propertyId,
+  });
+
+  if (!parsed.success) {
+    return undefined;
+  }
+
+  if (
+    tenantDirectory.some(
+      (tenant) =>
+        tenant.fullName.toLowerCase() === parsed.data.fullName.toLowerCase() &&
+        tenant.currentPropertyId === parsed.data.currentPropertyId
+    )
+  ) {
+    return undefined;
+  }
+
+  const timestamp = new Date().toISOString();
+  const tenant = zTenant.parse({
+    id: nextId('tenant'),
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    ...parsed.data,
+  });
+
+  tenantDirectory.push(tenant);
+  return tenant;
+};
 
 export async function GET(req: Request) {
   const url = new URL(req.url);
@@ -36,6 +112,10 @@ export async function POST(req: Request) {
     archived: body.archived ?? false,
   };
   properties.push(property);
+  const tenantRecord = maybeCreateTenantCrmRecord(id, body, property.tenant);
+  if (tenantRecord) {
+    tenants.push({ id: tenantRecord.id, name: tenantRecord.fullName, propertyId: id });
+  }
   const events = reminders
     .filter((r) => r.propertyId === id)
     .map((r) => ({ date: r.dueDate, title: r.title, severity: r.severity }));

--- a/app/api/tenant-crm/store.ts
+++ b/app/api/tenant-crm/store.ts
@@ -10,46 +10,45 @@ import type {
 
 const now = () => new Date().toISOString();
 
-const tNow = now();
+const createInitialTenantDirectory = (): Tenant[] => {
+  const timestamp = now();
+  return [
+    {
+      id: 'tenant1',
+      fullName: 'Alice Tenant',
+      email: 'alice@example.com',
+      phone: '+61 400 111 222',
+      altContacts: [{ name: 'Bob Support', phone: '+61 400 333 444' }],
+      tags: ['A-grade'],
+      currentPropertyId: '1',
+      currentTenancyId: 'tenancy1',
+      riskFlags: [],
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    },
+    {
+      id: 'tenant2',
+      fullName: 'Bob Renter',
+      email: 'bob@example.com',
+      phone: '+61 400 555 666',
+      tags: ['watchlist'],
+      currentPropertyId: '2',
+      currentTenancyId: 'tenancy2',
+      riskFlags: ['arrears'],
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    },
+    {
+      id: 'tenant3',
+      fullName: 'Charlie Prospect',
+      tags: ['prospect'],
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    },
+  ];
+};
 
-export const tenantDirectory: Tenant[] = [
-  {
-    id: 'tenant1',
-    fullName: 'Alice Tenant',
-    email: 'alice@example.com',
-    phone: '+61 400 111 222',
-    altContacts: [
-      { name: 'Bob Support', phone: '+61 400 333 444' },
-    ],
-    tags: ['A-grade'],
-    currentPropertyId: '1',
-    currentTenancyId: 'tenancy1',
-    riskFlags: [],
-    createdAt: tNow,
-    updatedAt: tNow,
-  },
-  {
-    id: 'tenant2',
-    fullName: 'Bob Renter',
-    email: 'bob@example.com',
-    phone: '+61 400 555 666',
-    tags: ['watchlist'],
-    currentPropertyId: '2',
-    currentTenancyId: 'tenancy2',
-    riskFlags: ['arrears'],
-    createdAt: tNow,
-    updatedAt: tNow,
-  },
-  {
-    id: 'tenant3',
-    fullName: 'Charlie Prospect',
-    tags: ['prospect'],
-    createdAt: tNow,
-    updatedAt: tNow,
-  },
-];
-
-export const tenancySummaries: Tenancy[] = [
+const createInitialTenancySummaries = (): Tenancy[] => [
   {
     id: 'tenancy1',
     tenantId: 'tenant1',
@@ -73,7 +72,7 @@ export const tenancySummaries: Tenancy[] = [
   },
 ];
 
-export const tenantNotesStore: TenantNote[] = [
+const createInitialTenantNotes = (): TenantNote[] => [
   {
     id: 'note1',
     tenantId: 'tenant1',
@@ -86,7 +85,7 @@ export const tenantNotesStore: TenantNote[] = [
   },
 ];
 
-export const commLogStore: CommLogEntry[] = [
+const createInitialCommLogStore = (): CommLogEntry[] => [
   {
     id: 'comm1',
     tenantId: 'tenant2',
@@ -99,13 +98,32 @@ export const commLogStore: CommLogEntry[] = [
   },
 ];
 
-export const notificationPreferenceStore: NotificationPreference[] = [
+const createInitialNotificationPreferences = (): NotificationPreference[] => [
   {
     id: 'pref1',
     tenantId: 'tenant1',
     channels: { email: true, sms: true, push: false },
   },
 ];
+
+export const tenantDirectory: Tenant[] = createInitialTenantDirectory();
+export const tenancySummaries: Tenancy[] = createInitialTenancySummaries();
+export const tenantNotesStore: TenantNote[] = createInitialTenantNotes();
+export const commLogStore: CommLogEntry[] = createInitialCommLogStore();
+export const notificationPreferenceStore: NotificationPreference[] =
+  createInitialNotificationPreferences();
+
+export const resetTenantCrmStore = () => {
+  tenantDirectory.splice(0, tenantDirectory.length, ...createInitialTenantDirectory());
+  tenancySummaries.splice(0, tenancySummaries.length, ...createInitialTenancySummaries());
+  tenantNotesStore.splice(0, tenantNotesStore.length, ...createInitialTenantNotes());
+  commLogStore.splice(0, commLogStore.length, ...createInitialCommLogStore());
+  notificationPreferenceStore.splice(
+    0,
+    notificationPreferenceStore.length,
+    ...createInitialNotificationPreferences()
+  );
+};
 
 export function nextId(prefix: string) {
   return `${prefix}_${randomUUID()}`;

--- a/tests/property-crud.spec.ts
+++ b/tests/property-crud.spec.ts
@@ -1,11 +1,16 @@
 import { test, expect } from '@playwright/test';
 import { resetStore } from '../app/api/store';
+import { resetTenantCrmStore } from '../app/api/tenant-crm/store';
 
 test.beforeEach(() => {
   resetStore();
+  resetTenantCrmStore();
 });
 
 test('property can be created, updated and deleted', async ({ request }) => {
+  const initialTenantsRes = await request.get('/api/tenants');
+  const initialTenants: any = await initialTenantsRes.json();
+
   const createRes = await request.post('/api/properties', {
     data: {
       address: '789 Pine Rd',
@@ -19,6 +24,15 @@ test('property can be created, updated and deleted', async ({ request }) => {
   expect(createRes.ok()).toBeTruthy();
   const created: any = await createRes.json();
   expect(created.address).toBe('789 Pine Rd');
+
+  const tenantsAfterCreateRes = await request.get('/api/tenants');
+  const tenantsAfterCreate: any = await tenantsAfterCreateRes.json();
+  expect(tenantsAfterCreate.pageInfo.total).toBe(initialTenants.pageInfo.total + 1);
+  expect(
+    tenantsAfterCreate.items.some(
+      (tenant: any) => tenant.fullName === 'New Tenant' && tenant.currentPropertyId === created.id
+    )
+  ).toBeTruthy();
 
   const updateRes = await request.patch(`/api/properties/${created.id}`, {
     data: { address: '789 Updated Rd', rent: 1100 },
@@ -34,5 +48,27 @@ test('property can be created, updated and deleted', async ({ request }) => {
   const listRes = await request.get('/api/properties');
   const list: any[] = await listRes.json();
   expect(list.find((p) => p.id === created.id)).toBeUndefined();
+});
+
+test('creating a property without tenant details does not create a CRM tenant', async ({ request }) => {
+  const beforeRes = await request.get('/api/tenants');
+  const before: any = await beforeRes.json();
+
+  const createRes = await request.post('/api/properties', {
+    data: {
+      address: '100 Empty Tenant Way',
+      tenant: '',
+      leaseStart: '',
+      leaseEnd: '',
+      rent: 0,
+    },
+  });
+
+  expect(createRes.ok()).toBeTruthy();
+
+  const afterRes = await request.get('/api/tenants');
+  const after: any = await afterRes.json();
+
+  expect(after.pageInfo.total).toBe(before.pageInfo.total);
 });
 


### PR DESCRIPTION
## Summary
- create tenant CRM records when a property is created with tenant details and sync the lightweight tenant list
- add reset helpers for the tenant CRM mock store and extend CRUD tests to cover CRM tenant creation behaviour

## Testing
- npx playwright test tests/property-crud.spec.ts *(fails: npm 403 forbidden when downloading playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68dc9205239c832c80c8394a380358e5