### PR TITLE
Connect edit property button to modal form

### DIFF
--- a/app/(app)/properties/[id]/components/PropertyHero.tsx
+++ b/app/(app)/properties/[id]/components/PropertyHero.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState, type KeyboardEvent } from "react";
-import PropertyEditModal from "../../../../../components/PropertyEditModal";
+import { type KeyboardEvent } from "react";
 import type { PropertySummary } from "../../../../../types/property";
 import { Button } from "../../../../../components/ui/button";
 import { type PropertyTabId } from "../tabs";
@@ -16,6 +15,7 @@ interface PropertyHeroProps {
   onAddExpense: () => void;
   onUploadDocument: () => void;
   onNavigateToTab: (tabId: PropertyTabId) => void;
+  onEditProperty: () => void;
 }
 
 const rentFormatter = new Intl.NumberFormat(undefined, {
@@ -53,15 +53,10 @@ export default function PropertyHero({
   onAddExpense,
   onUploadDocument,
   onNavigateToTab,
+  onEditProperty,
 }: PropertyHeroProps) {
   const imageSrc = property.imageUrl || "/default-house.svg";
   const sortedEvents = sortPropertyEvents(property.events);
-
-  const [isEditOpen, setIsEditOpen] = useState(false);
-
-  useEffect(() => {
-    setIsEditOpen(false);
-  }, [property.id]);
 
   const rentDisplay = formatRent(property.rent);
 
@@ -109,7 +104,7 @@ export default function PropertyHero({
           <Button
             type="button"
             variant="secondary"
-            onClick={() => setIsEditOpen(true)}
+            onClick={onEditProperty}
             aria-haspopup="dialog"
             className="pointer-events-auto bg-white/90 text-sm font-semibold text-gray-900 shadow-sm hover:bg-white"
           >
@@ -158,11 +153,6 @@ export default function PropertyHero({
           onUploadDocument={onUploadDocument}
         />
       </div>
-      <PropertyEditModal
-        property={property}
-        open={isEditOpen}
-        onClose={() => setIsEditOpen(false)}
-      />
     </section>
   );
 }

--- a/app/(app)/properties/[id]/page.tsx
+++ b/app/(app)/properties/[id]/page.tsx
@@ -11,6 +11,7 @@ import { getProperty, listProperties } from "../../../../lib/api";
 import type { PropertySummary } from "../../../../types/property";
 import { useURLState } from "../../../../lib/useURLState";
 import PropertyHero from "./components/PropertyHero";
+import PropertyEditModal from "../../../../components/PropertyEditModal";
 import ScrollableSectionBar from "./components/ScrollableSectionBar";
 import RentLedger from "./sections/RentLedger";
 import Expenses from "./sections/Expenses";
@@ -40,6 +41,7 @@ export default function PropertyPage() {
   const [incomeOpen, setIncomeOpen] = useState(false);
   const [expenseOpen, setExpenseOpen] = useState(false);
   const [documentOpen, setDocumentOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
   const [isRedirecting, setIsRedirecting] = useState(false);
 
   const hasValidId = typeof id === "string" && id.length > 0;
@@ -156,6 +158,7 @@ export default function PropertyPage() {
                   onAddExpense={() => setExpenseOpen(true)}
                   onUploadDocument={() => setDocumentOpen(true)}
                   onNavigateToTab={handleNavigateToTab}
+                  onEditProperty={() => setEditOpen(true)}
                 />
               </div>
               <div>
@@ -184,6 +187,11 @@ export default function PropertyPage() {
             <IncomeForm propertyId={id} open={incomeOpen} onOpenChange={setIncomeOpen} showTrigger={false} />
             <ExpenseForm propertyId={id} open={expenseOpen} onOpenChange={setExpenseOpen} showTrigger={false} />
             <DocumentUploadModal propertyId={id} open={documentOpen} onClose={() => setDocumentOpen(false)} />
+            <PropertyEditModal
+              property={property}
+              open={editOpen}
+              onClose={() => setEditOpen(false)}
+            />
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- open the existing property edit modal from the page and wire the hero button to trigger it
- pass the edit handler through PropertyHero so the modal uses the shared form

## Testing
- npm run lint *(fails: ESLint couldn't find configuration file in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df41fbf464832caf0b2fbdce1c956b