### PR TITLE
Update dashboard date display

### DIFF
--- a/components/dashboard/DashboardPage.tsx
+++ b/components/dashboard/DashboardPage.tsx
@@ -147,7 +147,7 @@ function DashboardContent({
   return (
     <div className="space-y-6">
       <div>
-        <Header from={from} to={to} />
+        <Header date={to} />
       </div>
       <div className="grid gap-6 lg:grid-cols-12 lg:items-start">
         <div className="space-y-6 lg:col-span-8 lg:sticky lg:top-6 lg:self-start">

--- a/components/dashboard/Header.tsx
+++ b/components/dashboard/Header.tsx
@@ -1,16 +1,15 @@
 import { formatDate } from '../../lib/format';
 
 interface Props {
-  from: Date;
-  to: Date;
+  date: Date;
 }
 
-export default function Header({ from, to }: Props) {
+export default function Header({ date }: Props) {
   return (
     <div className="flex flex-col md:flex-row md:items-center md:justify-between p-4">
       <h1 className="text-2xl font-bold">Dashboard</h1>
       <div className="text-2xl font-bold mt-2 md:mt-0">
-        {formatDate(from)} – {formatDate(to)}
+        {formatDate(date)}
       </div>
     </div>
   );

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1,15 +1,34 @@
 export const formatCurrency = (n: number) =>
   new Intl.NumberFormat('en-AU', { style: 'currency', currency: 'AUD' }).format(n);
 
+const getOrdinalDay = (day: number) => {
+  if (day >= 11 && day <= 13) {
+    return `${day}th`;
+  }
+
+  switch (day % 10) {
+    case 1:
+      return `${day}st`;
+    case 2:
+      return `${day}nd`;
+    case 3:
+      return `${day}rd`;
+    default:
+      return `${day}th`;
+  }
+};
+
 export const formatDate = (d?: string | Date) => {
   if (!d) return '';
   const date = new Date(d);
   if (isNaN(date.getTime())) return '';
-  return new Intl.DateTimeFormat('en-AU', {
-    day: '2-digit',
-    month: 'short',
-    year: 'numeric',
-  }).format(date);
+
+  const weekday = new Intl.DateTimeFormat('en-AU', { weekday: 'long' }).format(date);
+  const month = new Intl.DateTimeFormat('en-AU', { month: 'long' }).format(date);
+  const year = date.getFullYear();
+  const day = getOrdinalDay(date.getDate());
+
+  return `${weekday} | ${day} ${month} ${year}`;
 };
 
 export const formatChartDate = (d?: string | Date) => {


### PR DESCRIPTION
## Summary
- show the dashboard header using the current date instead of a range
- update shared date formatting to include the weekday and ordinal day for clarity

## Testing
- npm run test:unit *(fails: vitest not found because dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddd5257cf0832cb3da7c2134988874