### PR TITLE
Truncate property management notes columns

### DIFF
--- a/components/ExpensesTable.tsx
+++ b/components/ExpensesTable.tsx
@@ -237,7 +237,18 @@ export default function ExpensesTable({
                   <td className="p-2">{r.vendor}</td>
                   <td className="p-2">{r.amount}</td>
                   <td className="p-2">{r.gst}</td>
-                  <td className="p-2">{r.notes}</td>
+                  <td className="p-2">
+                    {r.notes ? (
+                      <span
+                      className="block max-w-[10rem] truncate sm:max-w-[12rem]"
+                        title={r.notes}
+                      >
+                        {r.notes}
+                      </span>
+                    ) : (
+                      <span className="text-gray-500 dark:text-gray-400">&mdash;</span>
+                    )}
+                  </td>
                   <td className="p-2">
                     <ReceiptLink url={r.receiptUrl} />
                   </td>

--- a/components/IncomesTable.tsx
+++ b/components/IncomesTable.tsx
@@ -139,7 +139,18 @@ export default function IncomesTable({
                   )}
                 </td>
                 <td className="p-2">{r.amount}</td>
-                <td className="p-2">{r.notes}</td>
+                <td className="p-2">
+                  {r.notes ? (
+                    <span
+                      className="block max-w-[10rem] truncate sm:max-w-[12rem]"
+                      title={r.notes}
+                    >
+                      {r.notes}
+                    </span>
+                  ) : (
+                    <span className="text-gray-500 dark:text-gray-400">&mdash;</span>
+                  )}
+                </td>
                 <td className="p-2">
                   <div className="flex items-center gap-2">
                     <button


### PR DESCRIPTION
## Summary
- truncate expense notes in property management tables with an ellipsis preview while keeping the notes column compact
- apply the same truncation treatment to income notes, keeping the column width unchanged and showing a neutral dash when no note is recorded

## Testing
- npm run lint *(fails: ESLint configuration file not found in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68df29ff16b0832ca2953b6ef25ed9aa