### PR TITLE
Render property modals via body portals

### DIFF
--- a/components/DocumentUploadModal.tsx
+++ b/components/DocumentUploadModal.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { useQueryClient } from "@tanstack/react-query";
+import { createPortal } from "react-dom";
 import { uploadFile, createDocument } from "../lib/api";
 import { DocumentTag } from "../types/document";
 
@@ -14,7 +15,14 @@ interface Props {
 
 export default function DocumentUploadModal({ open, onClose, propertyId }: Props) {
   const [file, setFile] = useState<File | null>(null);
+  const [portalTarget, setPortalTarget] = useState<Element | null>(null);
   const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      setPortalTarget(document.body);
+    }
+  }, []);
 
   const handleUpload = async () => {
     if (!file) return;
@@ -33,7 +41,9 @@ export default function DocumentUploadModal({ open, onClose, propertyId }: Props
     setFile(null);
   };
 
-  return (
+  if (!portalTarget) return null;
+
+  return createPortal(
     <AnimatePresence>
       {open && (
         <motion.div
@@ -83,6 +93,7 @@ export default function DocumentUploadModal({ open, onClose, propertyId }: Props
           </motion.div>
         </motion.div>
       )}
-    </AnimatePresence>
+    </AnimatePresence>,
+    portalTarget,
   );
 }

--- a/components/ExpenseForm.tsx
+++ b/components/ExpenseForm.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { createPortal } from "react-dom";
 import { createExpense, listProperties, uploadExpenseReceipt } from "../lib/api";
 import { logEvent } from "../lib/log";
 import { useToast } from "./ui/use-toast";
@@ -116,6 +117,7 @@ export default function ExpenseForm({
   const { toast } = useToast();
   const [recent, setRecent] = useState<string[]>([]);
   const [fileInputKey, setFileInputKey] = useState(0);
+  const [portalTarget, setPortalTarget] = useState<Element | null>(null);
 
   useEffect(() => {
     const stored = localStorage.getItem("recentExpenseCategories");
@@ -139,6 +141,12 @@ export default function ExpenseForm({
     setError(null);
     setFileInputKey((key) => key + 1);
   }, [open, computeInitialForm]);
+
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      setPortalTarget(document.body);
+    }
+  }, []);
 
 
   const { data: properties = [] } = useQuery<PropertySummary[]>({
@@ -210,104 +218,106 @@ export default function ExpenseForm({
         </button>
       )}
 
-      <AnimatePresence>
-        {open && (
-          <motion.div
-            key="expense-modal"
-            className="fixed inset-0 z-50 flex h-full w-full items-start justify-center bg-black/50 p-4 sm:p-6 md:items-center"
-            onClick={handleClose}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.2 }}
-          >
-            <motion.form
-              className="h-full w-full max-w-2xl max-h-full space-y-3 overflow-y-auto rounded-lg bg-white p-6 text-gray-900 shadow-lg dark:bg-gray-800 dark:text-gray-100"
-              onClick={(e) => e.stopPropagation()}
-              onSubmit={(e) => {
-                e.preventDefault();
-                setError(null);
-                if (
-                  !form.propertyId ||
-                  !form.date ||
-                  !form.group ||
-                  !form.vendor ||
-                  !form.amount ||
-                  (!form.category && !form.label)
-                ) {
-                  setError("Please fill in all required fields");
-                  return;
-                }
-                if (form.category && form.label) {
-                  setError("Please choose either an expense or a custom label");
-                  return;
-                }
-                if (isNaN(parseFloat(form.amount))) {
-                  setError("Amount must be a number");
-                  return;
-                }
-                mutation.mutate({
-                  expense: {
-                    propertyId: form.propertyId,
-                    date: form.date,
-                    category: form.category,
-                    vendor: form.vendor,
-                    amount: parseFloat(form.amount),
-                    gst: form.gst ? parseFloat(form.gst) : 0,
-                    notes: form.notes,
-                    label: form.label,
-                  },
-                  receipt: form.receipt,
-                });
-                if (form.group) {
-                  addRecent(form.group);
-                }
-              }}
-              initial={{ opacity: 0, y: 24, scale: 0.97 }}
-              animate={{ opacity: 1, y: 0, scale: 1 }}
-              exit={{ opacity: 0, y: 24, scale: 0.97 }}
-              transition={{ duration: 0.2 }}
-            >
-              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
-                Log an Expense
-              </h2>
-              {!propertyId && (
-                <label className="block text-gray-700 dark:text-gray-300">
-                  Property
-                  <select
-                    className="border p-1 w-full rounded bg-white dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
-                    value={form.propertyId}
-                    onChange={(e) =>
-                      setForm({ ...form, propertyId: e.target.value })
+      {portalTarget &&
+        createPortal(
+          <AnimatePresence>
+            {open && (
+              <motion.div
+                key="expense-modal"
+                className="fixed inset-0 z-50 flex h-full w-full items-start justify-center bg-black/50 p-4 sm:p-6 md:items-center"
+                onClick={handleClose}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.2 }}
+              >
+                <motion.form
+                  className="h-full w-full max-w-2xl max-h-full space-y-3 overflow-y-auto rounded-lg bg-white p-6 text-gray-900 shadow-lg dark:bg-gray-800 dark:text-gray-100"
+                  onClick={(e) => e.stopPropagation()}
+                  onSubmit={(e) => {
+                    e.preventDefault();
+                    setError(null);
+                    if (
+                      !form.propertyId ||
+                      !form.date ||
+                      !form.group ||
+                      !form.vendor ||
+                      !form.amount ||
+                      (!form.category && !form.label)
+                    ) {
+                      setError("Please fill in all required fields");
+                      return;
                     }
-                  >
-                    <option value="">Select property</option>
-                    {properties.map((p) => (
-                      <option key={p.id} value={p.id}>
-                        {p.address}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-              )}
-              <label className="block text-gray-700 dark:text-gray-300">
-                Date
-                <input
-                  type="date"
-                  className="border p-1 w-full rounded bg-white dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
-                  value={form.date}
-                  onChange={(e) => setForm({ ...form, date: e.target.value })}
-                />
-              </label>
-              <label className="block text-gray-700 dark:text-gray-300">
-                Category
-                <select
-                  className="border p-1 w-full rounded bg-white dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
-                  value={form.group}
-                  onChange={(e) =>
-                    setForm({ ...form, group: e.target.value, category: "" })
-                  }
+                    if (form.category && form.label) {
+                      setError("Please choose either an expense or a custom label");
+                      return;
+                    }
+                    if (isNaN(parseFloat(form.amount))) {
+                      setError("Amount must be a number");
+                      return;
+                    }
+                    mutation.mutate({
+                      expense: {
+                        propertyId: form.propertyId,
+                        date: form.date,
+                        category: form.category,
+                        vendor: form.vendor,
+                        amount: parseFloat(form.amount),
+                        gst: form.gst ? parseFloat(form.gst) : 0,
+                        notes: form.notes,
+                        label: form.label,
+                      },
+                      receipt: form.receipt,
+                    });
+                    if (form.group) {
+                      addRecent(form.group);
+                    }
+                  }}
+                  initial={{ opacity: 0, y: 24, scale: 0.97 }}
+                  animate={{ opacity: 1, y: 0, scale: 1 }}
+                  exit={{ opacity: 0, y: 24, scale: 0.97 }}
+                  transition={{ duration: 0.2 }}
                 >
+                  <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
+                    Log an Expense
+                  </h2>
+                  {!propertyId && (
+                    <label className="block text-gray-700 dark:text-gray-300">
+                      Property
+                      <select
+                        className="border p-1 w-full rounded bg-white dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
+                        value={form.propertyId}
+                        onChange={(e) =>
+                          setForm({ ...form, propertyId: e.target.value })
+                        }
+                      >
+                        <option value="">Select property</option>
+                        {properties.map((p) => (
+                          <option key={p.id} value={p.id}>
+                            {p.address}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  )}
+                  <label className="block text-gray-700 dark:text-gray-300">
+                    Date
+                    <input
+                      type="date"
+                      className="border p-1 w-full rounded bg-white dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
+                      value={form.date}
+                      onChange={(e) => setForm({ ...form, date: e.target.value })}
+                    />
+                  </label>
+                  <label className="block text-gray-700 dark:text-gray-300">
+                    Category
+                    <select
+                      className="border p-1 w-full rounded bg-white dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
+                      value={form.group}
+                      onChange={(e) =>
+                        setForm({ ...form, group: e.target.value, category: "" })
+                      }
+                    >
                   <option value="">Select category</option>
                   {recent.length > 0 && (
                     <optgroup label="Recent">
@@ -473,7 +483,9 @@ export default function ExpenseForm({
             </motion.form>
           </motion.div>
         )}
-      </AnimatePresence>
-    </div>
+      </AnimatePresence>,
+      portalTarget,
+    )}
+  </div>
   );
 }

--- a/components/ExpensesTable.tsx
+++ b/components/ExpensesTable.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
 import { listExpenses, deleteExpense, listProperties } from "../lib/api";
 import { formatShortDate } from "../lib/format";
 import type { ExpenseRow } from "../types/expense";
@@ -43,7 +44,14 @@ export default function ExpensesTable({
   const [editOpen, setEditOpen] = useState(false);
   const [editingExpense, setEditingExpense] = useState<ExpenseRow | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<ExpenseRow | null>(null);
+  const [portalTarget, setPortalTarget] = useState<Element | null>(null);
   const [search, setSearch] = useState("");
+
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      setPortalTarget(document.body);
+    }
+  }, []);
 
   const params = {
     propertyId: propertyId ?? (property || undefined),
@@ -295,54 +303,58 @@ export default function ExpensesTable({
           queryClient.invalidateQueries({ queryKey });
         }}
       />
-      {deleteTarget && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-          onClick={() => {
-            if (!deleteMutation.isPending) {
-              setDeleteTarget(null);
-            }
-          }}
-        >
+      {deleteTarget &&
+        portalTarget &&
+        createPortal(
           <div
-            className="w-full max-w-sm rounded-lg bg-white p-5 text-gray-900 shadow-lg dark:bg-gray-800 dark:text-gray-100"
-            onClick={(event) => event.stopPropagation()}
+            key="expense-delete-modal"
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+            onClick={() => {
+              if (!deleteMutation.isPending) {
+                setDeleteTarget(null);
+              }
+            }}
           >
-            <h2 className="text-lg font-semibold">Delete expense</h2>
-            <p className="mt-2 text-sm text-gray-700 dark:text-gray-300">
-              are you sure?
-            </p>
-            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-              This will permanently remove the entry for {deleteTarget.vendor || "this expense"} dated {deleteTarget.date}.
-            </p>
-            <div className="mt-4 flex justify-end gap-2">
-              <button
-                type="button"
-                className="rounded-md border border-gray-300 px-3 py-1 text-sm font-medium text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
-                onClick={() => setDeleteTarget(null)}
-                disabled={deleteMutation.isPending}
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                className="rounded-md bg-red-600 px-3 py-1 text-sm font-medium text-white hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-60"
-                onClick={() => {
-                  if (!deleteTarget) return;
-                  deleteMutation.mutate(deleteTarget.id, {
-                    onSettled: () => {
-                      setDeleteTarget(null);
-                    },
-                  });
-                }}
-                disabled={deleteMutation.isPending}
-              >
-                {deleteMutation.isPending ? "Deleting..." : "Delete"}
-              </button>
+            <div
+              className="w-full max-w-sm rounded-lg bg-white p-5 text-gray-900 shadow-lg dark:bg-gray-800 dark:text-gray-100"
+              onClick={(event) => event.stopPropagation()}
+            >
+              <h2 className="text-lg font-semibold">Delete expense</h2>
+              <p className="mt-2 text-sm text-gray-700 dark:text-gray-300">
+                are you sure?
+              </p>
+              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                This will permanently remove the entry for {deleteTarget.vendor || "this expense"} dated {deleteTarget.date}.
+              </p>
+              <div className="mt-4 flex justify-end gap-2">
+                <button
+                  type="button"
+                  className="rounded-md border border-gray-300 px-3 py-1 text-sm font-medium text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+                  onClick={() => setDeleteTarget(null)}
+                  disabled={deleteMutation.isPending}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className="rounded-md bg-red-600 px-3 py-1 text-sm font-medium text-white hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-60"
+                  onClick={() => {
+                    if (!deleteTarget) return;
+                    deleteMutation.mutate(deleteTarget.id, {
+                      onSettled: () => {
+                        setDeleteTarget(null);
+                      },
+                    });
+                  }}
+                  disabled={deleteMutation.isPending}
+                >
+                  {deleteMutation.isPending ? "Deleting..." : "Delete"}
+                </button>
+              </div>
             </div>
-          </div>
-        </div>
-      )}
+          </div>,
+          portalTarget,
+        )}
     </div>
   );
 }

--- a/components/PropertyEditModal.tsx
+++ b/components/PropertyEditModal.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { createPortal } from "react-dom";
 import PropertyForm from "./PropertyForm";
 import type { PropertySummary } from "../types/property";
-import { AnimatePresence, motion } from "framer-motion";
 
 interface Props {
   open: boolean;
@@ -11,31 +13,42 @@ interface Props {
 }
 
 export default function PropertyEditModal({ open, property, onClose }: Props) {
+  const [portalTarget, setPortalTarget] = useState<Element | null>(null);
+
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      setPortalTarget(document.body);
+    }
+  }, []);
+
   return (
     <AnimatePresence>
-      {open && (
-        <motion.div
-          key="property-edit-modal"
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-          onClick={onClose}
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          transition={{ duration: 0.2 }}
-        >
+      {open &&
+        portalTarget &&
+        createPortal(
           <motion.div
-            className="w-full max-w-md rounded-lg bg-white p-4 shadow-lg dark:bg-gray-800"
-            onClick={(e) => e.stopPropagation()}
-            initial={{ opacity: 0, y: 16, scale: 0.97 }}
-            animate={{ opacity: 1, y: 0, scale: 1 }}
-            exit={{ opacity: 0, y: 16, scale: 0.97 }}
+            key="property-edit-modal"
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+            onClick={onClose}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
             transition={{ duration: 0.2 }}
           >
-            <h2 className="mb-2 text-lg font-medium">Edit Property</h2>
-            <PropertyForm property={property} onSaved={onClose} />
-          </motion.div>
-        </motion.div>
-      )}
+            <motion.div
+              className="w-full max-w-md rounded-lg bg-white p-4 shadow-lg dark:bg-gray-800"
+              onClick={(e) => e.stopPropagation()}
+              initial={{ opacity: 0, y: 16, scale: 0.97 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: 16, scale: 0.97 }}
+              transition={{ duration: 0.2 }}
+            >
+              <h2 className="mb-2 text-lg font-medium">Edit Property</h2>
+              <PropertyForm property={property} onSaved={onClose} />
+            </motion.div>
+          </motion.div>,
+          portalTarget,
+        )}
     </AnimatePresence>
   );
 }


### PR DESCRIPTION
## Summary
- remove the shared ModalPortal helper and instead attach modal overlays directly to `document.body`
- update the income, expense, key date, property edit, property delete, and document upload dialogs to mount via `createPortal` while preserving their animations

## Testing
- npm run lint *(fails: ESLint 9 requires eslint.config.js and repo still uses .eslintrc)*

------
https://chatgpt.com/codex/tasks/task_e_68df1af98f90832c803b4fe829752caa