### PR TITLE
Fix property modals to cover the full viewport

### DIFF
--- a/components/DocumentUploadModal.tsx
+++ b/components/DocumentUploadModal.tsx
@@ -5,6 +5,7 @@ import { AnimatePresence, motion } from "framer-motion";
 import { useQueryClient } from "@tanstack/react-query";
 import { uploadFile, createDocument } from "../lib/api";
 import { DocumentTag } from "../types/document";
+import ModalPortal from "./ModalPortal";
 
 interface Props {
   open: boolean;
@@ -36,52 +37,53 @@ export default function DocumentUploadModal({ open, onClose, propertyId }: Props
   return (
     <AnimatePresence>
       {open && (
-        <motion.div
-          key="document-modal"
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-          onClick={() => {
-            setFile(null);
-            onClose();
-          }}
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          transition={{ duration: 0.2 }}
-        >
+        <ModalPortal key="document-modal">
           <motion.div
-            className="w-full max-w-xs space-y-2 rounded-lg bg-white p-4 shadow-lg"
-            onClick={(e) => e.stopPropagation()}
-            initial={{ opacity: 0, y: 16, scale: 0.96 }}
-            animate={{ opacity: 1, y: 0, scale: 1 }}
-            exit={{ opacity: 0, y: 16, scale: 0.96 }}
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+            onClick={() => {
+              setFile(null);
+              onClose();
+            }}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
             transition={{ duration: 0.2 }}
           >
-            <h2 className="text-lg font-medium">Upload Document</h2>
-            <input
-              type="file"
-              className="w-full rounded border p-1"
-              onChange={(e) => setFile(e.target.files?.[0] || null)}
-            />
-            <div className="flex justify-end gap-2 pt-2">
-              <button
-                className="rounded bg-gray-100 px-2 py-1"
-                onClick={() => {
-                  setFile(null);
-                  onClose();
-                }}
-              >
-                Cancel
-              </button>
-              <button
-                className="rounded bg-blue-600 px-2 py-1 text-white disabled:opacity-60"
-                disabled={!file}
-                onClick={handleUpload}
-              >
-                Upload
-              </button>
-            </div>
+            <motion.div
+              className="w-full max-w-xs space-y-2 rounded-lg bg-white p-4 shadow-lg"
+              onClick={(e) => e.stopPropagation()}
+              initial={{ opacity: 0, y: 16, scale: 0.96 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: 16, scale: 0.96 }}
+              transition={{ duration: 0.2 }}
+            >
+              <h2 className="text-lg font-medium">Upload Document</h2>
+              <input
+                type="file"
+                className="w-full rounded border p-1"
+                onChange={(e) => setFile(e.target.files?.[0] || null)}
+              />
+              <div className="flex justify-end gap-2 pt-2">
+                <button
+                  className="rounded bg-gray-100 px-2 py-1"
+                  onClick={() => {
+                    setFile(null);
+                    onClose();
+                  }}
+                >
+                  Cancel
+                </button>
+                <button
+                  className="rounded bg-blue-600 px-2 py-1 text-white disabled:opacity-60"
+                  disabled={!file}
+                  onClick={handleUpload}
+                >
+                  Upload
+                </button>
+              </div>
+            </motion.div>
           </motion.div>
-        </motion.div>
+        </ModalPortal>
       )}
     </AnimatePresence>
   );

--- a/components/ExpenseForm.tsx
+++ b/components/ExpenseForm.tsx
@@ -6,6 +6,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createExpense, listProperties, uploadExpenseReceipt } from "../lib/api";
 import { logEvent } from "../lib/log";
 import { useToast } from "./ui/use-toast";
+import ModalPortal from "./ModalPortal";
 import type { PropertySummary } from "../types/property";
 import { EXPENSE_CATEGORIES } from "../lib/categories";
 
@@ -212,57 +213,57 @@ export default function ExpenseForm({
 
       <AnimatePresence>
         {open && (
-          <motion.div
-            key="expense-modal"
-            className="fixed inset-0 z-50 flex h-full w-full items-start justify-center bg-black/50 p-4 sm:p-6 md:items-center"
-            onClick={handleClose}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.2 }}
-          >
-            <motion.form
-              className="h-full w-full max-w-2xl max-h-full space-y-3 overflow-y-auto rounded-lg bg-white p-6 text-gray-900 shadow-lg dark:bg-gray-800 dark:text-gray-100"
-              onClick={(e) => e.stopPropagation()}
-              onSubmit={(e) => {
-                e.preventDefault();
-                setError(null);
-                if (
-                  !form.propertyId ||
-                  !form.date ||
-                  !form.group ||
-                  !form.vendor ||
-                  !form.amount ||
-                  (!form.category && !form.label)
-                ) {
-                  setError("Please fill in all required fields");
-                  return;
-                }
-                if (form.category && form.label) {
-                  setError("Please choose either an expense or a custom label");
-                  return;
-                }
-                if (isNaN(parseFloat(form.amount))) {
-                  setError("Amount must be a number");
-                  return;
-                }
-                mutation.mutate({
-                  expense: {
-                    propertyId: form.propertyId,
-                    date: form.date,
-                    category: form.category,
-                    vendor: form.vendor,
-                    amount: parseFloat(form.amount),
-                    gst: form.gst ? parseFloat(form.gst) : 0,
-                    notes: form.notes,
-                    label: form.label,
-                  },
-                  receipt: form.receipt,
-                });
-                if (form.group) {
-                  addRecent(form.group);
-                }
-              }}
+          <ModalPortal key="expense-modal">
+            <motion.div
+              className="fixed inset-0 z-50 flex h-full w-full items-start justify-center bg-black/50 p-4 sm:p-6 md:items-center"
+              onClick={handleClose}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.2 }}
+            >
+              <motion.form
+                className="h-full w-full max-w-2xl max-h-full space-y-3 overflow-y-auto rounded-lg bg-white p-6 text-gray-900 shadow-lg dark:bg-gray-800 dark:text-gray-100"
+                onClick={(e) => e.stopPropagation()}
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  setError(null);
+                  if (
+                    !form.propertyId ||
+                    !form.date ||
+                    !form.group ||
+                    !form.vendor ||
+                    !form.amount ||
+                    (!form.category && !form.label)
+                  ) {
+                    setError("Please fill in all required fields");
+                    return;
+                  }
+                  if (form.category && form.label) {
+                    setError("Please choose either an expense or a custom label");
+                    return;
+                  }
+                  if (isNaN(parseFloat(form.amount))) {
+                    setError("Amount must be a number");
+                    return;
+                  }
+                  mutation.mutate({
+                    expense: {
+                      propertyId: form.propertyId,
+                      date: form.date,
+                      category: form.category,
+                      vendor: form.vendor,
+                      amount: parseFloat(form.amount),
+                      gst: form.gst ? parseFloat(form.gst) : 0,
+                      notes: form.notes,
+                      label: form.label,
+                    },
+                    receipt: form.receipt,
+                  });
+                  if (form.group) {
+                    addRecent(form.group);
+                  }
+                }}
               initial={{ opacity: 0, y: 24, scale: 0.97 }}
               animate={{ opacity: 1, y: 0, scale: 1 }}
               exit={{ opacity: 0, y: 24, scale: 0.97 }}
@@ -472,7 +473,8 @@ export default function ExpenseForm({
               </div>
             </motion.form>
           </motion.div>
-        )}
+        </ModalPortal>
+      )}
       </AnimatePresence>
     </div>
   );

--- a/components/ExpensesTable.tsx
+++ b/components/ExpensesTable.tsx
@@ -8,6 +8,7 @@ import type { ExpenseRow } from "../types/expense";
 import type { PropertySummary } from "../types/property";
 import EmptyState from "./EmptyState";
 import ExpenseForm from "./ExpenseForm";
+import ModalPortal from "./ModalPortal";
 
 function ReceiptLink({ url }: { url?: string | null }) {
   if (!url) {
@@ -296,53 +297,55 @@ export default function ExpensesTable({
         }}
       />
       {deleteTarget && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-          onClick={() => {
-            if (!deleteMutation.isPending) {
-              setDeleteTarget(null);
-            }
-          }}
-        >
+        <ModalPortal key="expense-delete-modal">
           <div
-            className="w-full max-w-sm rounded-lg bg-white p-5 text-gray-900 shadow-lg dark:bg-gray-800 dark:text-gray-100"
-            onClick={(event) => event.stopPropagation()}
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+            onClick={() => {
+              if (!deleteMutation.isPending) {
+                setDeleteTarget(null);
+              }
+            }}
           >
-            <h2 className="text-lg font-semibold">Delete expense</h2>
-            <p className="mt-2 text-sm text-gray-700 dark:text-gray-300">
-              are you sure?
-            </p>
-            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-              This will permanently remove the entry for {deleteTarget.vendor || "this expense"} dated {deleteTarget.date}.
-            </p>
-            <div className="mt-4 flex justify-end gap-2">
-              <button
-                type="button"
-                className="rounded-md border border-gray-300 px-3 py-1 text-sm font-medium text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
-                onClick={() => setDeleteTarget(null)}
-                disabled={deleteMutation.isPending}
+              <div
+                className="w-full max-w-sm rounded-lg bg-white p-5 text-gray-900 shadow-lg dark:bg-gray-800 dark:text-gray-100"
+                onClick={(event) => event.stopPropagation()}
               >
-                Cancel
-              </button>
-              <button
-                type="button"
-                className="rounded-md bg-red-600 px-3 py-1 text-sm font-medium text-white hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-60"
-                onClick={() => {
-                  if (!deleteTarget) return;
-                  deleteMutation.mutate(deleteTarget.id, {
-                    onSettled: () => {
-                      setDeleteTarget(null);
-                    },
-                  });
-                }}
-                disabled={deleteMutation.isPending}
-              >
-                {deleteMutation.isPending ? "Deleting..." : "Delete"}
-              </button>
+                <h2 className="text-lg font-semibold">Delete expense</h2>
+                <p className="mt-2 text-sm text-gray-700 dark:text-gray-300">
+                  are you sure?
+                </p>
+                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  This will permanently remove the entry for {deleteTarget.vendor || "this expense"} dated {deleteTarget.date}.
+                </p>
+                <div className="mt-4 flex justify-end gap-2">
+                  <button
+                    type="button"
+                    className="rounded-md border border-gray-300 px-3 py-1 text-sm font-medium text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+                    onClick={() => setDeleteTarget(null)}
+                    disabled={deleteMutation.isPending}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-md bg-red-600 px-3 py-1 text-sm font-medium text-white hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-60"
+                    onClick={() => {
+                      if (!deleteTarget) return;
+                      deleteMutation.mutate(deleteTarget.id, {
+                        onSettled: () => {
+                          setDeleteTarget(null);
+                        },
+                      });
+                    }}
+                    disabled={deleteMutation.isPending}
+                  >
+                    {deleteMutation.isPending ? "Deleting..." : "Delete"}
+                  </button>
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
-      )}
+          </ModalPortal>
+        )}
     </div>
   );
 }

--- a/components/IncomeForm.tsx
+++ b/components/IncomeForm.tsx
@@ -10,6 +10,7 @@ import {
   uploadFile,
 } from "../lib/api";
 import { useToast } from "./ui/use-toast";
+import ModalPortal from "./ModalPortal";
 import { INCOME_CATEGORIES } from "../lib/categories";
 import type { PropertySummary } from "../types/property";
 import type { IncomeRow } from "../types/income";
@@ -162,61 +163,61 @@ export default function IncomeForm({
 
       <AnimatePresence>
         {open && (
-          <motion.div
-            key="income-modal"
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-            onClick={handleClose}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.2 }}
-          >
-            <motion.form
-              className="w-full max-w-md max-h-[90vh] space-y-2 overflow-y-auto rounded-lg bg-white p-4 text-gray-900 shadow-lg dark:bg-gray-900 dark:text-gray-100"
-              onClick={(e) => e.stopPropagation()}
-              onSubmit={async (e) => {
-                e.preventDefault();
-                setError(null);
-                const targetPropertyId = propertyId ?? form.propertyId;
-                if (!targetPropertyId || !form.date || !form.group || !form.amount) {
-                  setError("Please fill in all required fields");
-                  return;
-                }
-                if (!form.category && !form.label) {
-                  setError("Please select an income or enter a custom label");
-                  return;
-                }
-                if (form.category && form.label) {
-                  setError("Please choose either an income or a custom label");
-                  return;
-                }
-                if (isNaN(parseFloat(form.amount))) {
-                  setError("Amount must be a number");
-                  return;
-                }
-
-                let evidenceUrl = form.evidenceUrl;
-                let evidenceName = form.evidenceName;
-                if (evidenceFile) {
-                  try {
-                    const upload = await uploadFile(evidenceFile);
-                    evidenceUrl = upload.url;
-                    evidenceName = evidenceFile.name;
-                  } catch (err: any) {
-                    const message =
-                      err instanceof Error ? err.message : "Failed to upload evidence";
-                    setError(message);
-                    toast({ title: "Failed to upload evidence", description: message });
+          <ModalPortal key="income-modal">
+            <motion.div
+              className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+              onClick={handleClose}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.2 }}
+            >
+              <motion.form
+                className="w-full max-w-md max-h-[90vh] space-y-2 overflow-y-auto rounded-lg bg-white p-4 text-gray-900 shadow-lg dark:bg-gray-900 dark:text-gray-100"
+                onClick={(e) => e.stopPropagation()}
+                onSubmit={async (e) => {
+                  e.preventDefault();
+                  setError(null);
+                  const targetPropertyId = propertyId ?? form.propertyId;
+                  if (!targetPropertyId || !form.date || !form.group || !form.amount) {
+                    setError("Please fill in all required fields");
                     return;
                   }
-                }
+                  if (!form.category && !form.label) {
+                    setError("Please select an income or enter a custom label");
+                    return;
+                  }
+                  if (form.category && form.label) {
+                    setError("Please choose either an income or a custom label");
+                    return;
+                  }
+                  if (isNaN(parseFloat(form.amount))) {
+                    setError("Amount must be a number");
+                    return;
+                  }
 
-                const shouldRemoveExistingEvidence =
-                  !evidenceFile && !evidenceUrl && !!initialIncome?.evidenceUrl;
+                  let evidenceUrl = form.evidenceUrl;
+                  let evidenceName = form.evidenceName;
+                  if (evidenceFile) {
+                    try {
+                      const upload = await uploadFile(evidenceFile);
+                      evidenceUrl = upload.url;
+                      evidenceName = evidenceFile.name;
+                    } catch (err: any) {
+                      const message =
+                        err instanceof Error ? err.message : "Failed to upload evidence";
+                      setError(message);
+                      toast({ title: "Failed to upload evidence", description: message });
+                      return;
+                    }
+                  }
 
-                mutation.mutate({
-                  propertyId: targetPropertyId,
-                  data: {
+                  const shouldRemoveExistingEvidence =
+                    !evidenceFile && !evidenceUrl && !!initialIncome?.evidenceUrl;
+
+                  mutation.mutate({
+                    propertyId: targetPropertyId,
+                    data: {
                     date: form.date,
                     category: form.category,
                     amount: parseFloat(form.amount),
@@ -440,7 +441,8 @@ export default function IncomeForm({
               </div>
             </motion.form>
           </motion.div>
-        )}
+        </ModalPortal>
+      )}
       </AnimatePresence>
     </div>
   );

--- a/components/KeyDateFormModal.tsx
+++ b/components/KeyDateFormModal.tsx
@@ -8,6 +8,7 @@ import type {
   ReminderDocument,
 } from "../lib/api";
 import ConfirmDeleteModal from "./ConfirmDeleteModal";
+import ModalPortal from "./ModalPortal";
 
 export type KeyDateFormValues = {
   propertyId: string;
@@ -229,15 +230,16 @@ export default function KeyDateFormModal({
   if (!open) return null;
 
   return (
-    <div
-      className="fixed inset-0 z-40 flex items-center justify-center bg-black/50 px-4 py-6 transition"
-      role="dialog"
-      aria-modal="true"
-      data-testid="key-date-modal"
-    >
-      <div className="max-h-[90vh] w-full max-w-2xl overflow-auto rounded-xl bg-white p-6 shadow-xl transition-all duration-200 ease-out dark:bg-gray-900 dark:text-white">
-        <header className="mb-4 space-y-1">
-          <h2 className="text-xl font-semibold">
+    <ModalPortal>
+      <div
+        className="fixed inset-0 z-40 flex items-center justify-center bg-black/50 px-4 py-6 transition"
+        role="dialog"
+        aria-modal="true"
+        data-testid="key-date-modal"
+      >
+        <div className="max-h-[90vh] w-full max-w-2xl overflow-auto rounded-xl bg-white p-6 shadow-xl transition-all duration-200 ease-out dark:bg-gray-900 dark:text-white">
+          <header className="mb-4 space-y-1">
+            <h2 className="text-xl font-semibold">
             {initialData ? "Edit key date" : "Add key date"}
           </h2>
           <p className="text-sm text-gray-500 dark:text-gray-400">
@@ -378,45 +380,45 @@ export default function KeyDateFormModal({
               {error}
             </div>
           )}
+          <footer className="mt-6 flex flex-wrap items-center justify-between gap-3">
+            {initialData && onDelete && (
+              <button
+                type="button"
+                className="text-sm text-red-600 hover:underline disabled:opacity-50"
+                onClick={() => setShowDeleteConfirm(true)}
+                disabled={isDeleting}
+              >
+                Delete key date
+              </button>
+            )}
+            <div className="ml-auto flex gap-2">
+              <button
+                type="button"
+                className="rounded border px-4 py-2 text-sm"
+                onClick={onClose}
+                disabled={isSaving}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+                onClick={handleSubmit}
+                disabled={!canSave || isSaving}
+              >
+                {isSaving ? "Saving…" : "Save"}
+              </button>
+            </div>
+          </footer>
         </div>
-        <footer className="mt-6 flex flex-wrap items-center justify-between gap-3">
-          {initialData && onDelete && (
-            <button
-              type="button"
-              className="text-sm text-red-600 hover:underline disabled:opacity-50"
-              onClick={() => setShowDeleteConfirm(true)}
-              disabled={isDeleting}
-            >
-              Delete key date
-            </button>
-          )}
-          <div className="ml-auto flex gap-2">
-            <button
-              type="button"
-              className="rounded border px-4 py-2 text-sm"
-              onClick={onClose}
-              disabled={isSaving}
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
-              onClick={handleSubmit}
-              disabled={!canSave || isSaving}
-            >
-              {isSaving ? "Saving…" : "Save"}
-            </button>
-          </div>
-        </footer>
+        {showDeleteConfirm && onDelete && (
+          <ConfirmDeleteModal
+            onClose={() => setShowDeleteConfirm(false)}
+            onConfirm={onDelete}
+            word="delete"
+          />
+        )}
       </div>
-      {showDeleteConfirm && onDelete && (
-        <ConfirmDeleteModal
-          onClose={() => setShowDeleteConfirm(false)}
-          onConfirm={onDelete}
-          word="delete"
-        />
-      )}
-    </div>
+    </ModalPortal>
   );
 }

--- a/components/ModalPortal.tsx
+++ b/components/ModalPortal.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+
+interface ModalPortalProps {
+  children: ReactNode;
+}
+
+export default function ModalPortal({ children }: ModalPortalProps) {
+  const [container, setContainer] = useState<Element | null>(null);
+
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      setContainer(document.body);
+    }
+  }, []);
+
+  if (!container) {
+    return null;
+  }
+
+  return createPortal(children, container);
+}

--- a/components/PropertyEditModal.tsx
+++ b/components/PropertyEditModal.tsx
@@ -3,6 +3,7 @@
 import PropertyForm from "./PropertyForm";
 import type { PropertySummary } from "../types/property";
 import { AnimatePresence, motion } from "framer-motion";
+import ModalPortal from "./ModalPortal";
 
 interface Props {
   open: boolean;
@@ -14,27 +15,28 @@ export default function PropertyEditModal({ open, property, onClose }: Props) {
   return (
     <AnimatePresence>
       {open && (
-        <motion.div
-          key="property-edit-modal"
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-          onClick={onClose}
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          transition={{ duration: 0.2 }}
-        >
+        <ModalPortal key="property-edit-modal">
           <motion.div
-            className="w-full max-w-md rounded-lg bg-white p-4 shadow-lg dark:bg-gray-800"
-            onClick={(e) => e.stopPropagation()}
-            initial={{ opacity: 0, y: 16, scale: 0.97 }}
-            animate={{ opacity: 1, y: 0, scale: 1 }}
-            exit={{ opacity: 0, y: 16, scale: 0.97 }}
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+            onClick={onClose}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
             transition={{ duration: 0.2 }}
           >
-            <h2 className="mb-2 text-lg font-medium">Edit Property</h2>
-            <PropertyForm property={property} onSaved={onClose} />
+            <motion.div
+              className="w-full max-w-md rounded-lg bg-white p-4 shadow-lg dark:bg-gray-800"
+              onClick={(e) => e.stopPropagation()}
+              initial={{ opacity: 0, y: 16, scale: 0.97 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: 16, scale: 0.97 }}
+              transition={{ duration: 0.2 }}
+            >
+              <h2 className="mb-2 text-lg font-medium">Edit Property</h2>
+              <PropertyForm property={property} onSaved={onClose} />
+            </motion.div>
           </motion.div>
-        </motion.div>
+        </ModalPortal>
       )}
     </AnimatePresence>
   );

--- a/components/PropertyForm.tsx
+++ b/components/PropertyForm.tsx
@@ -11,6 +11,7 @@ import {
 } from "../lib/api";
 import type { PropertySummary } from "../types/property";
 import { useToast } from "./ui/use-toast";
+import ModalPortal from "./ModalPortal";
 import { downloadJson } from "../lib/download";
 
 interface Props {
@@ -265,66 +266,68 @@ export default function PropertyForm({ property, onSaved }: Props) {
         </div>
       </form>
       {isEdit && deleteModalOpen && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
-          onClick={closeDeleteModal}
-        >
+        <ModalPortal key="property-delete-modal">
           <div
-            className="w-full max-w-lg rounded-md bg-white p-4 shadow-lg dark:bg-gray-800 dark:text-white"
-            onClick={(e) => e.stopPropagation()}
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
+            onClick={closeDeleteModal}
           >
-            <h2 className="text-lg font-semibold">Delete property</h2>
-            <p className="mt-2 text-sm text-gray-700 dark:text-gray-300">
-              Deleting this property will permanently remove all existing information
-              including income, expenses, records, tasks, and related notes. Are you
-              sure?
-            </p>
-            <div className="mt-3 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-500/60 dark:bg-amber-500/10 dark:text-amber-100">
-              <p className="mb-2">
-                We recommend downloading a copy of this property's data before
-                deleting it.
+            <div
+              className="w-full max-w-lg rounded-md bg-white p-4 shadow-lg dark:bg-gray-800 dark:text-white"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <h2 className="text-lg font-semibold">Delete property</h2>
+              <p className="mt-2 text-sm text-gray-700 dark:text-gray-300">
+                Deleting this property will permanently remove all existing information
+                including income, expenses, records, tasks, and related notes. Are you
+                sure?
               </p>
-              <button
-                type="button"
-                className="inline-flex items-center rounded border border-amber-400 px-3 py-1 text-sm font-medium text-amber-900 hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-amber-400/60 dark:text-amber-50 dark:hover:bg-amber-500/20"
-                onClick={handleDownloadData}
-                disabled={isDownloadingData}
-              >
-                {isDownloadingData ? "Preparing download..." : "Download all data"}
-              </button>
-            </div>
-            <label className="mt-4 block text-sm font-medium text-gray-700 dark:text-gray-300">
-              Type the property address to confirm
-              <input
-                className="mt-1 w-full rounded border border-gray-300 p-2 text-base dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-                value={deleteAddressInput}
-                onChange={(e) => setDeleteAddressInput(e.target.value)}
-                placeholder={confirmationTarget}
-              />
-            </label>
-            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-              Enter <span className="font-semibold text-gray-700 dark:text-gray-200">{confirmationTarget}</span> to proceed.
-            </p>
-            <div className="mt-4 flex justify-end gap-2">
-              <button
-                type="button"
-                className="rounded border border-gray-300 px-3 py-1 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-                onClick={closeDeleteModal}
-                disabled={deleteMutation.isPending}
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                className="rounded bg-red-600 px-3 py-1 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50 dark:bg-red-700"
-                onClick={() => deleteMutation.mutate()}
-                disabled={deleteDisabled}
-              >
-                {deleteButtonLabel}
-              </button>
+              <div className="mt-3 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-500/60 dark:bg-amber-500/10 dark:text-amber-100">
+                <p className="mb-2">
+                  We recommend downloading a copy of this property's data before
+                  deleting it.
+                </p>
+                <button
+                  type="button"
+                  className="inline-flex items-center rounded border border-amber-400 px-3 py-1 text-sm font-medium text-amber-900 hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-amber-400/60 dark:text-amber-50 dark:hover:bg-amber-500/20"
+                  onClick={handleDownloadData}
+                  disabled={isDownloadingData}
+                >
+                  {isDownloadingData ? "Preparing download..." : "Download all data"}
+                </button>
+              </div>
+              <label className="mt-4 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Type the property address to confirm
+                <input
+                  className="mt-1 w-full rounded border border-gray-300 p-2 text-base dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                  value={deleteAddressInput}
+                  onChange={(e) => setDeleteAddressInput(e.target.value)}
+                  placeholder={confirmationTarget}
+                />
+              </label>
+              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                Enter <span className="font-semibold text-gray-700 dark:text-gray-200">{confirmationTarget}</span> to proceed.
+              </p>
+              <div className="mt-4 flex justify-end gap-2">
+                <button
+                  type="button"
+                  className="rounded border border-gray-300 px-3 py-1 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                  onClick={closeDeleteModal}
+                  disabled={deleteMutation.isPending}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className="rounded bg-red-600 px-3 py-1 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50 dark:bg-red-700"
+                  onClick={() => deleteMutation.mutate()}
+                  disabled={deleteDisabled}
+                >
+                  {deleteButtonLabel}
+                </button>
+              </div>
             </div>
           </div>
-        </div>
+        </ModalPortal>
       )}
     </>
   );


### PR DESCRIPTION
## Summary
- add a reusable `ModalPortal` component to render modal overlays at the document root
- update property management forms and confirmation dialogs to use the portal so their overlays cover the full viewport

## Testing
- npm run lint *(fails: ESLint config missing `eslint.config.js` per CLI output)*

------
https://chatgpt.com/codex/tasks/task_e_68df1af98f90832c803b4fe829752caa