### PR TITLE
Format property tables dates as DD/MM/YY

### DIFF
--- a/components/ExpensesTable.tsx
+++ b/components/ExpensesTable.tsx
@@ -3,6 +3,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import { listExpenses, deleteExpense, listProperties } from "../lib/api";
+import { formatShortDate } from "../lib/format";
 import type { ExpenseRow } from "../types/expense";
 import type { PropertySummary } from "../types/property";
 import EmptyState from "./EmptyState";
@@ -219,7 +220,7 @@ export default function ExpensesTable({
                   {!propertyId && (
                     <td className="p-2">{propertyMap[r.propertyId] || r.propertyId}</td>
                   )}
-                  <td className="p-2">{r.date}</td>
+                  <td className="p-2">{formatShortDate(r.date)}</td>
                   <td className="p-2">{r.category}</td>
                   <td className="p-2">{r.vendor}</td>
                   <td className="p-2">{r.amount}</td>

--- a/components/IncomesTable.tsx
+++ b/components/IncomesTable.tsx
@@ -3,6 +3,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import { listIncome, deleteIncome } from "../lib/api";
+import { formatShortDate } from "../lib/format";
 import type { IncomeRow } from "../types/income";
 import EmptyState from "./EmptyState";
 import EvidenceLink from "./EvidenceLink";
@@ -124,7 +125,7 @@ export default function IncomesTable({
           <tbody>
             {rows.map((r) => (
               <tr key={r.id} className="border-t dark:border-gray-700">
-                <td className="p-2">{r.date}</td>
+                <td className="p-2">{formatShortDate(r.date)}</td>
                 <td className="p-2">{r.category || r.label || "—"}</td>
                 <td className="p-2 text-center">
                   {r.evidenceUrl ? (

--- a/components/PropertyDocumentsTable.tsx
+++ b/components/PropertyDocumentsTable.tsx
@@ -3,6 +3,7 @@
 import { useParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { listPropertyDocuments } from "../lib/api";
+import { formatShortDate } from "../lib/format";
 import type { PropertyDocument } from "../types/property";
 
 export default function PropertyDocumentsTable({
@@ -31,7 +32,7 @@ export default function PropertyDocumentsTable({
           {data.map((d) => (
             <tr key={d.id} className="border-t border-[var(--border)]">
               <td className="p-2">{d.name}</td>
-              <td className="p-2">{d.uploaded}</td>
+              <td className="p-2">{formatShortDate(d.uploaded)}</td>
               <td className="p-2">
                 <a
                   href={d.url}

--- a/components/RentLedgerTable.tsx
+++ b/components/RentLedgerTable.tsx
@@ -4,6 +4,7 @@ import { useParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { listLedger, updateLedgerEntry } from "../lib/api";
+import { formatShortDate } from "../lib/format";
 import type { LedgerEntry, LedgerStatus } from "../types/property";
 import EditLedgerEntryModal from "./EditLedgerEntryModal";
 import EvidenceLink from "./EvidenceLink";
@@ -71,7 +72,7 @@ export default function RentLedgerTable({
                 className="cursor-pointer border-t border-[var(--border)] hover:bg-[var(--hover)]"
                 onClick={() => setSelected(e)}
               >
-                <td className="p-2">{e.date}</td>
+                <td className="p-2">{formatShortDate(e.date)}</td>
                 <td className="p-2">
                   <StatusDot status={e.status} />
                 </td>

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -45,6 +45,18 @@ export const formatChartDate = (d?: string | Date) => {
 
 export const formatMoney = (cents: number) => formatCurrency(cents / 100);
 
+export const formatShortDate = (d?: string | Date) => {
+  if (!d) return '—';
+  const date = new Date(d);
+  if (Number.isNaN(date.getTime())) return '—';
+
+  return new Intl.DateTimeFormat('en-GB', {
+    day: '2-digit',
+    month: '2-digit',
+    year: '2-digit',
+  }).format(date);
+};
+
 export const statusToBadgeColor = (status: string) => {
   switch (status) {
     case 'Overdue':


### PR DESCRIPTION
## Summary
- add a shared short date formatter that outputs DD/MM/YY
- update income, expense, rent ledger, and property document tables to use the new format

## Testing
- npm run lint *(fails: ESLint configuration missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68dddd737ea8832c9f939c24e2a60552