### PR TITLE
Remove lease start card

### DIFF
--- a/app/(app)/properties/[id]/components/PropertyHero.tsx
+++ b/app/(app)/properties/[id]/components/PropertyHero.tsx
@@ -75,7 +75,6 @@ export default function PropertyHero({
       value: rentDisplay === "—" ? rentDisplay : `${rentDisplay}/week`,
       tabId: "rent-ledger",
     },
-    { label: "Lease start", value: formatDate(property.leaseStart), tabId: "documents" },
     { label: "Lease end", value: formatDate(property.leaseEnd), tabId: "documents" },
   ];
 


### PR DESCRIPTION
## Summary
- remove the lease start summary item from the property hero so only rent/week and lease end remain side-by-side

## Testing
- npm run dev *(fails: next executable missing in the environment)*


------
https://chatgpt.com/codex/tasks/task_e_68df3e53d27c832cbfd672bccc4b285c