### PR TITLE
Ensure property documents surface upload timestamps

### DIFF
--- a/app/api/documents/route.ts
+++ b/app/api/documents/route.ts
@@ -38,11 +38,20 @@ export async function GET(req: Request) {
 export async function POST(req: Request) {
   try {
     const body = await req.json();
-    const { url, title, tag, propertyId } = body || {};
+    const { url, title, tag, propertyId, notes, links, uploadedAt } = body || {};
     if (!url || !title) {
       return NextResponse.json({ error: 'url and title required' }, { status: 400 });
     }
-    const doc = { id: randomUUID(), url, title, tag: tag || 'Other', propertyId };
+    const doc = {
+      id: randomUUID(),
+      url,
+      title,
+      tag: tag || 'Other',
+      propertyId,
+      notes,
+      links,
+      uploadedAt: uploadedAt || new Date().toISOString(),
+    };
     if (process.env.MOCK_MODE === 'true') {
       documents.push(doc as any);
     } else {

--- a/app/api/store.ts
+++ b/app/api/store.ts
@@ -43,6 +43,9 @@ export type Document = {
   title: string;
   url: string;
   tag: DocumentTag;
+  notes?: string;
+  links?: string[];
+  uploadedAt?: string;
 };
 export type ReminderType =
   | 'lease_expiry'
@@ -1450,6 +1453,7 @@ const initialDocuments: Document[] = [
     title: 'lease.pdf',
     url: '/docs/lease-prop1.pdf',
     tag: DocumentTag.Lease,
+    uploadedAt: '2023-02-01T09:30:00.000Z',
   },
   {
     id: 'doc2',
@@ -1457,6 +1461,7 @@ const initialDocuments: Document[] = [
     title: 'inspection.pdf',
     url: '/docs/inspection-prop2.pdf',
     tag: DocumentTag.Compliance,
+    uploadedAt: '2023-05-18T14:10:00.000Z',
   },
   {
     id: 'doc3',
@@ -1464,6 +1469,7 @@ const initialDocuments: Document[] = [
     title: 'invoice.pdf',
     url: '/docs/invoice-prop1.pdf',
     tag: DocumentTag.Other,
+    uploadedAt: '2023-03-22T11:45:00.000Z',
   },
   {
     id: 'doc4',
@@ -1471,6 +1477,7 @@ const initialDocuments: Document[] = [
     title: 'insurance.pdf',
     url: '/docs/insurance-prop3.pdf',
     tag: DocumentTag.Insurance,
+    uploadedAt: '2022-12-15T16:20:00.000Z',
   },
 ];
 

--- a/components/DocumentUpload.tsx
+++ b/components/DocumentUpload.tsx
@@ -28,6 +28,7 @@ export default function DocumentUpload({ onUploaded }: Props) {
       title: file.name,
       propertyId,
       tag,
+      uploadedAt: new Date().toISOString(),
     });
     onUploaded();
     logEvent("document_upload", { propertyId, tag, title: file.name });

--- a/components/DocumentUploadModal.tsx
+++ b/components/DocumentUploadModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { useQueryClient } from "@tanstack/react-query";
 import { createPortal } from "react-dom";
@@ -16,8 +16,32 @@ interface Props {
 
 export default function DocumentUploadModal({ open, onClose, propertyId }: Props) {
   const [file, setFile] = useState<File | null>(null);
+  const [fileName, setFileName] = useState("");
+  const [notes, setNotes] = useState("");
+  const [links, setLinks] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showSuccess, setShowSuccess] = useState(false);
   const [portalTarget, setPortalTarget] = useState<Element | null>(null);
   const queryClient = useQueryClient();
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const resetUploadState = useCallback(() => {
+    setFile(null);
+    setFileName("");
+    setNotes("");
+    setLinks("");
+    setIsSubmitting(false);
+    setShowSuccess(false);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    if (closeTimer.current) {
+      clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+    resetUploadState();
+    onClose();
+  }, [onClose, resetUploadState]);
 
   useEffect(() => {
     if (typeof document !== "undefined") {
@@ -25,22 +49,71 @@ export default function DocumentUploadModal({ open, onClose, propertyId }: Props
     }
   }, []);
 
-  const handleUpload = async () => {
-    if (!file) return;
-    const { url } = await uploadFile(file);
-    await createDocument({
-      url,
-      title: file.name,
-      tag: DocumentTag.Other,
-      propertyId,
-    });
-    // Refresh any document queries for this property
-    if (propertyId) {
-      queryClient.invalidateQueries({ queryKey: ["documents", propertyId] });
+  useEffect(() => {
+    if (!open) {
+      resetUploadState();
+      return;
     }
-    onClose();
-    setFile(null);
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        handleClose();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [handleClose, open, resetUploadState]);
+
+  const scheduleClose = useCallback(() => {
+    if (closeTimer.current) {
+      clearTimeout(closeTimer.current);
+    }
+    closeTimer.current = setTimeout(() => {
+      setShowSuccess(false);
+      handleClose();
+    }, 1200);
+  }, [handleClose]);
+
+  const handleUpload = async () => {
+    if (!file || !fileName.trim() || isSubmitting) return;
+    setIsSubmitting(true);
+    try {
+      const { url } = await uploadFile(file);
+      const parsedLinks = links
+        .split(/\n|,/)
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+      await createDocument({
+        url,
+        title: fileName.trim(),
+        tag: DocumentTag.Other,
+        propertyId,
+        notes: notes.trim() || undefined,
+        links: parsedLinks.length > 0 ? parsedLinks : undefined,
+        uploadedAt: new Date().toISOString(),
+      });
+      // Refresh any document queries for this property
+      if (propertyId) {
+        queryClient.invalidateQueries({ queryKey: ["documents", propertyId] });
+      }
+      setShowSuccess(true);
+      scheduleClose();
+    } catch (error) {
+      console.error("Failed to upload document", error);
+    } finally {
+      setIsSubmitting(false);
+    }
   };
+
+  useEffect(() => () => {
+    if (closeTimer.current) {
+      clearTimeout(closeTimer.current);
+    }
+  }, []);
 
   if (!portalTarget) return null;
 
@@ -51,8 +124,7 @@ export default function DocumentUploadModal({ open, onClose, propertyId }: Props
           <motion.div
             className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
             onClick={() => {
-              setFile(null);
-              onClose();
+              handleClose();
             }}
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
@@ -60,36 +132,102 @@ export default function DocumentUploadModal({ open, onClose, propertyId }: Props
             transition={{ duration: 0.2 }}
           >
             <motion.div
-              className="w-full max-w-xs space-y-2 rounded-lg bg-white p-4 shadow-lg"
+              className="w-full max-w-md space-y-4 rounded-xl bg-white p-6 shadow-lg"
               onClick={(e) => e.stopPropagation()}
               initial={{ opacity: 0, y: 16, scale: 0.96 }}
               animate={{ opacity: 1, y: 0, scale: 1 }}
               exit={{ opacity: 0, y: 16, scale: 0.96 }}
               transition={{ duration: 0.2 }}
             >
-              <h2 className="text-lg font-medium">Upload Document</h2>
-              <input
-                type="file"
-                className="w-full rounded border p-1"
-                onChange={(e) => setFile(e.target.files?.[0] || null)}
-              />
-              <div className="flex justify-end gap-2 pt-2">
+              <div className="space-y-1">
+                <h2 className="text-lg font-semibold">Upload Document</h2>
+                <p className="text-sm text-gray-500">
+                  Add details to keep everything organised for this property.
+                </p>
+              </div>
+              <div className="space-y-4">
+                <label className="block text-sm font-medium text-gray-700">
+                  Document File
+                  <input
+                    type="file"
+                    className="mt-1 w-full rounded border p-2 text-sm"
+                    onChange={(e) => {
+                      const selected = e.target.files?.[0] || null;
+                      setFile(selected);
+                      if (selected) {
+                        setFileName(selected.name);
+                      }
+                    }}
+                  />
+                </label>
+                <label className="block text-sm font-medium text-gray-700">
+                  File Name
+                  <input
+                    type="text"
+                    className="mt-1 w-full rounded border p-2 text-sm"
+                    placeholder="e.g. Lease Agreement"
+                    value={fileName}
+                    onChange={(e) => setFileName(e.target.value)}
+                  />
+                </label>
+                <label className="block text-sm font-medium text-gray-700">
+                  Notes
+                  <textarea
+                    className="mt-1 w-full rounded border p-2 text-sm"
+                    placeholder="Add any relevant context"
+                    rows={3}
+                    value={notes}
+                    onChange={(e) => setNotes(e.target.value)}
+                  />
+                </label>
+                <label className="block text-sm font-medium text-gray-700">
+                  Links
+                  <textarea
+                    className="mt-1 w-full rounded border p-2 text-sm"
+                    placeholder="Paste any related URLs (separate with commas or line breaks)"
+                    rows={2}
+                    value={links}
+                    onChange={(e) => setLinks(e.target.value)}
+                  />
+                </label>
+              </div>
+              <div className="flex items-center justify-between pt-2 text-xs text-gray-500">
+                <span>Upload date will be recorded automatically.</span>
+              </div>
+              <div className="relative flex justify-end gap-2 pt-2">
                 <button
                   className="rounded bg-gray-100 px-2 py-1"
+                  disabled={isSubmitting}
                   onClick={() => {
-                    setFile(null);
-                    onClose();
+                    handleClose();
                   }}
                 >
                   Cancel
                 </button>
                 <button
-                  className="rounded bg-blue-600 px-2 py-1 text-white disabled:opacity-60"
-                  disabled={!file}
+                  className="rounded bg-blue-600 px-3 py-1 text-white disabled:opacity-60"
+                  disabled={!file || !fileName.trim() || isSubmitting || showSuccess}
                   onClick={handleUpload}
                 >
-                  Upload
+                  {showSuccess ? "Saved" : isSubmitting ? "Uploading..." : "Upload"}
                 </button>
+                <AnimatePresence>
+                  {showSuccess && (
+                    <motion.div
+                      key="upload-success"
+                      initial={{ opacity: 0, x: 12, scale: 0.95 }}
+                      animate={{ opacity: 1, x: 0, scale: 1 }}
+                      exit={{ opacity: 0, x: 12, scale: 0.95 }}
+                      transition={{ duration: 0.2 }}
+                      className="absolute -right-2 top-full mt-2 flex items-center gap-1 rounded-full bg-green-100 px-3 py-1 text-xs font-medium text-green-700 shadow"
+                      role="status"
+                      aria-live="polite"
+                    >
+                      <span aria-hidden>✓</span>
+                      <span>Document saved to Documents tab</span>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
               </div>
             </motion.div>
           </motion.div>

--- a/components/PropertyDocumentsTable.tsx
+++ b/components/PropertyDocumentsTable.tsx
@@ -23,28 +23,56 @@ export default function PropertyDocumentsTable({
       <table className="min-w-full">
         <thead>
           <tr>
-            <th className="p-2 text-left">Name</th>
-            <th className="p-2 text-left">Uploaded</th>
-            <th className="p-2 text-left">Link</th>
+            <th className="p-2 text-left">File Name</th>
+            <th className="p-2 text-left">Notes</th>
+            <th className="p-2 text-left">Links</th>
+            <th className="p-2 text-left">Upload Date</th>
           </tr>
         </thead>
         <tbody>
-          {data.map((d) => (
-            <tr key={d.id} className="border-t border-[var(--border)]">
-              <td className="p-2">{d.name}</td>
-              <td className="p-2">{formatShortDate(d.uploaded)}</td>
-              <td className="p-2">
-                <a
-                  href={d.url}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="text-[var(--primary)] underline"
-                >
-                  View
-                </a>
-              </td>
-            </tr>
-          ))}
+          {data.map((d) => {
+            const displayName = d.name?.trim() || d.title?.trim();
+            return (
+              <tr key={d.id} className="border-t border-[var(--border)]">
+                <td className="p-2 align-top font-medium">
+                  {displayName ?? "Untitled document"}
+                </td>
+                <td className="p-2 align-top text-sm text-gray-600 whitespace-pre-line">
+                  {d.notes ? d.notes : "—"}
+                </td>
+                <td className="p-2 align-top text-sm">
+                  <div className="flex flex-col gap-1">
+                    {d.url ? (
+                      <a
+                        href={d.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-[var(--primary)] underline"
+                      >
+                        Open document
+                      </a>
+                    ) : (
+                      <span className="text-gray-500">—</span>
+                    )}
+                    {(d.links ?? []).map((link) => (
+                      <a
+                        key={link}
+                        href={link}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-[var(--primary)] underline"
+                      >
+                        {link}
+                      </a>
+                    ))}
+                  </div>
+                </td>
+                <td className="p-2 align-top text-sm text-gray-600">
+                  {formatShortDate(d.uploadedAt ?? d.uploaded)}
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -447,6 +447,9 @@ export interface DocumentRecord {
   propertyId?: string;
   tag: string;
   url: string;
+  notes?: string;
+  links?: string[];
+  uploadedAt?: string;
 }
 
 export const listDocuments = (params?: {
@@ -468,6 +471,9 @@ export const createDocument = (payload: {
   title: string;
   tag: string;
   propertyId?: string;
+  notes?: string;
+  links?: string[];
+  uploadedAt?: string;
 }) =>
   api<DocumentRecord>('/documents', {
     method: 'POST',

--- a/types/document.ts
+++ b/types/document.ts
@@ -12,4 +12,7 @@ export interface DocumentItem {
   title: string;
   url: string;
   tag: DocumentTag;
+  notes?: string;
+  links?: string[];
+  uploadedAt?: string;
 }

--- a/types/property.ts
+++ b/types/property.ts
@@ -33,5 +33,9 @@ export interface PropertyDocument {
   name: string;
   url: string;
   uploaded: string;
+  title?: string;
+  notes?: string;
+  links?: string[];
+  uploadedAt?: string;
 }
 


### PR DESCRIPTION
## Summary
- persist notes, links, and uploaded timestamps when creating property documents via the API
- seed demo documents with upload dates so the documents table can display meaningful timestamps

## Testing
- npm run test:unit -- --runInBand *(fails: vitest not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df282b4774832c998bca3b07e9dcf1