### PR TITLE
Clamp dashboard date range to available data

### DIFF
--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -64,9 +64,7 @@ export async function GET(req: Request) {
   seedIfEmpty();
 
   const url = new URL(req.url);
-  const to = url.searchParams.get('to') ?? formatToday();
-  const defaultFrom = `${to.slice(0, 7)}-01`;
-  const from = url.searchParams.get('from') ?? defaultFrom;
+  let to = url.searchParams.get('to') ?? formatToday();
 
   const activeProperties = properties.filter(isActiveProperty);
   const activePropertyIds = new Set(activeProperties.map((property) => property.id));
@@ -100,6 +98,20 @@ export async function GET(req: Request) {
       category: expense.category,
       amount: expense.amount,
     }));
+
+  const latestActivityDate = [...incomeEntries, ...expenseEntries]
+    .map((entry) => entry.date)
+    .reduce((latest, current) => (current > latest ? current : latest), '');
+
+  if (latestActivityDate && to > latestActivityDate) {
+    to = latestActivityDate;
+  }
+
+  const defaultFrom = `${to.slice(0, 7)}-01`;
+  let from = url.searchParams.get('from') ?? defaultFrom;
+  if (from > to) {
+    from = defaultFrom;
+  }
 
   const yearStart = to.slice(0, 4) + '-01-01';
   const monthStart = defaultFrom;


### PR DESCRIPTION
## Summary
- clamp the dashboard API's effective date range to the latest available transaction when a future date is requested
- reset the requested start date to the current month when clamping occurs so month-to-date metrics still have data

## Testing
- npm run test:unit *(fails: vitest: not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc95251058832c82e5a0ad06cf9dce