### PR TITLE
Adjust tab spacing in property section bar

### DIFF
--- a/app/(app)/properties/[id]/components/ScrollableSectionBar.tsx
+++ b/app/(app)/properties/[id]/components/ScrollableSectionBar.tsx
@@ -133,7 +133,7 @@ export default function ScrollableSectionBar({
       root: "flex w-full justify-start",
       wrapper: "pointer-events-auto relative w-full max-w-full",
       tablist:
-        "flex w-full items-center gap-2 overflow-x-auto whitespace-nowrap pb-4",
+        "flex w-full items-center gap-2 overflow-x-auto whitespace-nowrap px-1 pt-1 pb-4",
       tabBase:
         "flex-shrink-0 whitespace-nowrap rounded-md px-3 py-2 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-gray-300 focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-gray-600 dark:focus:ring-offset-gray-900",
       tabActive:


### PR DESCRIPTION
## Summary
- add horizontal and top padding to the contained scrollable section bar tabs
- ensure active tab outlines are no longer clipped by the container

## Testing
- not run (dependency installation blocked in environment)


------
https://chatgpt.com/codex/tasks/task_e_68df2b67f0b0832c920aeb35550572f6