### PR TITLE
Ensure dashboard API respects requested date range

### DIFF
--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -99,14 +99,6 @@ export async function GET(req: Request) {
       amount: expense.amount,
     }));
 
-  const latestActivityDate = [...incomeEntries, ...expenseEntries]
-    .map((entry) => entry.date)
-    .reduce((latest, current) => (current > latest ? current : latest), '');
-
-  if (latestActivityDate && to > latestActivityDate) {
-    to = latestActivityDate;
-  }
-
   const defaultFrom = `${to.slice(0, 7)}-01`;
   let from = url.searchParams.get('from') ?? defaultFrom;
   if (from > to) {


### PR DESCRIPTION
## Summary
- allow the dashboard API to honor the requested date range so month-to-date views extend to the current date

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68e250bc5040832c890658a864d27fd3