### PR TITLE
Ensure task queries refresh after key date task sync

### DIFF
--- a/app/(app)/properties/[id]/sections/KeyDates.tsx
+++ b/app/(app)/properties/[id]/sections/KeyDates.tsx
@@ -60,7 +60,7 @@ export default function KeyDates({ propertyId }: KeyDatesProps) {
     void queryClient.invalidateQueries({ queryKey: ["reminders"] });
     void queryClient.invalidateQueries({ queryKey: ["property", propertyId] });
     void queryClient.invalidateQueries({ queryKey: ["properties"] });
-    void queryClient.invalidateQueries({ queryKey: ["tasks"] });
+    void queryClient.invalidateQueries({ queryKey: ["tasks"], exact: false });
   };
 
   const createMutation = useMutation({

--- a/components/tasks/TaskList.tsx
+++ b/components/tasks/TaskList.tsx
@@ -17,22 +17,28 @@ export default function TaskList() {
   });
   const defaultProp = properties[0];
 
+  const invalidateTasks = () =>
+    qc.invalidateQueries({ queryKey: ["tasks"], exact: false });
+
   const createMut = useMutation({
     mutationFn: (title: string) =>
-      createTask({ title, properties: defaultProp ? [{ id: defaultProp.id, address: defaultProp.address }] : [] }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["tasks"] }),
+      createTask({
+        title,
+        properties: defaultProp ? [{ id: defaultProp.id, address: defaultProp.address }] : [],
+      }),
+    onSuccess: invalidateTasks,
   });
   const updateMut = useMutation({
     mutationFn: ({ id, data }: { id: string; data: Partial<TaskDto> }) => updateTask(id, data),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["tasks"] }),
+    onSuccess: invalidateTasks,
   });
   const deleteMut = useMutation({
     mutationFn: (id: string) => deleteTask(id),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["tasks"] }),
+    onSuccess: invalidateTasks,
   });
   const completeMut = useMutation({
     mutationFn: (id: string) => completeTask(id),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["tasks"] }),
+    onSuccess: invalidateTasks,
   });
 
   return (

--- a/components/tasks/TasksKanban.tsx
+++ b/components/tasks/TasksKanban.tsx
@@ -388,20 +388,24 @@ export default function TasksKanban({
             ]
           : [],
       }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["tasks"] }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: ["tasks"], exact: false }),
   });
   const updateMut = useMutation({
     mutationFn: ({ id, data }: { id: string; data: Partial<TaskDto> }) =>
       updateTask(id, data),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["tasks"] }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: ["tasks"], exact: false }),
   });
   const archiveMut = useMutation({
     mutationFn: (id: string) => archiveTask(id),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["tasks"] }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: ["tasks"], exact: false }),
   });
   const completeMut = useMutation({
     mutationFn: (id: string) => completeTask(id),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["tasks"] }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: ["tasks"], exact: false }),
   });
   const [completingTaskId, setCompletingTaskId] = useState<string | null>(null);
   const [completionPrompt, setCompletionPrompt] =


### PR DESCRIPTION
## Summary
- broaden task query invalidation after key-date updates so property scoped boards refresh
- reuse the same broader task invalidation in kanban and list views to pick up new linked tasks

## Testing
- npm run lint *(fails: ESLint config missing in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68e25b45b354832cb6cc9184f1c4bced