### PR TITLE
Fix edit property button layering

### DIFF
--- a/app/(app)/properties/[id]/components/PropertyHero.tsx
+++ b/app/(app)/properties/[id]/components/PropertyHero.tsx
@@ -94,13 +94,13 @@ export default function PropertyHero({
         <img
           src={imageSrc}
           alt={`Photo of ${property.address}`}
-          className="h-full w-full object-cover"
+          className="pointer-events-none h-full w-full object-cover"
         />
         <Button
           type="button"
           variant="secondary"
           onClick={onEdit}
-          className="absolute right-4 top-4 bg-white/90 text-sm font-semibold text-gray-900 hover:bg-white"
+          className="absolute right-4 top-4 z-10 bg-white/90 text-sm font-semibold text-gray-900 hover:bg-white"
         >
           Edit Property
         </Button>


### PR DESCRIPTION
## Summary
- ensure the property hero image does not intercept pointer events
- raise the edit property button above the hero image so it remains clickable

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df2771ea10832c8830829a9359d3a2