### PR TITLE
Enhance property document upload details

### DIFF
--- a/components/DocumentUpload.tsx
+++ b/components/DocumentUpload.tsx
@@ -28,6 +28,7 @@ export default function DocumentUpload({ onUploaded }: Props) {
       title: file.name,
       propertyId,
       tag,
+      uploadedAt: new Date().toISOString(),
     });
     onUploaded();
     logEvent("document_upload", { propertyId, tag, title: file.name });

--- a/components/DocumentUploadModal.tsx
+++ b/components/DocumentUploadModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { useQueryClient } from "@tanstack/react-query";
 import { createPortal } from "react-dom";
@@ -16,8 +16,23 @@ interface Props {
 
 export default function DocumentUploadModal({ open, onClose, propertyId }: Props) {
   const [file, setFile] = useState<File | null>(null);
+  const [fileName, setFileName] = useState("");
+  const [notes, setNotes] = useState("");
+  const [links, setLinks] = useState("");
   const [portalTarget, setPortalTarget] = useState<Element | null>(null);
   const queryClient = useQueryClient();
+
+  const resetState = useCallback(() => {
+    setFile(null);
+    setFileName("");
+    setNotes("");
+    setLinks("");
+  }, []);
+
+  const handleClose = useCallback(() => {
+    resetState();
+    onClose();
+  }, [onClose, resetState]);
 
   useEffect(() => {
     if (typeof document !== "undefined") {
@@ -25,21 +40,46 @@ export default function DocumentUploadModal({ open, onClose, propertyId }: Props
     }
   }, []);
 
+  useEffect(() => {
+    if (!open) {
+      resetState();
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        handleClose();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [handleClose, open, resetState]);
+
   const handleUpload = async () => {
-    if (!file) return;
+    if (!file || !fileName.trim()) return;
     const { url } = await uploadFile(file);
+    const parsedLinks = links
+      .split(/\n|,/)
+      .map((entry) => entry.trim())
+      .filter(Boolean);
     await createDocument({
       url,
-      title: file.name,
+      title: fileName.trim(),
       tag: DocumentTag.Other,
       propertyId,
+      notes: notes.trim() || undefined,
+      links: parsedLinks.length > 0 ? parsedLinks : undefined,
+      uploadedAt: new Date().toISOString(),
     });
     // Refresh any document queries for this property
     if (propertyId) {
       queryClient.invalidateQueries({ queryKey: ["documents", propertyId] });
     }
-    onClose();
-    setFile(null);
+    handleClose();
   };
 
   if (!portalTarget) return null;
@@ -51,8 +91,7 @@ export default function DocumentUploadModal({ open, onClose, propertyId }: Props
           <motion.div
             className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
             onClick={() => {
-              setFile(null);
-              onClose();
+              handleClose();
             }}
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
@@ -60,32 +99,80 @@ export default function DocumentUploadModal({ open, onClose, propertyId }: Props
             transition={{ duration: 0.2 }}
           >
             <motion.div
-              className="w-full max-w-xs space-y-2 rounded-lg bg-white p-4 shadow-lg"
+              className="w-full max-w-md space-y-4 rounded-xl bg-white p-6 shadow-lg"
               onClick={(e) => e.stopPropagation()}
               initial={{ opacity: 0, y: 16, scale: 0.96 }}
               animate={{ opacity: 1, y: 0, scale: 1 }}
               exit={{ opacity: 0, y: 16, scale: 0.96 }}
               transition={{ duration: 0.2 }}
             >
-              <h2 className="text-lg font-medium">Upload Document</h2>
-              <input
-                type="file"
-                className="w-full rounded border p-1"
-                onChange={(e) => setFile(e.target.files?.[0] || null)}
-              />
+              <div className="space-y-1">
+                <h2 className="text-lg font-semibold">Upload Document</h2>
+                <p className="text-sm text-gray-500">
+                  Add details to keep everything organised for this property.
+                </p>
+              </div>
+              <div className="space-y-4">
+                <label className="block text-sm font-medium text-gray-700">
+                  Document File
+                  <input
+                    type="file"
+                    className="mt-1 w-full rounded border p-2 text-sm"
+                    onChange={(e) => {
+                      const selected = e.target.files?.[0] || null;
+                      setFile(selected);
+                      if (selected) {
+                        setFileName(selected.name);
+                      }
+                    }}
+                  />
+                </label>
+                <label className="block text-sm font-medium text-gray-700">
+                  File Name
+                  <input
+                    type="text"
+                    className="mt-1 w-full rounded border p-2 text-sm"
+                    placeholder="e.g. Lease Agreement"
+                    value={fileName}
+                    onChange={(e) => setFileName(e.target.value)}
+                  />
+                </label>
+                <label className="block text-sm font-medium text-gray-700">
+                  Notes
+                  <textarea
+                    className="mt-1 w-full rounded border p-2 text-sm"
+                    placeholder="Add any relevant context"
+                    rows={3}
+                    value={notes}
+                    onChange={(e) => setNotes(e.target.value)}
+                  />
+                </label>
+                <label className="block text-sm font-medium text-gray-700">
+                  Links
+                  <textarea
+                    className="mt-1 w-full rounded border p-2 text-sm"
+                    placeholder="Paste any related URLs (separate with commas or line breaks)"
+                    rows={2}
+                    value={links}
+                    onChange={(e) => setLinks(e.target.value)}
+                  />
+                </label>
+              </div>
+              <div className="flex items-center justify-between pt-2 text-xs text-gray-500">
+                <span>Upload date will be recorded automatically.</span>
+              </div>
               <div className="flex justify-end gap-2 pt-2">
                 <button
                   className="rounded bg-gray-100 px-2 py-1"
                   onClick={() => {
-                    setFile(null);
-                    onClose();
+                    handleClose();
                   }}
                 >
                   Cancel
                 </button>
                 <button
                   className="rounded bg-blue-600 px-2 py-1 text-white disabled:opacity-60"
-                  disabled={!file}
+                  disabled={!file || !fileName.trim()}
                   onClick={handleUpload}
                 >
                   Upload

--- a/components/PropertyDocumentsTable.tsx
+++ b/components/PropertyDocumentsTable.tsx
@@ -23,25 +23,48 @@ export default function PropertyDocumentsTable({
       <table className="min-w-full">
         <thead>
           <tr>
-            <th className="p-2 text-left">Name</th>
-            <th className="p-2 text-left">Uploaded</th>
-            <th className="p-2 text-left">Link</th>
+            <th className="p-2 text-left">File Name</th>
+            <th className="p-2 text-left">Notes</th>
+            <th className="p-2 text-left">Links</th>
+            <th className="p-2 text-left">Upload Date</th>
           </tr>
         </thead>
         <tbody>
           {data.map((d) => (
             <tr key={d.id} className="border-t border-[var(--border)]">
-              <td className="p-2">{d.name}</td>
-              <td className="p-2">{formatShortDate(d.uploaded)}</td>
-              <td className="p-2">
-                <a
-                  href={d.url}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="text-[var(--primary)] underline"
-                >
-                  View
-                </a>
+              <td className="p-2 align-top font-medium">{d.name}</td>
+              <td className="p-2 align-top text-sm text-gray-600 whitespace-pre-line">
+                {d.notes ? d.notes : "—"}
+              </td>
+              <td className="p-2 align-top text-sm">
+                <div className="flex flex-col gap-1">
+                  {d.url ? (
+                    <a
+                      href={d.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-[var(--primary)] underline"
+                    >
+                      Open document
+                    </a>
+                  ) : (
+                    <span className="text-gray-500">—</span>
+                  )}
+                  {(d.links ?? []).map((link) => (
+                    <a
+                      key={link}
+                      href={link}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-[var(--primary)] underline"
+                    >
+                      {link}
+                    </a>
+                  ))}
+                </div>
+              </td>
+              <td className="p-2 align-top text-sm text-gray-600">
+                {formatShortDate(d.uploadedAt ?? d.uploaded)}
               </td>
             </tr>
           ))}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -447,6 +447,9 @@ export interface DocumentRecord {
   propertyId?: string;
   tag: string;
   url: string;
+  notes?: string;
+  links?: string[];
+  uploadedAt?: string;
 }
 
 export const listDocuments = (params?: {
@@ -468,6 +471,9 @@ export const createDocument = (payload: {
   title: string;
   tag: string;
   propertyId?: string;
+  notes?: string;
+  links?: string[];
+  uploadedAt?: string;
 }) =>
   api<DocumentRecord>('/documents', {
     method: 'POST',

--- a/types/document.ts
+++ b/types/document.ts
@@ -12,4 +12,7 @@ export interface DocumentItem {
   title: string;
   url: string;
   tag: DocumentTag;
+  notes?: string;
+  links?: string[];
+  uploadedAt?: string;
 }

--- a/types/property.ts
+++ b/types/property.ts
@@ -33,5 +33,8 @@ export interface PropertyDocument {
   name: string;
   url: string;
   uploaded: string;
+  notes?: string;
+  links?: string[];
+  uploadedAt?: string;
 }
 


### PR DESCRIPTION
## Summary
- expand the property document upload modal with fields for file name, notes, related links, and an auto-recorded upload date
- add escape key handling, click-away closing, and rounded styling to keep the modal consistent with the property management UI
- surface the new document metadata in the property documents table and align shared API/types with the richer payload

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df282b4774832c998bca3b07e9dcf1