### PR TITLE
Format property tables dates as DD/MM/YY

### DIFF
--- a/components/ExpensesTable.tsx
+++ b/components/ExpensesTable.tsx
@@ -3,6 +3,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import { listExpenses, deleteExpense, listProperties } from "../lib/api";
+import { formatShortDate } from "../lib/format";
 import type { ExpenseRow } from "../types/expense";
 import type { PropertySummary } from "../types/property";
 import EmptyState from "./EmptyState";
@@ -219,7 +220,7 @@ export default function ExpensesTable({
                   {!propertyId && (
                     <td className="p-2">{propertyMap[r.propertyId] || r.propertyId}</td>
                   )}
-                  <td className="p-2">{r.date}</td>
+                  <td className="p-2">{formatShortDate(r.date)}</td>
                   <td className="p-2">{r.category}</td>
                   <td className="p-2">{r.vendor}</td>
                   <td className="p-2">{r.amount}</td>

--- a/components/IncomesTable.tsx
+++ b/components/IncomesTable.tsx
@@ -3,6 +3,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import { listIncome, deleteIncome } from "../lib/api";
+import { formatShortDate } from "../lib/format";
 import type { IncomeRow } from "../types/income";
 import EmptyState from "./EmptyState";
 import EvidenceLink from "./EvidenceLink";
@@ -124,7 +125,7 @@ export default function IncomesTable({
           <tbody>
             {rows.map((r) => (
               <tr key={r.id} className="border-t dark:border-gray-700">
-                <td className="p-2">{r.date}</td>
+                <td className="p-2">{formatShortDate(r.date)}</td>
                 <td className="p-2">{r.category || r.label || "—"}</td>
                 <td className="p-2 text-center">
                   {r.evidenceUrl ? (

--- a/components/PropertyDocumentsTable.tsx
+++ b/components/PropertyDocumentsTable.tsx
@@ -3,6 +3,7 @@
 import { useParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { listPropertyDocuments } from "../lib/api";
+import { formatShortDate } from "../lib/format";
 import type { PropertyDocument } from "../types/property";
 
 export default function PropertyDocumentsTable({
@@ -31,7 +32,7 @@ export default function PropertyDocumentsTable({
           {data.map((d) => (
             <tr key={d.id} className="border-t border-[var(--border)]">
               <td className="p-2">{d.name}</td>
-              <td className="p-2">{d.uploaded}</td>
+              <td className="p-2">{formatShortDate(d.uploaded)}</td>
               <td className="p-2">
                 <a
                   href={d.url}

--- a/components/RentLedgerTable.tsx
+++ b/components/RentLedgerTable.tsx
@@ -4,6 +4,7 @@ import { useParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { listLedger, updateLedgerEntry } from "../lib/api";
+import { formatShortDate } from "../lib/format";
 import type { LedgerEntry, LedgerStatus } from "../types/property";
 import EditLedgerEntryModal from "./EditLedgerEntryModal";
 import EvidenceLink from "./EvidenceLink";
@@ -71,7 +72,7 @@ export default function RentLedgerTable({
                 className="cursor-pointer border-t border-[var(--border)] hover:bg-[var(--hover)]"
                 onClick={() => setSelected(e)}
               >
-                <td className="p-2">{e.date}</td>
+                <td className="p-2">{formatShortDate(e.date)}</td>
                 <td className="p-2">
                   <StatusDot status={e.status} />
                 </td>

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -45,6 +45,42 @@ export const formatChartDate = (d?: string | Date) => {
 
 export const formatMoney = (cents: number) => formatCurrency(cents / 100);
 
+const shortDateFromParts = (year: number, month: number, day: number) => {
+  const pad = (value: number) => value.toString().padStart(2, '0');
+  return `${pad(day)}/${pad(month)}/${year.toString().slice(-2)}`;
+};
+
+const ISO_LIKE_DATE = /^(\d{4})[-/](\d{1,2})[-/](\d{1,2})/;
+
+export const formatShortDate = (input?: string | Date | null) => {
+  if (!input) return '—';
+
+  const formatDate = (date: Date) =>
+    shortDateFromParts(date.getFullYear(), date.getMonth() + 1, date.getDate());
+
+  if (input instanceof Date) {
+    return Number.isNaN(input.getTime()) ? '—' : formatDate(input);
+  }
+
+  const value = String(input).trim();
+  if (!value) return '—';
+
+  const isoMatch = value.match(ISO_LIKE_DATE);
+  if (isoMatch) {
+    const [, year, month, day] = isoMatch;
+    return shortDateFromParts(
+      Number.parseInt(year, 10),
+      Number.parseInt(month, 10),
+      Number.parseInt(day, 10)
+    );
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '—';
+
+  return formatDate(date);
+};
+
 export const statusToBadgeColor = (status: string) => {
   switch (status) {
     case 'Overdue':

--- a/tests/formatShortDate.test.ts
+++ b/tests/formatShortDate.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { formatShortDate } from '../lib/format';
+
+describe('formatShortDate', () => {
+  it('formats ISO dates into DD/MM/YY', () => {
+    expect(formatShortDate('2024-06-09')).toBe('09/06/24');
+  });
+
+  it('formats slash-delimited dates', () => {
+    expect(formatShortDate('2024/1/5')).toBe('05/01/24');
+  });
+
+  it('formats ISO date-times without timezone drift', () => {
+    expect(formatShortDate('2024-06-09T12:30:00Z')).toBe('09/06/24');
+  });
+
+  it('formats Date instances', () => {
+    expect(formatShortDate(new Date('2024-06-09T00:00:00Z'))).toBe('09/06/24');
+  });
+
+  it('returns an em dash for invalid input', () => {
+    expect(formatShortDate('not-a-date')).toBe('—');
+    expect(formatShortDate(undefined)).toBe('—');
+    expect(formatShortDate(null)).toBe('—');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the property management tables continue to use the shared short date formatter for DD/MM/YY display
- harden the short date formatter to avoid timezone drift and accept ISO or slash-delimited inputs
- add unit coverage for the short date formatting helper

## Testing
- npm run test:unit -- tests/formatShortDate.test.ts *(fails: `vitest` binary is unavailable because dependencies are not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dddd737ea8832c9f939c24e2a60552