### PR TITLE
Remove property hero edit button

### DIFF
--- a/app/(app)/properties/[id]/components/PropertyHero.tsx
+++ b/app/(app)/properties/[id]/components/PropertyHero.tsx
@@ -3,7 +3,6 @@
 import Link from "next/link";
 import { type KeyboardEvent } from "react";
 import type { PropertySummary } from "../../../../../types/property";
-import { Button } from "../../../../../components/ui/button";
 import { type PropertyTabId } from "../tabs";
 import { sortPropertyEvents } from "../lib/sortEvents";
 import ActionButtons from "./ActionButtons";
@@ -53,7 +52,7 @@ export default function PropertyHero({
   onAddExpense,
   onUploadDocument,
   onNavigateToTab,
-  onEditProperty,
+  onEditProperty: _onEditProperty,
 }: PropertyHeroProps) {
   const imageSrc = property.imageUrl || "/default-house.svg";
   const sortedEvents = sortPropertyEvents(property.events);
@@ -100,17 +99,6 @@ export default function PropertyHero({
           aria-hidden="true"
           className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/5 to-black/0"
         />
-        <div className="pointer-events-none absolute inset-0 z-20 flex items-start justify-end p-4">
-          <Button
-            type="button"
-            variant="secondary"
-            onClick={onEditProperty}
-            aria-haspopup="dialog"
-            className="pointer-events-auto bg-white/90 text-sm font-semibold text-gray-900 shadow-sm hover:bg-white"
-          >
-            Edit Property
-          </Button>
-        </div>
       </div>
       <div className="space-y-6 p-6">
         <div>


### PR DESCRIPTION
## Summary
- remove the Edit Property button from the property hero card so it no longer displays in its previous position

## Testing
- npm install *(fails: registry access forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_68df48f518d4832cb686425649517e39