### PR TITLE
feat: enable confirmable row actions for finance tables

### DIFF
--- a/components/ExpensesTable.tsx
+++ b/components/ExpensesTable.tsx
@@ -1,15 +1,20 @@
 "use client";
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { listExpenses, deleteExpense, listProperties } from "../lib/api";
+import {
+  createExpense,
+  deleteExpense,
+  listExpenses,
+  listProperties,
+  updateExpense,
+} from "../lib/api";
 import { formatShortDate } from "../lib/format";
 import type { ExpenseRow } from "../types/expense";
 import type { PropertySummary } from "../types/property";
 import EmptyState from "./EmptyState";
 import ExpenseForm from "./ExpenseForm";
-import ModalPortal from "./ModalPortal";
 
 function ReceiptLink({ url }: { url?: string | null }) {
   if (!url) {
@@ -44,15 +49,75 @@ export default function ExpensesTable({
   const [to, setTo] = useState("");
   const [editOpen, setEditOpen] = useState(false);
   const [editingExpense, setEditingExpense] = useState<ExpenseRow | null>(null);
-  const [deleteTarget, setDeleteTarget] = useState<ExpenseRow | null>(null);
+  const [selectedExpense, setSelectedExpense] = useState<ExpenseRow | null>(null);
+  const [detailConfirm, setDetailConfirm] = useState("");
+  const [detailVisible, setDetailVisible] = useState(false);
+  const [notification, setNotification] = useState<{
+    id: number;
+    message: string;
+    undo?: () => Promise<void> | void;
+  } | null>(null);
+  const [notificationVisible, setNotificationVisible] = useState(false);
   const [portalTarget, setPortalTarget] = useState<Element | null>(null);
   const [search, setSearch] = useState("");
+  const hideTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const removeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const notificationIdRef = useRef(0);
+  const editingSnapshotRef = useRef<ExpenseRow | null>(null);
 
   useEffect(() => {
     if (typeof document !== "undefined") {
       setPortalTarget(document.body);
     }
   }, []);
+
+  useEffect(() => {
+    if (selectedExpense) {
+      requestAnimationFrame(() => setDetailVisible(true));
+    }
+  }, [selectedExpense]);
+
+  useEffect(() => {
+    if (!notification) {
+      return () => {
+        if (hideTimeoutRef.current) {
+          clearTimeout(hideTimeoutRef.current);
+          hideTimeoutRef.current = null;
+        }
+        if (removeTimeoutRef.current) {
+          clearTimeout(removeTimeoutRef.current);
+          removeTimeoutRef.current = null;
+        }
+      };
+    }
+
+    setNotificationVisible(true);
+
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current);
+    }
+    if (removeTimeoutRef.current) {
+      clearTimeout(removeTimeoutRef.current);
+    }
+
+    hideTimeoutRef.current = setTimeout(() => {
+      setNotificationVisible(false);
+      removeTimeoutRef.current = setTimeout(() => {
+        setNotification(null);
+      }, 200);
+    }, 5000);
+
+    return () => {
+      if (hideTimeoutRef.current) {
+        clearTimeout(hideTimeoutRef.current);
+        hideTimeoutRef.current = null;
+      }
+      if (removeTimeoutRef.current) {
+        clearTimeout(removeTimeoutRef.current);
+        removeTimeoutRef.current = null;
+      }
+    };
+  }, [notification]);
 
   const params = {
     propertyId: propertyId ?? (property || undefined),
@@ -100,9 +165,6 @@ export default function ExpensesTable({
     [properties]
   );
 
-  const iconButtonClass =
-    "rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-gray-100";
-
   const editDefaults = useMemo(() => {
     if (!editingExpense) return undefined;
     return {
@@ -117,9 +179,57 @@ export default function ExpensesTable({
     };
   }, [editingExpense]);
 
+  const openDetail = (expense: ExpenseRow) => {
+    setSelectedExpense(expense);
+    setDetailConfirm("");
+  };
+
+  const closeDetail = () => {
+    setDetailVisible(false);
+    setDetailConfirm("");
+    setTimeout(() => {
+      setSelectedExpense(null);
+    }, 180);
+  };
+
+  const showNotification = (
+    message: string,
+    undo?: () => Promise<void> | void
+  ) => {
+    notificationIdRef.current += 1;
+    setNotification({ id: notificationIdRef.current, message, undo });
+  };
+
   const handleEdit = (expense: ExpenseRow) => {
+    editingSnapshotRef.current = expense;
+    closeDetail();
     setEditingExpense(expense);
     setEditOpen(true);
+  };
+
+  const handleDelete = (expense: ExpenseRow) => {
+    const expenseId = expense.id;
+    deleteMutation.mutate(expenseId, {
+      onSuccess: async (_data, _variables, context) => {
+        closeDetail();
+        const previousEntries = context?.previous ?? [];
+        const deletedEntry =
+          previousEntries.find((entry) => entry.id === expenseId) ?? expense;
+        showNotification("Expense deleted", async () => {
+          await createExpense({
+            propertyId: deletedEntry.propertyId,
+            date: deletedEntry.date,
+            category: deletedEntry.category,
+            vendor: deletedEntry.vendor,
+            amount: deletedEntry.amount,
+            gst: deletedEntry.gst,
+            notes: deletedEntry.notes,
+            label: deletedEntry.label,
+          });
+          await queryClient.invalidateQueries({ queryKey });
+        });
+      },
+    });
   };
 
   const filteredData = useMemo(() => {
@@ -148,6 +258,8 @@ export default function ExpensesTable({
 
   const filterControlClass =
     "h-10 rounded-lg border border-gray-300 bg-white px-3 text-sm text-gray-900 shadow-sm focus:border-gray-400 focus:outline-none focus:ring-1 focus:ring-gray-400 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100";
+
+  const confirmReady = detailConfirm.trim().toLowerCase() === "confirm";
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -227,12 +339,24 @@ export default function ExpensesTable({
                     <th className="p-2 text-left">GST</th>
                     <th className="p-2 text-left">Notes</th>
                     <th className="p-2 text-left">Receipt</th>
-                    <th className="p-2 text-left">Actions</th>
                   </tr>
                 </thead>
                 <tbody>
                   {filteredData.map((r) => (
-                    <tr key={r.id} className="border-t dark:border-gray-700">
+                    <tr
+                      key={r.id}
+                      className="border-t transition dark:border-gray-700 hover:bg-gray-50 focus-within:bg-gray-50 dark:hover:bg-gray-700/60 dark:focus-within:bg-gray-700/60"
+                      onClick={() => openDetail(r)}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                          event.preventDefault();
+                          openDetail(r);
+                        }
+                      }}
+                      role="button"
+                      tabIndex={0}
+                      aria-label={`View expense ${r.vendor ? `from ${r.vendor}` : ""} dated ${formatShortDate(r.date)}`.trim()}
+                    >
                       {!propertyId && (
                         <td className="p-2">{propertyMap[r.propertyId] || r.propertyId}</td>
                       )}
@@ -267,46 +391,6 @@ export default function ExpensesTable({
                       <td className="p-2">
                         <ReceiptLink url={r.receiptUrl} />
                       </td>
-                      <td className="p-2">
-                        <div className="flex items-center gap-2">
-                          <button
-                            type="button"
-                            className={iconButtonClass}
-                            onClick={() => handleEdit(r)}
-                            aria-label="Edit expense"
-                          >
-                            <svg
-                              xmlns="http://www.w3.org/2000/svg"
-                              viewBox="0 0 20 20"
-                              fill="currentColor"
-                              className="h-5 w-5"
-                            >
-                              <path d="M17.414 2.586a2 2 0 0 0-2.828 0l-1.086 1.086 2.828 2.828 1.086-1.086a2 2 0 0 0 0-2.828ZM14.57 7.5 11.672 4.672 4 12.343V15.5h3.157L14.5 7.5Z" />
-                              <path d="M2 6a2 2 0 0 1 2-2h4a1 1 0 1 1 0 2H4v10h10v-4a1 1 0 1 1 2 0v4a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6Z" />
-                            </svg>
-                          </button>
-                          <button
-                            type="button"
-                            className={`${iconButtonClass} text-red-600 hover:text-red-500 dark:text-red-400 dark:hover:text-red-300`}
-                            onClick={() => setDeleteTarget(r)}
-                            aria-label="Delete expense"
-                            disabled={deleteMutation.isPending}
-                          >
-                            <svg
-                              xmlns="http://www.w3.org/2000/svg"
-                              viewBox="0 0 20 20"
-                              fill="currentColor"
-                              className="h-5 w-5"
-                            >
-                              <path
-                                fillRule="evenodd"
-                                d="M8.75 3a1.75 1.75 0 0 0-1.744 1.602l-.035.348H4a.75.75 0 0 0 0 1.5h.532l.634 9.182A2.25 2.25 0 0 0 7.41 17.75h5.18a2.25 2.25 0 0 0 2.244-2.118L15.468 6.45H16a.75.75 0 0 0 0-1.5h-2.97l-.035-.348A1.75 1.75 0 0 0 11.25 3h-2.5ZM9.75 7a.75.75 0 0 0-1.5 0v6a.75.75 0 0 0 1.5 0V7Zm2.75-.75a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0V7a.75.75 0 0 1 .75-.75Z"
-                                clipRule="evenodd"
-                              />
-                            </svg>
-                          </button>
-                        </div>
-                      </td>
                     </tr>
                   ))}
                 </tbody>
@@ -328,58 +412,187 @@ export default function ExpensesTable({
         defaults={editDefaults}
         mode="edit"
         expenseId={editingExpense?.id}
-        onSaved={() => {
+        onSaved={(updated) => {
           queryClient.invalidateQueries({ queryKey });
+          showNotification("Expense updated", async () => {
+            const previous = editingSnapshotRef.current;
+            if (!previous) {
+              return;
+            }
+            await updateExpense(updated.id, {
+              propertyId: previous.propertyId,
+              date: previous.date,
+              category: previous.category,
+              vendor: previous.vendor,
+              amount: previous.amount,
+              gst: previous.gst,
+              notes: previous.notes,
+              label: previous.label,
+            });
+            await queryClient.invalidateQueries({ queryKey });
+          });
+          editingSnapshotRef.current = null;
         }}
       />
-      {deleteTarget &&
+      {selectedExpense &&
         portalTarget &&
         createPortal(
           <div
-            key="expense-delete-modal"
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-            onClick={() => {
-              if (!deleteMutation.isPending) {
-                setDeleteTarget(null);
-              }
-            }}
+            className={`fixed inset-0 z-50 flex items-end justify-center bg-black/40 px-4 pb-6 pt-10 sm:items-center sm:pb-10 ${
+              detailVisible ? "opacity-100" : "opacity-0"
+            } transition-opacity duration-150`}
+            onClick={closeDetail}
           >
             <div
-              className="w-full max-w-sm rounded-lg bg-white p-5 text-gray-900 shadow-lg dark:bg-gray-800 dark:text-gray-100"
+              className={`w-full max-w-lg transform rounded-xl bg-white p-5 text-gray-900 shadow-xl transition-all duration-200 dark:bg-gray-900 dark:text-gray-100 ${
+                detailVisible ? "translate-y-0 opacity-100" : "translate-y-4 opacity-0"
+              }`}
               onClick={(event) => event.stopPropagation()}
             >
-              <h2 className="text-lg font-semibold">Delete expense</h2>
-              <p className="mt-2 text-sm text-gray-700 dark:text-gray-300">
-                are you sure?
-              </p>
-              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                This will permanently remove the entry for {deleteTarget.vendor || "this expense"} dated {deleteTarget.date}.
-              </p>
-              <div className="mt-4 flex justify-end gap-2">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <h2 className="text-lg font-semibold">Expense details</h2>
+                  <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+                    Click edit or delete after typing <span className="font-medium">confirm</span> below.
+                  </p>
+                </div>
                 <button
                   type="button"
-                  className="rounded-md border border-gray-300 px-3 py-1 text-sm font-medium text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
-                  onClick={() => setDeleteTarget(null)}
-                  disabled={deleteMutation.isPending}
+                  className="rounded-full p-1 text-gray-500 transition hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+                  onClick={closeDetail}
+                  aria-label="Close details"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                    className="h-5 w-5"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M4.22 4.22a.75.75 0 0 1 1.06 0L10 8.94l4.72-4.72a.75.75 0 1 1 1.06 1.06L11.06 10l4.72 4.72a.75.75 0 1 1-1.06 1.06L10 11.06l-4.72 4.72a.75.75 0 0 1-1.06-1.06L8.94 10 4.22 5.28a.75.75 0 0 1 0-1.06Z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                </button>
+              </div>
+              <dl className="mt-4 grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
+                {!propertyId && (
+                  <div>
+                    <dt className="text-gray-500 dark:text-gray-400">Property</dt>
+                    <dd>{propertyMap[selectedExpense.propertyId] || selectedExpense.propertyId}</dd>
+                  </div>
+                )}
+                <div>
+                  <dt className="text-gray-500 dark:text-gray-400">Date</dt>
+                  <dd>{formatShortDate(selectedExpense.date)}</dd>
+                </div>
+                <div>
+                  <dt className="text-gray-500 dark:text-gray-400">Category</dt>
+                  <dd>{selectedExpense.category}</dd>
+                </div>
+                <div>
+                  <dt className="text-gray-500 dark:text-gray-400">Vendor</dt>
+                  <dd>{selectedExpense.vendor || "—"}</dd>
+                </div>
+                <div>
+                  <dt className="text-gray-500 dark:text-gray-400">Amount</dt>
+                  <dd>{selectedExpense.amount}</dd>
+                </div>
+                <div>
+                  <dt className="text-gray-500 dark:text-gray-400">GST</dt>
+                  <dd>{selectedExpense.gst}</dd>
+                </div>
+                <div className="sm:col-span-2">
+                  <dt className="text-gray-500 dark:text-gray-400">Notes</dt>
+                  <dd className="break-words">
+                    {selectedExpense.notes ? (
+                      <span>{selectedExpense.notes}</span>
+                    ) : (
+                      <span className="text-gray-500 dark:text-gray-400">—</span>
+                    )}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-gray-500 dark:text-gray-400">Receipt</dt>
+                  <dd>
+                    <ReceiptLink url={selectedExpense.receiptUrl} />
+                  </dd>
+                </div>
+              </dl>
+              <div className="mt-4">
+                <label className="text-sm font-medium text-gray-700 dark:text-gray-200">
+                  Type <span className="uppercase">confirm</span> to edit or delete
+                </label>
+                <input
+                  className="mt-2 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                  value={detailConfirm}
+                  onChange={(event) => setDetailConfirm(event.target.value)}
+                  placeholder="confirm"
+                />
+              </div>
+              <div className="mt-4 flex flex-wrap items-center justify-end gap-2">
+                <button
+                  type="button"
+                  className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800"
+                  onClick={closeDetail}
                 >
                   Cancel
                 </button>
                 <button
                   type="button"
-                  className="rounded-md bg-red-600 px-3 py-1 text-sm font-medium text-white hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-60"
-                  onClick={() => {
-                    if (!deleteTarget) return;
-                    deleteMutation.mutate(deleteTarget.id, {
-                      onSettled: () => {
-                        setDeleteTarget(null);
-                      },
-                    });
-                  }}
-                  disabled={deleteMutation.isPending}
+                  className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300 disabled:text-blue-100"
+                  onClick={() => selectedExpense && handleEdit(selectedExpense)}
+                  disabled={!confirmReady}
+                >
+                  Edit
+                </button>
+                <button
+                  type="button"
+                  className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-red-500 disabled:cursor-not-allowed disabled:bg-red-300"
+                  onClick={() => selectedExpense && handleDelete(selectedExpense)}
+                  disabled={!confirmReady || deleteMutation.isPending}
                 >
                   {deleteMutation.isPending ? "Deleting..." : "Delete"}
                 </button>
               </div>
+            </div>
+          </div>,
+          portalTarget,
+        )}
+      {notification &&
+        portalTarget &&
+        createPortal(
+          <div className="fixed bottom-6 right-6 z-[60] flex w-full max-w-sm justify-end text-sm">
+            <div
+              className={`flex w-full items-center justify-between gap-4 rounded-lg bg-gray-900/90 px-4 py-3 text-white shadow-lg backdrop-blur transition-all duration-200 ${
+                notificationVisible
+                  ? "translate-y-0 opacity-100"
+                  : "translate-y-2 opacity-0"
+              }`}
+            >
+              <span>{notification.message}</span>
+              {notification.undo && (
+                <button
+                  type="button"
+                  className="rounded-md border border-white/40 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white transition hover:border-white hover:bg-white/10"
+                  onClick={async () => {
+                    if (hideTimeoutRef.current) {
+                      clearTimeout(hideTimeoutRef.current);
+                      hideTimeoutRef.current = null;
+                    }
+                    if (removeTimeoutRef.current) {
+                      clearTimeout(removeTimeoutRef.current);
+                      removeTimeoutRef.current = null;
+                    }
+                    await notification.undo?.();
+                    setNotificationVisible(false);
+                    setNotification(null);
+                  }}
+                >
+                  Undo
+                </button>
+              )}
             </div>
           </div>,
           portalTarget,

--- a/components/IncomeForm.tsx
+++ b/components/IncomeForm.tsx
@@ -45,6 +45,7 @@ interface IncomeFormProps {
   onOpenChange?: (open: boolean) => void;
   showTrigger?: boolean;
   initialIncome?: IncomeRow | null;
+  onSaved?: (income: IncomeRow) => void;
 }
 
 export default function IncomeForm({
@@ -54,6 +55,7 @@ export default function IncomeForm({
   onOpenChange,
   showTrigger = true,
   initialIncome = null,
+  onSaved,
 }: IncomeFormProps) {
   const queryClient = useQueryClient();
   const [internalOpen, setInternalOpen] = useState(false);
@@ -129,7 +131,7 @@ export default function IncomeForm({
       isEditing && initialIncome
         ? updateIncome(propertyId, initialIncome.id, data)
         : createIncome(propertyId, data),
-    onSuccess: (_data, vars) => {
+    onSuccess: (savedIncome, vars) => {
       toast({ title: "Income saved" });
       setOpen(false);
       setForm(getInitialForm());
@@ -138,6 +140,7 @@ export default function IncomeForm({
       queryClient.invalidateQueries({ queryKey: ["income", vars.propertyId] });
       queryClient.invalidateQueries({ queryKey: ["pnl", vars.propertyId] });
       onCreated?.();
+      onSaved?.(savedIncome as IncomeRow);
     },
     onError: (err: any) => {
       const message = err instanceof Error ? err.message : "Failed to save income";

--- a/components/IncomesTable.tsx
+++ b/components/IncomesTable.tsx
@@ -1,8 +1,14 @@
 "use client";
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
-import { listIncome, deleteIncome } from "../lib/api";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import {
+  createIncome,
+  deleteIncome,
+  listIncome,
+  updateIncome,
+} from "../lib/api";
 import { formatShortDate } from "../lib/format";
 import type { IncomeRow } from "../types/income";
 import EmptyState from "./EmptyState";
@@ -55,11 +61,79 @@ export default function IncomesTable({
   const [to, setTo] = useState("");
   const [search, setSearch] = useState("");
   const [editingIncome, setEditingIncome] = useState<IncomeRow | null>(null);
+  const [selectedIncome, setSelectedIncome] = useState<IncomeRow | null>(null);
+  const [detailConfirm, setDetailConfirm] = useState("");
+  const [detailVisible, setDetailVisible] = useState(false);
+  const [notification, setNotification] = useState<{
+    id: number;
+    message: string;
+    undo?: () => Promise<void> | void;
+  } | null>(null);
+  const [notificationVisible, setNotificationVisible] = useState(false);
+  const [portalTarget, setPortalTarget] = useState<Element | null>(null);
+  const hideTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const removeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const notificationIdRef = useRef(0);
+  const editingSnapshotRef = useRef<IncomeRow | null>(null);
 
   const excludedCategories = useMemo(
     () => excludeCategories.map((value) => value.trim().toLowerCase()),
     [excludeCategories]
   );
+
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      setPortalTarget(document.body);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (selectedIncome) {
+      requestAnimationFrame(() => setDetailVisible(true));
+    }
+  }, [selectedIncome]);
+
+  useEffect(() => {
+    if (!notification) {
+      return () => {
+        if (hideTimeoutRef.current) {
+          clearTimeout(hideTimeoutRef.current);
+          hideTimeoutRef.current = null;
+        }
+        if (removeTimeoutRef.current) {
+          clearTimeout(removeTimeoutRef.current);
+          removeTimeoutRef.current = null;
+        }
+      };
+    }
+
+    setNotificationVisible(true);
+
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current);
+    }
+    if (removeTimeoutRef.current) {
+      clearTimeout(removeTimeoutRef.current);
+    }
+
+    hideTimeoutRef.current = setTimeout(() => {
+      setNotificationVisible(false);
+      removeTimeoutRef.current = setTimeout(() => {
+        setNotification(null);
+      }, 200);
+    }, 5000);
+
+    return () => {
+      if (hideTimeoutRef.current) {
+        clearTimeout(hideTimeoutRef.current);
+        hideTimeoutRef.current = null;
+      }
+      if (removeTimeoutRef.current) {
+        clearTimeout(removeTimeoutRef.current);
+        removeTimeoutRef.current = null;
+      }
+    };
+  }, [notification]);
 
   const filtered = useMemo(() => {
     if (!excludedCategories.length) {
@@ -99,6 +173,62 @@ export default function IncomesTable({
     });
   }, [filtered, from, search, to]);
 
+  const openDetail = (income: IncomeRow) => {
+    setSelectedIncome(income);
+    setDetailConfirm("");
+  };
+
+  const closeDetail = () => {
+    setDetailVisible(false);
+    setDetailConfirm("");
+    setTimeout(() => {
+      setSelectedIncome(null);
+    }, 180);
+  };
+
+  const showNotification = (
+    message: string,
+    undo?: () => Promise<void> | void
+  ) => {
+    notificationIdRef.current += 1;
+    setNotification({ id: notificationIdRef.current, message, undo });
+  };
+
+  const handleEdit = (income: IncomeRow) => {
+    editingSnapshotRef.current = income;
+    closeDetail();
+    setEditingIncome(income);
+  };
+
+  const handleDelete = (income: IncomeRow) => {
+    const incomeId = income.id;
+    deleteMutation.mutate(incomeId, {
+      onSuccess: async (_data, _variables, context) => {
+        closeDetail();
+        const previousEntries = context?.previousIncome ?? [];
+        const deletedEntry =
+          previousEntries.find((entry) => entry.id === incomeId) ?? income;
+        showNotification("Income deleted", async () => {
+          await createIncome(deletedEntry.propertyId, {
+            date: deletedEntry.date,
+            category: deletedEntry.category,
+            amount: deletedEntry.amount,
+            notes: deletedEntry.notes,
+            label: deletedEntry.label,
+            evidenceUrl: deletedEntry.evidenceUrl,
+            evidenceName: deletedEntry.evidenceName,
+          });
+          await queryClient.invalidateQueries({
+            queryKey: ["income", deletedEntry.propertyId],
+          });
+          await queryClient.invalidateQueries({
+            queryKey: ["pnl", deletedEntry.propertyId],
+          });
+        });
+      },
+    });
+  };
+
   const hasMatches = rows.length > 0;
   const hasRecords = filtered.length > 0;
 
@@ -117,12 +247,24 @@ export default function IncomesTable({
               <th className="p-2 text-center">Evidence</th>
               <th className="p-2 text-left">Amount</th>
               <th className="p-2 text-left">Notes</th>
-              <th className="p-2 text-left">Actions</th>
             </tr>
           </thead>
           <tbody>
             {rows.map((r) => (
-              <tr key={r.id} className="border-t dark:border-gray-700">
+              <tr
+                key={r.id}
+                className="border-t transition dark:border-gray-700 hover:bg-gray-50 focus-within:bg-gray-50 dark:hover:bg-gray-700/60 dark:focus-within:bg-gray-700/60"
+                onClick={() => openDetail(r)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    openDetail(r);
+                  }
+                }}
+                role="button"
+                tabIndex={0}
+                aria-label={`View income entry for ${formatShortDate(r.date)}`}
+              >
                 <td className="p-2">{formatShortDate(r.date)}</td>
                 <td className="p-2">{r.category || r.label || "—"}</td>
                 <td className="p-2 text-center">
@@ -160,48 +302,6 @@ export default function IncomesTable({
                     <span className="text-gray-500 dark:text-gray-400">&mdash;</span>
                   )}
                 </td>
-                <td className="p-2">
-                  <div className="flex items-center gap-2">
-                    <button
-                      type="button"
-                      className="text-gray-600 hover:text-blue-600 dark:text-gray-300 dark:hover:text-blue-400"
-                      onClick={() => setEditingIncome(r)}
-                      aria-label="Edit income"
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                        className="h-4 w-4"
-                        aria-hidden="true"
-                      >
-                        <path d="M13.586 2.586a2 2 0 0 1 2.828 2.828l-.793.793-2.828-2.828.793-.793zM12.379 4.207 3 13.586V17h3.414l9.379-9.379-3.414-3.414z" />
-                      </svg>
-                      <span className="sr-only">Edit income</span>
-                    </button>
-                    <button
-                      type="button"
-                      className="text-gray-600 hover:text-red-600 dark:text-gray-300 dark:hover:text-red-400"
-                      onClick={() => {
-                        if (confirm("are you sure?")) {
-                          deleteMutation.mutate(r.id);
-                        }
-                      }}
-                      aria-label="Delete income"
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                        className="h-4 w-4"
-                        aria-hidden="true"
-                      >
-                        <path d="M8.5 3a1.5 1.5 0 0 1 3 0H15a1 1 0 1 1 0 2h-1v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V5H5a1 1 0 1 1 0-2h3.5zM8 5v10h4V5H8z" />
-                      </svg>
-                      <span className="sr-only">Delete income</span>
-                    </button>
-                  </div>
-                </td>
               </tr>
             ))}
           </tbody>
@@ -212,6 +312,8 @@ export default function IncomesTable({
 
   const filterControlClass =
     "h-10 rounded-lg border border-gray-300 bg-white px-3 text-sm text-gray-900 shadow-sm focus:border-gray-400 focus:outline-none focus:ring-1 focus:ring-gray-400 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100";
+
+  const confirmReady = detailConfirm.trim().toLowerCase() === "confirm";
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -270,7 +372,189 @@ export default function IncomesTable({
         showTrigger={false}
         initialIncome={editingIncome}
         onCreated={() => setEditingIncome(null)}
+        onSaved={(updated) => {
+          queryClient.invalidateQueries({ queryKey: ["income", propertyId] });
+          queryClient.invalidateQueries({ queryKey: ["pnl", propertyId] });
+          showNotification("Income updated", async () => {
+            const previous = editingSnapshotRef.current;
+            if (!previous) {
+              return;
+            }
+            await updateIncome(previous.propertyId, updated.id, {
+              date: previous.date,
+              category: previous.category,
+              amount: previous.amount,
+              notes: previous.notes,
+              label: previous.label,
+              evidenceUrl: previous.evidenceUrl ?? null,
+              evidenceName: previous.evidenceName ?? null,
+            });
+            await queryClient.invalidateQueries({
+              queryKey: ["income", previous.propertyId],
+            });
+            await queryClient.invalidateQueries({
+              queryKey: ["pnl", previous.propertyId],
+            });
+          });
+          editingSnapshotRef.current = null;
+        }}
       />
+      {selectedIncome &&
+        portalTarget &&
+        createPortal(
+          <div
+            className={`fixed inset-0 z-50 flex items-end justify-center bg-black/40 px-4 pb-6 pt-10 sm:items-center sm:pb-10 ${
+              detailVisible ? "opacity-100" : "opacity-0"
+            } transition-opacity duration-150`}
+            onClick={closeDetail}
+          >
+            <div
+              className={`w-full max-w-lg transform rounded-xl bg-white p-5 text-gray-900 shadow-xl transition-all duration-200 dark:bg-gray-900 dark:text-gray-100 ${
+                detailVisible ? "translate-y-0 opacity-100" : "translate-y-4 opacity-0"
+              }`}
+              onClick={(event) => event.stopPropagation()}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <h2 className="text-lg font-semibold">Income details</h2>
+                  <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+                    Type <span className="font-medium">confirm</span> below to edit or delete this entry.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  className="rounded-full p-1 text-gray-500 transition hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+                  onClick={closeDetail}
+                  aria-label="Close details"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                    className="h-5 w-5"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M4.22 4.22a.75.75 0 0 1 1.06 0L10 8.94l4.72-4.72a.75.75 0 1 1 1.06 1.06L11.06 10l4.72 4.72a.75.75 0 1 1-1.06 1.06L10 11.06l-4.72 4.72a.75.75 0 0 1-1.06-1.06L8.94 10 4.22 5.28a.75.75 0 0 1 0-1.06Z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                </button>
+              </div>
+              <dl className="mt-4 grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
+                <div>
+                  <dt className="text-gray-500 dark:text-gray-400">Date</dt>
+                  <dd>{formatShortDate(selectedIncome.date)}</dd>
+                </div>
+                <div>
+                  <dt className="text-gray-500 dark:text-gray-400">Category</dt>
+                  <dd>{selectedIncome.category || selectedIncome.label || "—"}</dd>
+                </div>
+                <div>
+                  <dt className="text-gray-500 dark:text-gray-400">Amount</dt>
+                  <dd>{selectedIncome.amount}</dd>
+                </div>
+                <div>
+                  <dt className="text-gray-500 dark:text-gray-400">Evidence</dt>
+                  <dd>
+                    {selectedIncome.evidenceUrl ? (
+                      <EvidenceLink
+                        href={selectedIncome.evidenceUrl}
+                        fileName={selectedIncome.evidenceName}
+                      />
+                    ) : (
+                      <span className="text-gray-500 dark:text-gray-400">—</span>
+                    )}
+                  </dd>
+                </div>
+                <div className="sm:col-span-2">
+                  <dt className="text-gray-500 dark:text-gray-400">Notes</dt>
+                  <dd className="break-words">
+                    {selectedIncome.notes ? (
+                      <span>{selectedIncome.notes}</span>
+                    ) : (
+                      <span className="text-gray-500 dark:text-gray-400">—</span>
+                    )}
+                  </dd>
+                </div>
+              </dl>
+              <div className="mt-4">
+                <label className="text-sm font-medium text-gray-700 dark:text-gray-200">
+                  Type <span className="uppercase">confirm</span> to continue
+                </label>
+                <input
+                  className="mt-2 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                  value={detailConfirm}
+                  onChange={(event) => setDetailConfirm(event.target.value)}
+                  placeholder="confirm"
+                />
+              </div>
+              <div className="mt-4 flex flex-wrap items-center justify-end gap-2">
+                <button
+                  type="button"
+                  className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800"
+                  onClick={closeDetail}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300 disabled:text-blue-100"
+                  onClick={() => selectedIncome && handleEdit(selectedIncome)}
+                  disabled={!confirmReady}
+                >
+                  Edit
+                </button>
+                <button
+                  type="button"
+                  className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-red-500 disabled:cursor-not-allowed disabled:bg-red-300"
+                  onClick={() => selectedIncome && handleDelete(selectedIncome)}
+                  disabled={!confirmReady || deleteMutation.isPending}
+                >
+                  {deleteMutation.isPending ? "Deleting..." : "Delete"}
+                </button>
+              </div>
+            </div>
+          </div>,
+          portalTarget,
+        )}
+      {notification &&
+        portalTarget &&
+        createPortal(
+          <div className="fixed bottom-6 right-6 z-[60] flex w-full max-w-sm justify-end text-sm">
+            <div
+              className={`flex w-full items-center justify-between gap-4 rounded-lg bg-gray-900/90 px-4 py-3 text-white shadow-lg backdrop-blur transition-all duration-200 ${
+                notificationVisible
+                  ? "translate-y-0 opacity-100"
+                  : "translate-y-2 opacity-0"
+              }`}
+            >
+              <span>{notification.message}</span>
+              {notification.undo && (
+                <button
+                  type="button"
+                  className="rounded-md border border-white/40 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white transition hover:border-white hover:bg-white/10"
+                  onClick={async () => {
+                    if (hideTimeoutRef.current) {
+                      clearTimeout(hideTimeoutRef.current);
+                      hideTimeoutRef.current = null;
+                    }
+                    if (removeTimeoutRef.current) {
+                      clearTimeout(removeTimeoutRef.current);
+                      removeTimeoutRef.current = null;
+                    }
+                    await notification.undo?.();
+                    setNotificationVisible(false);
+                    setNotification(null);
+                  }}
+                >
+                  Undo
+                </button>
+              )}
+            </div>
+          </div>,
+          portalTarget,
+        )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace inline action buttons on expenses and income tables with clickable rows that open detail overlays requiring users to type "confirm" before editing or deleting
- surface animated confirmation overlays with undo-capable notifications and five-second lifetime, including undo hooks for delete and edit operations
- extend shared forms to return saved entities so table interactions can schedule undo updates

## Testing
- npm run lint *(fails: ESLint configuration missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e2542efc34832cb8e6f441c1358aaa