### PR TITLE
Fix document tag display and align dark theme styles

### DIFF
--- a/app/(app)/documents/page.tsx
+++ b/app/(app)/documents/page.tsx
@@ -7,8 +7,8 @@ import DocumentsHub from "../../../components/DocumentsHub";
 export default function DocumentsPage() {
   const [refresh, setRefresh] = useState(0);
   return (
-    <main className="p-4 space-y-4">
-      <h1 className="text-2xl font-bold">Documents</h1>
+    <main className="space-y-4 p-4 text-slate-900 dark:text-slate-100">
+      <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">Documents</h1>
       <DocumentUpload onUploaded={() => setRefresh((r) => r + 1)} />
       <DocumentsHub refresh={refresh} />
     </main>

--- a/app/api/store.ts
+++ b/app/api/store.ts
@@ -34,15 +34,13 @@ export type Income = {
   evidenceUrl?: string;
   evidenceName?: string;
 };
-import { DocumentTag } from '../../types/document';
-
 export type Document = {
   id: string;
   propertyId?: string;
   tenantId?: string;
   title: string;
   url: string;
-  tag: DocumentTag;
+  tag: string;
   notes?: string;
   links?: string[];
   uploadedAt?: string;
@@ -1452,7 +1450,7 @@ const initialDocuments: Document[] = [
     propertyId: '1',
     title: 'lease.pdf',
     url: '/docs/lease-prop1.pdf',
-    tag: DocumentTag.Lease,
+    tag: 'Lease',
     uploadedAt: '2023-02-01T09:30:00.000Z',
   },
   {
@@ -1460,7 +1458,7 @@ const initialDocuments: Document[] = [
     propertyId: '2',
     title: 'inspection.pdf',
     url: '/docs/inspection-prop2.pdf',
-    tag: DocumentTag.Compliance,
+    tag: 'Compliance',
     uploadedAt: '2023-05-18T14:10:00.000Z',
   },
   {
@@ -1468,7 +1466,7 @@ const initialDocuments: Document[] = [
     propertyId: '1',
     title: 'invoice.pdf',
     url: '/docs/invoice-prop1.pdf',
-    tag: DocumentTag.Other,
+    tag: 'Other',
     uploadedAt: '2023-03-22T11:45:00.000Z',
   },
   {
@@ -1476,7 +1474,7 @@ const initialDocuments: Document[] = [
     propertyId: '3',
     title: 'insurance.pdf',
     url: '/docs/insurance-prop3.pdf',
-    tag: DocumentTag.Insurance,
+    tag: 'Insurance',
     uploadedAt: '2022-12-15T16:20:00.000Z',
   },
 ];

--- a/components/DocumentUpload.tsx
+++ b/components/DocumentUpload.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { listProperties, uploadFile, createDocument } from "../lib/api";
 import { logEvent } from "../lib/log";
-import { DocumentTag } from "../types/document";
+import { useDocumentTags } from "../hooks/useDocumentTags";
 import type { PropertySummary } from "../types/summary";
 
 interface Props {
@@ -12,15 +12,34 @@ interface Props {
 
 export default function DocumentUpload({ onUploaded }: Props) {
   const [propertyId, setPropertyId] = useState("");
-  const [tag, setTag] = useState<DocumentTag>(DocumentTag.Other);
+  const [tag, setTag] = useState("");
+  const [newTagName, setNewTagName] = useState("");
   const [properties, setProperties] = useState<PropertySummary[]>([]);
+  const { tags, addTag } = useDocumentTags();
+
+  const fallbackTag = useMemo(() => {
+    if (tags.length === 0) return "";
+    const otherTag = tags.find((value) => value.toLowerCase() === "other");
+    return otherTag ?? tags[0];
+  }, [tags]);
 
   useEffect(() => {
     listProperties().then(setProperties);
   }, []);
 
+  useEffect(() => {
+    if (!tag && fallbackTag) {
+      setTag(fallbackTag);
+      return;
+    }
+
+    if (tag && !tags.some((value) => value.toLowerCase() === tag.toLowerCase())) {
+      setTag(fallbackTag);
+    }
+  }, [fallbackTag, tag, tags]);
+
   const handleFiles = async (files: FileList | null) => {
-    if (!files || files.length === 0) return;
+    if (!files || files.length === 0 || !tag) return;
     const file = files[0];
     const { url } = await uploadFile(file);
     await createDocument({
@@ -39,12 +58,15 @@ export default function DocumentUpload({ onUploaded }: Props) {
     handleFiles(e.dataTransfer.files);
   };
 
+  const controlStyles =
+    "rounded border border-slate-300 bg-white p-1 text-sm text-slate-900 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100";
+
   return (
-    <div className="space-y-2">
-      <div className="flex gap-2">
+    <div className="space-y-2 text-slate-900 dark:text-slate-100">
+      <div className="flex flex-wrap gap-2">
         <select
           aria-label="Property"
-          className="border p-1"
+          className={`${controlStyles} min-w-[160px] h-10`}
           value={propertyId}
           onChange={(e) => setPropertyId(e.target.value)}
         >
@@ -57,27 +79,63 @@ export default function DocumentUpload({ onUploaded }: Props) {
         </select>
         <select
           aria-label="Tag"
-          className="border p-1"
+          className={`${controlStyles} min-w-[140px] h-10`}
           value={tag}
-          onChange={(e) => setTag(e.target.value as DocumentTag)}
+          onChange={(e) => setTag(e.target.value)}
         >
-          {Object.values(DocumentTag).map((t) => (
-            <option key={t} value={t}>
-              {t}
+          <option value="" disabled>
+            Select a tag
+          </option>
+          {tags.map((value) => (
+            <option key={value} value={value}>
+              {value}
             </option>
           ))}
         </select>
+        <div className="flex flex-1 min-w-[200px] gap-2">
+          <input
+            type="text"
+            className={`${controlStyles} flex-1 h-10`}
+            placeholder="Create a new tag"
+            value={newTagName}
+            onChange={(e) => setNewTagName(e.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                const created = addTag(newTagName);
+                if (created) {
+                  setTag(created);
+                  setNewTagName("");
+                }
+              }
+            }}
+          />
+          <button
+            type="button"
+            className="inline-flex h-10 items-center justify-center rounded border border-slate-300 bg-slate-100 px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-200 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
+            onClick={() => {
+              const created = addTag(newTagName);
+              if (created) {
+                setTag(created);
+                setNewTagName("");
+              }
+            }}
+            disabled={!newTagName.trim()}
+          >
+            Add tag
+          </button>
+        </div>
       </div>
       <div
         onDrop={handleDrop}
         onDragOver={(e) => e.preventDefault()}
-        className="border-2 border-dashed p-4 text-center"
+        className="rounded border-2 border-dashed border-slate-300 p-4 text-center text-sm text-slate-600 dark:border-slate-700 dark:text-slate-300"
       >
-        Drag & drop to upload
+        Drag &amp; drop to upload
         <input
           type="file"
           data-testid="doc-upload"
-          className="block mx-auto mt-2"
+          className="mx-auto mt-2 block text-slate-900 dark:text-slate-100"
           onChange={(e) => handleFiles(e.target.files)}
         />
       </div>

--- a/components/DocumentUploadModal.tsx
+++ b/components/DocumentUploadModal.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { useQueryClient } from "@tanstack/react-query";
 import { createPortal } from "react-dom";
 import { uploadFile, createDocument } from "../lib/api";
-import { DocumentTag } from "../types/document";
+import { useDocumentTags } from "../hooks/useDocumentTags";
 import ModalPortal from "./ModalPortal";
 
 interface Props {
@@ -19,20 +19,45 @@ export default function DocumentUploadModal({ open, onClose, propertyId }: Props
   const [fileName, setFileName] = useState("");
   const [notes, setNotes] = useState("");
   const [links, setLinks] = useState("");
+  const [selectedTag, setSelectedTag] = useState("");
+  const [newTagName, setNewTagName] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
   const [portalTarget, setPortalTarget] = useState<Element | null>(null);
   const queryClient = useQueryClient();
   const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const { tags, addTag } = useDocumentTags();
+
+  const fallbackTag = useMemo(() => {
+    if (tags.length === 0) return "";
+    const otherTag = tags.find((tag) => tag.toLowerCase() === "other");
+    return otherTag ?? tags[0];
+  }, [tags]);
 
   const resetUploadState = useCallback(() => {
     setFile(null);
     setFileName("");
     setNotes("");
     setLinks("");
+    setSelectedTag(fallbackTag);
+    setNewTagName("");
     setIsSubmitting(false);
     setShowSuccess(false);
-  }, []);
+  }, [fallbackTag]);
+
+  useEffect(() => {
+    if (!selectedTag && fallbackTag) {
+      setSelectedTag(fallbackTag);
+      return;
+    }
+
+    if (
+      selectedTag &&
+      !tags.some((tag) => tag.toLowerCase() === selectedTag.toLowerCase())
+    ) {
+      setSelectedTag(fallbackTag);
+    }
+  }, [fallbackTag, selectedTag, tags]);
 
   const handleClose = useCallback(() => {
     if (closeTimer.current) {
@@ -79,7 +104,7 @@ export default function DocumentUploadModal({ open, onClose, propertyId }: Props
   }, [handleClose]);
 
   const handleUpload = async () => {
-    if (!file || !fileName.trim() || isSubmitting) return;
+    if (!file || !fileName.trim() || !selectedTag || isSubmitting) return;
     setIsSubmitting(true);
     try {
       const { url } = await uploadFile(file);
@@ -90,13 +115,12 @@ export default function DocumentUploadModal({ open, onClose, propertyId }: Props
       await createDocument({
         url,
         title: fileName.trim(),
-        tag: DocumentTag.Other,
+        tag: selectedTag,
         propertyId,
         notes: notes.trim() || undefined,
         links: parsedLinks.length > 0 ? parsedLinks : undefined,
         uploadedAt: new Date().toISOString(),
       });
-      // Refresh any document queries for this property
       if (propertyId) {
         queryClient.invalidateQueries({ queryKey: ["documents", propertyId] });
       }
@@ -117,6 +141,9 @@ export default function DocumentUploadModal({ open, onClose, propertyId }: Props
 
   if (!portalTarget) return null;
 
+  const inputStyles =
+    "mt-1 w-full rounded border border-slate-300 bg-white p-2 text-sm text-slate-900 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100";
+
   return createPortal(
     <AnimatePresence>
       {open && (
@@ -132,7 +159,7 @@ export default function DocumentUploadModal({ open, onClose, propertyId }: Props
             transition={{ duration: 0.2 }}
           >
             <motion.div
-              className="w-full max-w-md space-y-4 rounded-xl bg-white p-6 shadow-lg"
+              className="w-full max-w-md space-y-4 rounded-xl bg-white p-6 shadow-lg dark:bg-slate-900 dark:text-slate-100"
               onClick={(e) => e.stopPropagation()}
               initial={{ opacity: 0, y: 16, scale: 0.96 }}
               animate={{ opacity: 1, y: 0, scale: 1 }}
@@ -141,16 +168,16 @@ export default function DocumentUploadModal({ open, onClose, propertyId }: Props
             >
               <div className="space-y-1">
                 <h2 className="text-lg font-semibold">Upload Document</h2>
-                <p className="text-sm text-gray-500">
+                <p className="text-sm text-slate-500 dark:text-slate-400">
                   Add details to keep everything organised for this property.
                 </p>
               </div>
               <div className="space-y-4">
-                <label className="block text-sm font-medium text-gray-700">
+                <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">
                   Document File
                   <input
                     type="file"
-                    className="mt-1 w-full rounded border p-2 text-sm"
+                    className={`${inputStyles} cursor-pointer`}
                     onChange={(e) => {
                       const selected = e.target.files?.[0] || null;
                       setFile(selected);
@@ -160,30 +187,82 @@ export default function DocumentUploadModal({ open, onClose, propertyId }: Props
                     }}
                   />
                 </label>
-                <label className="block text-sm font-medium text-gray-700">
+                <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">
                   File Name
                   <input
                     type="text"
-                    className="mt-1 w-full rounded border p-2 text-sm"
+                    className={inputStyles}
                     placeholder="e.g. Lease Agreement"
                     value={fileName}
                     onChange={(e) => setFileName(e.target.value)}
                   />
                 </label>
-                <label className="block text-sm font-medium text-gray-700">
+                <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">
+                  Tag
+                  <div className="mt-1 space-y-2">
+                    <select
+                      className={inputStyles}
+                      value={selectedTag}
+                      onChange={(e) => setSelectedTag(e.target.value)}
+                    >
+                      <option value="" disabled>
+                        Select a tag
+                      </option>
+                      {tags.map((tag) => (
+                        <option key={tag} value={tag}>
+                          {tag}
+                        </option>
+                      ))}
+                    </select>
+                    <div className="flex flex-col gap-2 sm:flex-row">
+                      <input
+                        type="text"
+                        className={`${inputStyles} h-10 sm:flex-1`}
+                        placeholder="Create a new tag"
+                        value={newTagName}
+                        onChange={(e) => setNewTagName(e.target.value)}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter") {
+                            event.preventDefault();
+                            const created = addTag(newTagName);
+                            if (created) {
+                              setSelectedTag(created);
+                              setNewTagName("");
+                            }
+                          }
+                        }}
+                      />
+                      <button
+                        type="button"
+                        className="inline-flex h-10 items-center justify-center rounded border border-slate-300 bg-slate-100 px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-200 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
+                        onClick={() => {
+                          const created = addTag(newTagName);
+                          if (created) {
+                            setSelectedTag(created);
+                            setNewTagName("");
+                          }
+                        }}
+                        disabled={!newTagName.trim()}
+                      >
+                        Add tag
+                      </button>
+                    </div>
+                  </div>
+                </label>
+                <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">
                   Notes
                   <textarea
-                    className="mt-1 w-full rounded border p-2 text-sm"
+                    className={inputStyles}
                     placeholder="Add any relevant context"
                     rows={3}
                     value={notes}
                     onChange={(e) => setNotes(e.target.value)}
                   />
                 </label>
-                <label className="block text-sm font-medium text-gray-700">
+                <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">
                   Links
                   <textarea
-                    className="mt-1 w-full rounded border p-2 text-sm"
+                    className={inputStyles}
                     placeholder="Paste any related URLs (separate with commas or line breaks)"
                     rows={2}
                     value={links}
@@ -191,12 +270,12 @@ export default function DocumentUploadModal({ open, onClose, propertyId }: Props
                   />
                 </label>
               </div>
-              <div className="flex items-center justify-between pt-2 text-xs text-gray-500">
+              <div className="flex items-center justify-between pt-2 text-xs text-slate-500 dark:text-slate-400">
                 <span>Upload date will be recorded automatically.</span>
               </div>
               <div className="relative flex justify-end gap-2 pt-2">
                 <button
-                  className="rounded bg-gray-100 px-2 py-1"
+                  className="rounded border border-slate-300 bg-slate-100 px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-200 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
                   disabled={isSubmitting}
                   onClick={() => {
                     handleClose();
@@ -205,8 +284,8 @@ export default function DocumentUploadModal({ open, onClose, propertyId }: Props
                   Cancel
                 </button>
                 <button
-                  className="rounded bg-blue-600 px-3 py-1 text-white disabled:opacity-60"
-                  disabled={!file || !fileName.trim() || isSubmitting || showSuccess}
+                  className="rounded bg-blue-600 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-0 dark:bg-blue-500 dark:hover:bg-blue-400 disabled:opacity-60"
+                  disabled={!file || !fileName.trim() || !selectedTag || isSubmitting || showSuccess}
                   onClick={handleUpload}
                 >
                   {showSuccess ? "Saved" : isSubmitting ? "Uploading..." : "Upload"}
@@ -219,7 +298,7 @@ export default function DocumentUploadModal({ open, onClose, propertyId }: Props
                       animate={{ opacity: 1, x: 0, scale: 1 }}
                       exit={{ opacity: 0, x: 12, scale: 0.95 }}
                       transition={{ duration: 0.2 }}
-                      className="absolute -right-2 top-full mt-2 flex items-center gap-1 rounded-full bg-green-100 px-3 py-1 text-xs font-medium text-green-700 shadow"
+                      className="absolute -right-2 top-full mt-2 flex items-center gap-1 rounded-full bg-green-100 px-3 py-1 text-xs font-medium text-green-700 shadow dark:bg-green-900 dark:text-green-200"
                       role="status"
                       aria-live="polite"
                     >

--- a/components/DocumentsHub.tsx
+++ b/components/DocumentsHub.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { listDocuments, listProperties, type DocumentRecord } from "../lib/api";
-import { DocumentTag } from "../types/document";
+import { useDocumentTags } from "../hooks/useDocumentTags";
 import type { PropertySummary } from "../types/summary";
 
 interface Props {
@@ -15,6 +15,7 @@ export default function DocumentsHub({ refresh }: Props) {
   const [propertyId, setPropertyId] = useState("");
   const [tag, setTag] = useState("");
   const [properties, setProperties] = useState<PropertySummary[]>([]);
+  const { tags } = useDocumentTags();
 
   useEffect(() => {
     listProperties().then(setProperties);
@@ -24,22 +25,59 @@ export default function DocumentsHub({ refresh }: Props) {
     listDocuments({ propertyId, tag, query: search }).then(setDocs);
   }, [propertyId, tag, search, refresh]);
 
-  const propertyMap = Object.fromEntries(
-    properties.map((p) => [p.id, p.address])
+  const availableTags = useMemo(() => {
+    const entries = new Map<string, string>();
+
+    tags.forEach((value) => {
+      const normalized = value.trim();
+      if (!normalized) return;
+      const key = normalized.toLowerCase();
+      if (!entries.has(key)) {
+        entries.set(key, normalized);
+      }
+    });
+
+    docs.forEach((doc) => {
+      const normalized = doc.tag?.trim();
+      if (!normalized) return;
+      const key = normalized.toLowerCase();
+      if (!entries.has(key)) {
+        entries.set(key, normalized);
+      }
+    });
+
+    return Array.from(entries.values());
+  }, [docs, tags]);
+
+  useEffect(() => {
+    if (
+      tag &&
+      !availableTags.some((value) => value.toLowerCase() === tag.toLowerCase())
+    ) {
+      setTag("");
+    }
+  }, [availableTags, tag]);
+
+  const propertyMap = useMemo(
+    () => Object.fromEntries(properties.map((p) => [p.id, p.address])),
+    [properties]
   );
 
+  const controlStyles =
+    "rounded border border-slate-300 bg-white p-2 text-sm text-slate-900 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100";
+
   return (
-    <div className="space-y-4">
-      <div className="flex gap-2">
+    <div className="space-y-4 text-slate-900 dark:text-slate-100">
+      <div className="flex flex-wrap gap-2">
         <input
           placeholder="Search documents"
-          className="border p-1 flex-1"
+          className={`${controlStyles} flex-1 min-w-[200px]`}
           value={search}
           onChange={(e) => setSearch(e.target.value)}
         />
         <select
           aria-label="Property filter"
-          className="border p-1"
+          className={`${controlStyles} min-w-[180px]`}
           value={propertyId}
           onChange={(e) => setPropertyId(e.target.value)}
         >
@@ -52,14 +90,14 @@ export default function DocumentsHub({ refresh }: Props) {
         </select>
         <select
           aria-label="Tag filter"
-          className="border p-1"
+          className={`${controlStyles} min-w-[160px]`}
           value={tag}
           onChange={(e) => setTag(e.target.value)}
         >
           <option value="">All Tags</option>
-          {Object.values(DocumentTag).map((t) => (
-            <option key={t} value={t}>
-              {t}
+          {availableTags.map((value) => (
+            <option key={value} value={value}>
+              {value}
             </option>
           ))}
         </select>
@@ -68,22 +106,30 @@ export default function DocumentsHub({ refresh }: Props) {
         {docs.map((doc) => (
           <div
             key={doc.id}
-            className="flex justify-between border p-2 rounded"
+            className="rounded-lg border border-slate-200 bg-white p-3 shadow-sm dark:border-slate-700 dark:bg-slate-900"
           >
-            <a
-              href={doc.url}
-              target="_blank"
-              rel="noreferrer"
-              className="underline text-blue-600"
-            >
-              {doc.title}
-            </a>
-            <span className="text-xs text-gray-600">
-              {propertyMap[doc.propertyId ?? ""]} - {doc.tag}
-            </span>
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <a
+                href={doc.url}
+                target="_blank"
+                rel="noreferrer"
+                className="text-sm font-medium text-blue-600 underline hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300"
+              >
+                {doc.title}
+              </a>
+              <span className="inline-flex w-fit items-center rounded-full bg-slate-100 px-2 py-1 text-xs font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-200">
+                {doc.tag?.trim() || "Other"}
+              </span>
+            </div>
+            <div className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+              {propertyMap[doc.propertyId ?? ""] ?? "General"}
+              {doc.uploadedAt ? ` • ${new Date(doc.uploadedAt).toLocaleDateString()}` : ""}
+            </div>
           </div>
         ))}
-        {docs.length === 0 && <p>No documents found</p>}
+        {docs.length === 0 && (
+          <p className="text-sm text-slate-500 dark:text-slate-400">No documents found</p>
+        )}
       </div>
     </div>
   );

--- a/hooks/useDocumentTags.ts
+++ b/hooks/useDocumentTags.ts
@@ -1,0 +1,138 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { DEFAULT_DOCUMENT_TAGS } from "../types/document";
+
+const STORAGE_KEY = "proptech-document-tags";
+const TAG_UPDATE_EVENT = "document-tags:update";
+
+const normalizeTag = (value: string) => {
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+
+  return trimmed
+    .replace(/\s+/g, " ")
+    .split(" ")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(" ");
+};
+
+const parseStoredTags = (raw: string | null) => {
+  if (!raw) return [] as string[];
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed
+        .filter((tag): tag is string => typeof tag === "string" && tag.trim().length > 0)
+        .map(normalizeTag);
+    }
+  } catch (error) {
+    console.warn("Failed to parse stored document tags", error);
+  }
+  return [] as string[];
+};
+
+const persistCustomTags = (tags: string[]) => {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(tags));
+  window.dispatchEvent(
+    new CustomEvent<string[]>(TAG_UPDATE_EVENT, { detail: [...tags] })
+  );
+};
+
+export function useDocumentTags() {
+  const [customTags, setCustomTags] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    setCustomTags(parseStoredTags(window.localStorage.getItem(STORAGE_KEY)));
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === STORAGE_KEY) {
+        setCustomTags(parseStoredTags(event.newValue));
+      }
+    };
+
+    const handleCustomUpdate = (event: Event) => {
+      const detail = (event as CustomEvent<string[]>).detail;
+      if (Array.isArray(detail)) {
+        setCustomTags(detail.map(normalizeTag));
+      }
+    };
+
+    window.addEventListener("storage", handleStorage);
+    window.addEventListener(TAG_UPDATE_EVENT, handleCustomUpdate as EventListener);
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+      window.removeEventListener(TAG_UPDATE_EVENT, handleCustomUpdate as EventListener);
+    };
+  }, []);
+
+  const tags = useMemo(() => {
+    const seen = new Set<string>();
+    const combined: string[] = [];
+
+    DEFAULT_DOCUMENT_TAGS.forEach((tag) => {
+      const key = tag.toLowerCase();
+      if (!seen.has(key)) {
+        seen.add(key);
+        combined.push(tag);
+      }
+    });
+
+    [...customTags]
+      .sort((a, b) => a.localeCompare(b))
+      .forEach((tag) => {
+        const normalized = normalizeTag(tag);
+        const key = normalized.toLowerCase();
+        if (!seen.has(key)) {
+          seen.add(key);
+          combined.push(normalized);
+        }
+      });
+
+    return combined;
+  }, [customTags]);
+
+  const addTag = useCallback((value: string) => {
+    if (typeof window === "undefined") return undefined;
+
+    const normalizedInput = normalizeTag(value);
+    if (!normalizedInput) return undefined;
+
+    const defaultMatch = DEFAULT_DOCUMENT_TAGS.find(
+      (tag) => tag.toLowerCase() === normalizedInput.toLowerCase()
+    );
+    if (defaultMatch) {
+      return defaultMatch;
+    }
+
+    let result = normalizedInput;
+
+    setCustomTags((prev) => {
+      const exists = prev.find(
+        (tag) => tag.toLowerCase() === normalizedInput.toLowerCase()
+      );
+
+      if (exists) {
+        result = exists;
+        return prev;
+      }
+
+      const next = [...prev, normalizedInput].sort((a, b) => a.localeCompare(b));
+      result = normalizedInput;
+      persistCustomTags(next);
+      return next;
+    });
+
+    return result;
+  }, []);
+
+  return { tags, addTag } as const;
+}
+

--- a/types/document.ts
+++ b/types/document.ts
@@ -1,10 +1,12 @@
-export enum DocumentTag {
-  Lease = 'Lease',
-  Expense = 'Expense',
-  Compliance = 'Compliance',
-  Insurance = 'Insurance',
-  Other = 'Other',
-}
+export const DEFAULT_DOCUMENT_TAGS = [
+  'Lease',
+  'Expense',
+  'Compliance',
+  'Insurance',
+  'Other',
+] as const;
+
+export type DocumentTag = string;
 
 export interface DocumentItem {
   id: string;


### PR DESCRIPTION
## Summary
- surface newly created document tags in the documents hub by merging stored tags with those on existing documents
- adjust the document upload form controls for dark theme legibility and matching button/input heights
- ensure the documents page inherits dark mode text colors for consistent readability

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68df410d6b0c832c8caec125a45426c3