### PR TITLE
Integrate vendor management into property profile

### DIFF
--- a/app/(app)/properties/[id]/sections/Vendors.tsx
+++ b/app/(app)/properties/[id]/sections/Vendors.tsx
@@ -1,82 +1,85 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
-import { listVendors, type Vendor } from "../../../../../lib/api";
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import ErrorState from "../../../../../components/ErrorState";
+import Skeleton from "../../../../../components/Skeleton";
+import VendorCard from "../../../../../components/VendorCard";
+import VendorForm from "../../../../../components/VendorForm";
+import { listVendors, updateVendor, type Vendor } from "../../../../../lib/api";
 
 interface VendorsProps {
   propertyId: string;
 }
 
 export default function Vendors({ propertyId: _propertyId }: VendorsProps) {
-  const { data = [], isPending } = useQuery<Vendor[]>({
+  const queryClient = useQueryClient();
+  const { data: vendors = [], isPending, error } = useQuery<Vendor[]>({
     queryKey: ["vendors"],
     queryFn: listVendors,
   });
 
+  const update = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: Partial<Vendor> }) =>
+      updateVendor(id, data),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["vendors"] }),
+  });
+
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [editing, setEditing] = useState<Vendor | null>(null);
+
+  const handleClose = () => {
+    setDrawerOpen(false);
+    setEditing(null);
+  };
+
   return (
-    <div className="space-y-4">
-      <h2 className="text-xl font-semibold">Preferred Vendors</h2>
+    <div className="flex flex-1 flex-col gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h2 className="text-xl font-semibold">Preferred Vendors</h2>
+        <button
+          className="rounded bg-blue-600 px-3 py-1 text-sm font-medium text-white shadow-sm hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+          onClick={() => {
+            setEditing(null);
+            setDrawerOpen(true);
+          }}
+        >
+          New Vendor
+        </button>
+      </div>
       {isPending ? (
-        <div>Loading vendors...</div>
-      ) : data.length === 0 ? (
+        <Skeleton className="h-24" />
+      ) : error ? (
+        <ErrorState message={error instanceof Error ? error.message : "Failed to load vendors"} />
+      ) : vendors.length === 0 ? (
         <div className="rounded border border-dashed p-6 text-center text-gray-500">
           No vendors available
         </div>
       ) : (
         <div className="grid gap-4 md:grid-cols-2">
-          {data.map((vendor) => (
-            <div
+          {vendors.map((vendor) => (
+            <VendorCard
               key={vendor.id ?? vendor.name}
-              className="space-y-2 rounded border bg-white p-4 shadow-sm dark:border-gray-800 dark:bg-gray-900"
-            >
-              <div className="flex items-center justify-between">
-                <h3 className="text-lg font-semibold">{vendor.name}</h3>
-                {vendor.favourite && <span aria-label="Favourite vendor">★</span>}
-              </div>
-              {vendor.tags && vendor.tags.length > 0 && (
-                <div className="flex flex-wrap gap-2 text-xs">
-                  {vendor.tags.map((tag) => (
-                    <span
-                      key={tag}
-                      className="rounded-full bg-gray-100 px-2 py-1 text-gray-700 dark:bg-gray-800 dark:text-gray-200"
-                    >
-                      {tag}
-                    </span>
-                  ))}
-                </div>
-              )}
-              <div className="flex flex-wrap gap-2 text-xs text-gray-600 dark:text-gray-300">
-                <span
-                  className={`rounded-full px-2 py-1 ${
-                    vendor.insured ? "bg-green-100 text-green-700" : "bg-red-100 text-red-700"
-                  }`}
-                >
-                  {vendor.insured ? "Insured" : "Not insured"}
-                </span>
-                <span
-                  className={`rounded-full px-2 py-1 ${
-                    vendor.licensed ? "bg-green-100 text-green-700" : "bg-red-100 text-red-700"
-                  }`}
-                >
-                  {vendor.licensed ? "Licensed" : "No licence"}
-                </span>
-              </div>
-              {vendor.avgResponseTime !== undefined && (
-                <div className="text-sm text-gray-500 dark:text-gray-400">
-                  Avg response: {vendor.avgResponseTime}h
-                </div>
-              )}
-              {vendor.documents && vendor.documents.length > 0 && (
-                <div className="flex flex-wrap gap-2 text-xs text-blue-600">
-                  {vendor.documents.map((doc) => (
-                    <span key={doc} className="rounded bg-blue-100 px-2 py-1">
-                      {doc}
-                    </span>
-                  ))}
-                </div>
-              )}
-            </div>
+              vendor={vendor}
+              onEdit={() => {
+                setEditing(vendor);
+                setDrawerOpen(true);
+              }}
+              onToggleFavourite={(fav) =>
+                vendor.id &&
+                update.mutate({
+                  id: vendor.id,
+                  data: { favourite: fav },
+                })
+              }
+            />
           ))}
+        </div>
+      )}
+      {drawerOpen && (
+        <div className="fixed inset-0 z-50 flex justify-end bg-black/50">
+          <VendorForm vendor={editing || undefined} onClose={handleClose} />
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- reuse the existing vendor card and form inside the property profile vendors tab
- enable creating, editing, and favouriting vendors directly from a property profile
- add loading and error handling to match the dedicated vendors workspace

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file in this repo)*

------
https://chatgpt.com/codex/tasks/task_e_68e24d234978832c988668c341ce29f0