### PR TITLE
Replace notes text with note icons

### DIFF
--- a/components/ExpensesTable.tsx
+++ b/components/ExpensesTable.tsx
@@ -237,7 +237,29 @@ export default function ExpensesTable({
                   <td className="p-2">{r.vendor}</td>
                   <td className="p-2">{r.amount}</td>
                   <td className="p-2">{r.gst}</td>
-                  <td className="p-2">{r.notes}</td>
+                  <td className="p-2">
+                    {r.notes ? (
+                      <span
+                        className="inline-flex items-center text-gray-600 dark:text-gray-300"
+                        title={r.notes}
+                        aria-label="View note"
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox="0 0 20 20"
+                          fill="currentColor"
+                          className="h-5 w-5"
+                          aria-hidden="true"
+                        >
+                          <path d="M4 4a2 2 0 0 1 2-2h4.586A2 2 0 0 1 12 2.586L15.414 6A2 2 0 0 1 16 7.414V16a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V4Z" />
+                          <path d="M8 7a1 1 0 0 0 0 2h4a1 1 0 1 0 0-2H8Zm0 4a1 1 0 0 0 0 2h4a1 1 0 1 0 0-2H8Z" />
+                        </svg>
+                        <span className="sr-only">Note available</span>
+                      </span>
+                    ) : (
+                      <span className="text-gray-500 dark:text-gray-400">&mdash;</span>
+                    )}
+                  </td>
                   <td className="p-2">
                     <ReceiptLink url={r.receiptUrl} />
                   </td>

--- a/components/IncomesTable.tsx
+++ b/components/IncomesTable.tsx
@@ -139,7 +139,29 @@ export default function IncomesTable({
                   )}
                 </td>
                 <td className="p-2">{r.amount}</td>
-                <td className="p-2">{r.notes}</td>
+                <td className="p-2">
+                  {r.notes ? (
+                    <span
+                      className="inline-flex items-center text-gray-600 dark:text-gray-300"
+                      title={r.notes}
+                      aria-label="View note"
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 20 20"
+                        fill="currentColor"
+                        className="h-5 w-5"
+                        aria-hidden="true"
+                      >
+                        <path d="M4 4a2 2 0 0 1 2-2h4.586A2 2 0 0 1 12 2.586L15.414 6A2 2 0 0 1 16 7.414V16a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V4Z" />
+                        <path d="M8 7a1 1 0 0 0 0 2h4a1 1 0 1 0 0-2H8Zm0 4a1 1 0 0 0 0 2h4a1 1 0 1 0 0-2H8Z" />
+                      </svg>
+                      <span className="sr-only">Note available</span>
+                    </span>
+                  ) : (
+                    <span className="text-gray-500 dark:text-gray-400">&mdash;</span>
+                  )}
+                </td>
                 <td className="p-2">
                   <div className="flex items-center gap-2">
                     <button


### PR DESCRIPTION
## Summary
- replace expense note previews with a compact note icon so the actions column remains visible
- apply the same note icon indicator to income rows while keeping the em dash placeholder for empty notes

## Testing
- npm run lint *(fails: ESLint configuration file not found in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68df29ff16b0832ca2953b6ef25ed9aa