### PR TITLE
Align finance table filter controls

### DIFF
--- a/components/ExpensesTable.tsx
+++ b/components/ExpensesTable.tsx
@@ -136,12 +136,15 @@ export default function ExpensesTable({
     });
   }, [data, propertyId, propertyMap, search]);
 
+  const filterControlClass =
+    "h-10 rounded-lg border border-gray-300 bg-white px-3 text-sm text-gray-900 shadow-sm focus:border-gray-400 focus:outline-none focus:ring-1 focus:ring-gray-400 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100";
+
   return (
     <div className="space-y-2">
-      <div className="flex flex-wrap gap-2">
+      <div className="mx-4 flex flex-wrap items-center gap-2">
         {!propertyId && (
           <select
-            className="border p-1 bg-white dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+            className={`${filterControlClass} pr-10`}
             value={property}
             onChange={(e) => setProperty(e.target.value)}
           >
@@ -155,20 +158,20 @@ export default function ExpensesTable({
         )}
         <input
           type="date"
-          className="border p-1 bg-white dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+          className={filterControlClass}
           value={from}
           onChange={(e) => setFrom(e.target.value)}
           placeholder="From"
         />
         <input
           type="date"
-          className="border p-1 bg-white dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+          className={filterControlClass}
           value={to}
           onChange={(e) => setTo(e.target.value)}
           placeholder="To"
         />
         <div className="relative">
-          <span className="pointer-events-none absolute inset-y-0 left-2 flex items-center text-gray-400">
+          <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-gray-400">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 20 20"
@@ -185,7 +188,7 @@ export default function ExpensesTable({
           </span>
           <input
             type="search"
-            className="w-full min-w-[18rem] rounded border border-gray-300 bg-white py-1 pl-8 pr-3 text-sm text-gray-900 shadow-sm focus:border-gray-400 focus:outline-none focus:ring-1 focus:ring-gray-400 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+            className={`${filterControlClass} w-full min-w-[18rem] pl-10`}
             placeholder="Search for an expense"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
@@ -198,79 +201,81 @@ export default function ExpensesTable({
       ) : filteredData.length === 0 ? (
         <EmptyState message="No expenses match your search." />
       ) : (
-        <table className="min-w-full border bg-white dark:bg-gray-800 dark:border-gray-700">
-          <thead>
-            <tr className="bg-gray-100 dark:bg-gray-700">
-              {!propertyId && <th className="p-2 text-left">Property</th>}
-              <th className="p-2 text-left">Date</th>
-              <th className="p-2 text-left">Category</th>
-              <th className="p-2 text-left">Vendor</th>
-              <th className="p-2 text-left">Amount</th>
-              <th className="p-2 text-left">GST</th>
-              <th className="p-2 text-left">Notes</th>
-              <th className="p-2 text-left">Receipt</th>
-              <th className="p-2 text-left">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {filteredData.map((r) => (
-              <tr key={r.id} className="border-t dark:border-gray-700">
-                {!propertyId && (
-                  <td className="p-2">{propertyMap[r.propertyId] || r.propertyId}</td>
-                )}
-                <td className="p-2">{r.date}</td>
-                <td className="p-2">{r.category}</td>
-                <td className="p-2">{r.vendor}</td>
-                <td className="p-2">{r.amount}</td>
-                <td className="p-2">{r.gst}</td>
-                <td className="p-2">{r.notes}</td>
-                <td className="p-2">
-                  <ReceiptLink url={r.receiptUrl} />
-                </td>
-                <td className="p-2">
-                  <div className="flex items-center gap-2">
-                    <button
-                      type="button"
-                      className={iconButtonClass}
-                      onClick={() => handleEdit(r)}
-                      aria-label="Edit expense"
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                        className="h-5 w-5"
-                      >
-                        <path d="M17.414 2.586a2 2 0 0 0-2.828 0l-1.086 1.086 2.828 2.828 1.086-1.086a2 2 0 0 0 0-2.828ZM14.57 7.5 11.672 4.672 4 12.343V15.5h3.157L14.5 7.5Z" />
-                        <path d="M2 6a2 2 0 0 1 2-2h4a1 1 0 1 1 0 2H4v10h10v-4a1 1 0 1 1 2 0v4a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6Z" />
-                      </svg>
-                    </button>
-                    <button
-                      type="button"
-                      className={`${iconButtonClass} text-red-600 hover:text-red-500 dark:text-red-400 dark:hover:text-red-300`}
-                      onClick={() => setDeleteTarget(r)}
-                      aria-label="Delete expense"
-                      disabled={deleteMutation.isPending}
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                        className="h-5 w-5"
-                      >
-                        <path
-                          fillRule="evenodd"
-                          d="M8.75 3a1.75 1.75 0 0 0-1.744 1.602l-.035.348H4a.75.75 0 0 0 0 1.5h.532l.634 9.182A2.25 2.25 0 0 0 7.41 17.75h5.18a2.25 2.25 0 0 0 2.244-2.118L15.468 6.45H16a.75.75 0 0 0 0-1.5h-2.97l-.035-.348A1.75 1.75 0 0 0 11.25 3h-2.5ZM9.75 7a.75.75 0 0 0-1.5 0v6a.75.75 0 0 0 1.5 0V7Zm2.75-.75a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0V7a.75.75 0 0 1 .75-.75Z"
-                          clipRule="evenodd"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </td>
+        <div className="mx-4 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <table className="min-w-full">
+            <thead>
+              <tr className="bg-gray-100 dark:bg-gray-700">
+                {!propertyId && <th className="p-2 text-left">Property</th>}
+                <th className="p-2 text-left">Date</th>
+                <th className="p-2 text-left">Category</th>
+                <th className="p-2 text-left">Vendor</th>
+                <th className="p-2 text-left">Amount</th>
+                <th className="p-2 text-left">GST</th>
+                <th className="p-2 text-left">Notes</th>
+                <th className="p-2 text-left">Receipt</th>
+                <th className="p-2 text-left">Actions</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {filteredData.map((r) => (
+                <tr key={r.id} className="border-t dark:border-gray-700">
+                  {!propertyId && (
+                    <td className="p-2">{propertyMap[r.propertyId] || r.propertyId}</td>
+                  )}
+                  <td className="p-2">{r.date}</td>
+                  <td className="p-2">{r.category}</td>
+                  <td className="p-2">{r.vendor}</td>
+                  <td className="p-2">{r.amount}</td>
+                  <td className="p-2">{r.gst}</td>
+                  <td className="p-2">{r.notes}</td>
+                  <td className="p-2">
+                    <ReceiptLink url={r.receiptUrl} />
+                  </td>
+                  <td className="p-2">
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        className={iconButtonClass}
+                        onClick={() => handleEdit(r)}
+                        aria-label="Edit expense"
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox="0 0 20 20"
+                          fill="currentColor"
+                          className="h-5 w-5"
+                        >
+                          <path d="M17.414 2.586a2 2 0 0 0-2.828 0l-1.086 1.086 2.828 2.828 1.086-1.086a2 2 0 0 0 0-2.828ZM14.57 7.5 11.672 4.672 4 12.343V15.5h3.157L14.5 7.5Z" />
+                          <path d="M2 6a2 2 0 0 1 2-2h4a1 1 0 1 1 0 2H4v10h10v-4a1 1 0 1 1 2 0v4a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6Z" />
+                        </svg>
+                      </button>
+                      <button
+                        type="button"
+                        className={`${iconButtonClass} text-red-600 hover:text-red-500 dark:text-red-400 dark:hover:text-red-300`}
+                        onClick={() => setDeleteTarget(r)}
+                        aria-label="Delete expense"
+                        disabled={deleteMutation.isPending}
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox="0 0 20 20"
+                          fill="currentColor"
+                          className="h-5 w-5"
+                        >
+                          <path
+                            fillRule="evenodd"
+                            d="M8.75 3a1.75 1.75 0 0 0-1.744 1.602l-.035.348H4a.75.75 0 0 0 0 1.5h.532l.634 9.182A2.25 2.25 0 0 0 7.41 17.75h5.18a2.25 2.25 0 0 0 2.244-2.118L15.468 6.45H16a.75.75 0 0 0 0-1.5h-2.97l-.035-.348A1.75 1.75 0 0 0 11.25 3h-2.5ZM9.75 7a.75.75 0 0 0-1.5 0v6a.75.75 0 0 0 1.5 0V7Zm2.75-.75a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0V7a.75.75 0 0 1 .75-.75Z"
+                            clipRule="evenodd"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
       <ExpenseForm
         propertyId={propertyId}

--- a/components/IncomesTable.tsx
+++ b/components/IncomesTable.tsx
@@ -109,103 +109,108 @@ export default function IncomesTable({
     content = <EmptyState message="No income records found." />;
   } else if (hasMatches) {
     content = (
-      <table className="min-w-full border bg-white dark:bg-gray-800 dark:border-gray-700">
-        <thead>
-          <tr className="bg-gray-100 dark:bg-gray-700">
-            <th className="p-2 text-left">Date</th>
-            <th className="p-2 text-left">Category</th>
-            <th className="p-2 text-center">Evidence</th>
-            <th className="p-2 text-left">Amount</th>
-            <th className="p-2 text-left">Notes</th>
-            <th className="p-2 text-left">Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((r) => (
-            <tr key={r.id} className="border-t dark:border-gray-700">
-              <td className="p-2">{r.date}</td>
-              <td className="p-2">{r.category || r.label || "—"}</td>
-              <td className="p-2 text-center">
-                {r.evidenceUrl ? (
-                  <EvidenceLink
-                    href={r.evidenceUrl}
-                    fileName={r.evidenceName}
-                    className="mx-auto"
-                  />
-                ) : (
-                  <span className="text-gray-500 dark:text-gray-400">&mdash;</span>
-                )}
-              </td>
-              <td className="p-2">{r.amount}</td>
-              <td className="p-2">{r.notes}</td>
-              <td className="p-2">
-                <div className="flex items-center gap-2">
-                  <button
-                    type="button"
-                    className="text-gray-600 hover:text-blue-600 dark:text-gray-300 dark:hover:text-blue-400"
-                    onClick={() => setEditingIncome(r)}
-                    aria-label="Edit income"
-                  >
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      viewBox="0 0 20 20"
-                      fill="currentColor"
-                      className="h-4 w-4"
-                      aria-hidden="true"
-                    >
-                      <path d="M13.586 2.586a2 2 0 0 1 2.828 2.828l-.793.793-2.828-2.828.793-.793zM12.379 4.207 3 13.586V17h3.414l9.379-9.379-3.414-3.414z" />
-                    </svg>
-                    <span className="sr-only">Edit income</span>
-                  </button>
-                  <button
-                    type="button"
-                    className="text-gray-600 hover:text-red-600 dark:text-gray-300 dark:hover:text-red-400"
-                    onClick={() => {
-                      if (confirm("are you sure?")) {
-                        deleteMutation.mutate(r.id);
-                      }
-                    }}
-                    aria-label="Delete income"
-                  >
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      viewBox="0 0 20 20"
-                      fill="currentColor"
-                      className="h-4 w-4"
-                      aria-hidden="true"
-                    >
-                      <path d="M8.5 3a1.5 1.5 0 0 1 3 0H15a1 1 0 1 1 0 2h-1v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V5H5a1 1 0 1 1 0-2h3.5zM8 5v10h4V5H8z" />
-                    </svg>
-                    <span className="sr-only">Delete income</span>
-                  </button>
-                </div>
-              </td>
+      <div className="mx-4 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <table className="min-w-full">
+          <thead>
+            <tr className="bg-gray-100 dark:bg-gray-700">
+              <th className="p-2 text-left">Date</th>
+              <th className="p-2 text-left">Category</th>
+              <th className="p-2 text-center">Evidence</th>
+              <th className="p-2 text-left">Amount</th>
+              <th className="p-2 text-left">Notes</th>
+              <th className="p-2 text-left">Actions</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.id} className="border-t dark:border-gray-700">
+                <td className="p-2">{r.date}</td>
+                <td className="p-2">{r.category || r.label || "—"}</td>
+                <td className="p-2 text-center">
+                  {r.evidenceUrl ? (
+                    <EvidenceLink
+                      href={r.evidenceUrl}
+                      fileName={r.evidenceName}
+                      className="mx-auto"
+                    />
+                  ) : (
+                    <span className="text-gray-500 dark:text-gray-400">&mdash;</span>
+                  )}
+                </td>
+                <td className="p-2">{r.amount}</td>
+                <td className="p-2">{r.notes}</td>
+                <td className="p-2">
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      className="text-gray-600 hover:text-blue-600 dark:text-gray-300 dark:hover:text-blue-400"
+                      onClick={() => setEditingIncome(r)}
+                      aria-label="Edit income"
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 20 20"
+                        fill="currentColor"
+                        className="h-4 w-4"
+                        aria-hidden="true"
+                      >
+                        <path d="M13.586 2.586a2 2 0 0 1 2.828 2.828l-.793.793-2.828-2.828.793-.793zM12.379 4.207 3 13.586V17h3.414l9.379-9.379-3.414-3.414z" />
+                      </svg>
+                      <span className="sr-only">Edit income</span>
+                    </button>
+                    <button
+                      type="button"
+                      className="text-gray-600 hover:text-red-600 dark:text-gray-300 dark:hover:text-red-400"
+                      onClick={() => {
+                        if (confirm("are you sure?")) {
+                          deleteMutation.mutate(r.id);
+                        }
+                      }}
+                      aria-label="Delete income"
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 20 20"
+                        fill="currentColor"
+                        className="h-4 w-4"
+                        aria-hidden="true"
+                      >
+                        <path d="M8.5 3a1.5 1.5 0 0 1 3 0H15a1 1 0 1 1 0 2h-1v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V5H5a1 1 0 1 1 0-2h3.5zM8 5v10h4V5H8z" />
+                      </svg>
+                      <span className="sr-only">Delete income</span>
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     );
   }
 
+  const filterControlClass =
+    "h-10 rounded-lg border border-gray-300 bg-white px-3 text-sm text-gray-900 shadow-sm focus:border-gray-400 focus:outline-none focus:ring-1 focus:ring-gray-400 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100";
+
   return (
     <div className="space-y-2">
-      <div className="flex flex-wrap gap-2">
+      <div className="mx-4 flex flex-wrap items-center gap-2">
         <input
           type="date"
-          className="border p-1 bg-white dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+          className={filterControlClass}
           value={from}
           onChange={(e) => setFrom(e.target.value)}
           placeholder="From"
         />
         <input
           type="date"
-          className="border p-1 bg-white dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+          className={filterControlClass}
           value={to}
           onChange={(e) => setTo(e.target.value)}
           placeholder="To"
         />
         <div className="relative">
-          <span className="pointer-events-none absolute inset-y-0 left-2 flex items-center text-gray-400">
+          <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-gray-400">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 20 20"
@@ -222,7 +227,7 @@ export default function IncomesTable({
           </span>
           <input
             type="search"
-            className="w-full min-w-[12rem] rounded border border-gray-300 bg-white py-1 pl-8 pr-2 text-sm text-gray-900 shadow-sm focus:border-gray-400 focus:outline-none focus:ring-1 focus:ring-gray-400 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+            className={`${filterControlClass} w-full min-w-[12rem] pl-10`}
             placeholder="Search income"
             value={search}
             onChange={(e) => setSearch(e.target.value)}

--- a/components/PropertyDocumentsTable.tsx
+++ b/components/PropertyDocumentsTable.tsx
@@ -18,33 +18,35 @@ export default function PropertyDocumentsTable({
   });
 
   return (
-    <table className="min-w-full border rounded card">
-      <thead>
-        <tr>
-          <th className="p-2 text-left">Name</th>
-          <th className="p-2 text-left">Uploaded</th>
-          <th className="p-2 text-left">Link</th>
-        </tr>
-      </thead>
-      <tbody>
-        {data.map((d) => (
-          <tr key={d.id} className="border-t border-[var(--border)]">
-            <td className="p-2">{d.name}</td>
-            <td className="p-2">{d.uploaded}</td>
-            <td className="p-2">
-              <a
-                href={d.url}
-                target="_blank"
-                rel="noreferrer"
-                className="text-[var(--primary)] underline"
-              >
-                View
-              </a>
-            </td>
+    <div className="card mx-4 overflow-hidden rounded-xl">
+      <table className="min-w-full">
+        <thead>
+          <tr>
+            <th className="p-2 text-left">Name</th>
+            <th className="p-2 text-left">Uploaded</th>
+            <th className="p-2 text-left">Link</th>
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {data.map((d) => (
+            <tr key={d.id} className="border-t border-[var(--border)]">
+              <td className="p-2">{d.name}</td>
+              <td className="p-2">{d.uploaded}</td>
+              <td className="p-2">
+                <a
+                  href={d.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-[var(--primary)] underline"
+                >
+                  View
+                </a>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }
 

--- a/components/RentLedgerTable.tsx
+++ b/components/RentLedgerTable.tsx
@@ -53,44 +53,46 @@ export default function RentLedgerTable({
 
   return (
     <>
-      <table className="min-w-full border rounded card">
-        <thead>
-          <tr>
-            <th className="p-2 text-left">Date</th>
-            <th className="p-2 text-left">Status</th>
-            <th className="p-2 text-left">Amount</th>
-            <th className="p-2 text-center">Evidence</th>
-            <th className="p-2 text-left">Balance</th>
-          </tr>
-        </thead>
-        <tbody>
-          {entries.map((e) => (
-            <tr
-              key={e.id}
-              className="cursor-pointer border-t border-[var(--border)] hover:bg-[var(--hover)]"
-              onClick={() => setSelected(e)}
-            >
-              <td className="p-2">{e.date}</td>
-              <td className="p-2">
-                <StatusDot status={e.status} />
-              </td>
-              <td className="p-2">{e.amount}</td>
-              <td className="p-2 text-center">
-                {e.evidenceUrl ? (
-                  <EvidenceLink
-                    href={e.evidenceUrl}
-                    fileName={e.evidenceName}
-                    className="mx-auto"
-                  />
-                ) : (
-                  <span className="text-gray-500 dark:text-gray-400">&mdash;</span>
-                )}
-              </td>
-              <td className="p-2">{e.balance}</td>
+      <div className="card mx-4 overflow-hidden rounded-xl">
+        <table className="min-w-full">
+          <thead>
+            <tr>
+              <th className="p-2 text-left">Date</th>
+              <th className="p-2 text-left">Status</th>
+              <th className="p-2 text-left">Amount</th>
+              <th className="p-2 text-center">Evidence</th>
+              <th className="p-2 text-left">Balance</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {entries.map((e) => (
+              <tr
+                key={e.id}
+                className="cursor-pointer border-t border-[var(--border)] hover:bg-[var(--hover)]"
+                onClick={() => setSelected(e)}
+              >
+                <td className="p-2">{e.date}</td>
+                <td className="p-2">
+                  <StatusDot status={e.status} />
+                </td>
+                <td className="p-2">{e.amount}</td>
+                <td className="p-2 text-center">
+                  {e.evidenceUrl ? (
+                    <EvidenceLink
+                      href={e.evidenceUrl}
+                      fileName={e.evidenceName}
+                      className="mx-auto"
+                    />
+                  ) : (
+                    <span className="text-gray-500 dark:text-gray-400">&mdash;</span>
+                  )}
+                </td>
+                <td className="p-2">{e.balance}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
       {selected && (
         <EditLedgerEntryModal
           entry={selected}


### PR DESCRIPTION
## Summary
- unify the styling of the expense and income filters with shared rounded input styles
- vertically center the filter row contents so the date pickers, property selector, and search field line up consistently
- align the filter rows with the table card margins so each control starts on the same left edge as the data table

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddd77668f4832c9cc9fe5f412bff0e