### PR TITLE
Improve ledger entry modal usability and safeguards

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -110,3 +110,54 @@
 [data-theme] *::-webkit-scrollbar-thumb:hover{
   background-color: var(--scrollbar-thumb-hover);
 }
+
+.range-thumb{
+  position: relative;
+  z-index: 10;
+  height: 32px;
+  cursor: pointer;
+}
+
+.range-thumb::-webkit-slider-thumb{
+  -webkit-appearance: none;
+  appearance: none;
+  height: 28px;
+  width: 28px;
+  border-radius: 9999px;
+  background: #2563eb;
+  box-shadow: 0 4px 10px rgba(37, 99, 235, 0.35);
+  border: 2px solid #ffffff;
+}
+
+.range-thumb::-moz-range-thumb{
+  height: 28px;
+  width: 28px;
+  border-radius: 9999px;
+  background: #2563eb;
+  border: 2px solid #ffffff;
+  box-shadow: 0 4px 10px rgba(37, 99, 235, 0.35);
+}
+
+.range-thumb::-ms-thumb{
+  height: 28px;
+  width: 28px;
+  border-radius: 9999px;
+  background: #2563eb;
+  border: 2px solid #ffffff;
+  box-shadow: 0 4px 10px rgba(37, 99, 235, 0.35);
+}
+
+.range-thumb::-webkit-slider-runnable-track{
+  height: 0;
+}
+
+.range-thumb::-moz-range-track{
+  height: 0;
+}
+
+.range-thumb::-ms-track{
+  height: 0;
+  background: transparent;
+  border-color: transparent;
+  color: transparent;
+}

--- a/components/EditLedgerEntryModal.tsx
+++ b/components/EditLedgerEntryModal.tsx
@@ -12,7 +12,7 @@ interface Props {
   onClose: () => void;
 }
 
-const TRANSITION_MS = 200;
+const TRANSITION_MS = 300;
 
 export default function EditLedgerEntryModal({ entry, onSave, onClose }: Props) {
   const [isMounted, setIsMounted] = useState(false);
@@ -25,6 +25,8 @@ export default function EditLedgerEntryModal({ entry, onSave, onClose }: Props) 
   const [error, setError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
+  const [confirmationProgress, setConfirmationProgress] = useState(0);
+  const isConfirmed = confirmationProgress >= 100;
 
   useEffect(() => {
     setIsMounted(true);
@@ -40,6 +42,7 @@ export default function EditLedgerEntryModal({ entry, onSave, onClose }: Props) 
     setEvidenceName(entry.evidenceName ?? "");
     setEvidenceFile(null);
     setError(null);
+    setConfirmationProgress(0);
   }, [entry]);
 
   const daysLate = useMemo(() => {
@@ -53,6 +56,7 @@ export default function EditLedgerEntryModal({ entry, onSave, onClose }: Props) 
 
   const handleRequestClose = () => {
     setIsVisible(false);
+    setConfirmationProgress(0);
     setTimeout(onClose, TRANSITION_MS);
   };
 
@@ -75,6 +79,11 @@ export default function EditLedgerEntryModal({ entry, onSave, onClose }: Props) 
   };
 
   const handleSave = async () => {
+    if (!isConfirmed) {
+      setError("Slide to confirm before saving your changes.");
+      return;
+    }
+
     setError(null);
     setIsSaving(true);
     try {
@@ -126,6 +135,7 @@ export default function EditLedgerEntryModal({ entry, onSave, onClose }: Props) 
       setError(message);
     } finally {
       setIsSaving(false);
+      setConfirmationProgress(0);
     }
   };
 
@@ -136,60 +146,63 @@ export default function EditLedgerEntryModal({ entry, onSave, onClose }: Props) 
   return createPortal(
     <div
       onClick={handleOverlayClick}
-      className={`fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm transition-opacity duration-200 ${
+      className={`fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm transition-opacity duration-300 ${
         isVisible ? "opacity-100" : "opacity-0"
       }`}
     >
       <div
-        className={`w-80 max-w-[90vw] transform rounded-lg bg-white p-4 shadow-lg transition-all duration-200 dark:bg-gray-800 ${
-          isVisible ? "scale-100 opacity-100" : "-translate-y-2 scale-95 opacity-0"
+        className={`w-full max-w-2xl transform rounded-2xl bg-white p-6 shadow-2xl transition-all duration-300 ease-in-out dark:bg-gray-800 ${
+          isVisible ? "scale-100 opacity-100" : "-translate-y-3 scale-95 opacity-0"
         }`}
         onClick={(e) => e.stopPropagation()}
       >
-        <h2 className="mb-4 text-lg font-semibold">Ledger Entry</h2>
-        <div className="mb-3">
-          <label className="mb-1 block text-sm">Date Paid</label>
-          <input
-            type="date"
-            className="w-full rounded border p-2 dark:border-gray-600 dark:bg-gray-700"
-            value={datePaid}
-            onChange={(e) => setDatePaid(e.target.value)}
-          />
-          {daysLate > 0 && (
-            <p className="mt-1 text-sm text-red-500">Late by {daysLate} day(s)</p>
-          )}
+        <h2 className="mb-6 text-xl font-semibold text-gray-900 dark:text-gray-100">Ledger Entry</h2>
+        <div className="grid gap-4 md:grid-cols-[repeat(2,minmax(0,1fr))]">
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">Date Paid</label>
+            <input
+              type="date"
+              className="w-full rounded-lg border border-gray-300 p-2.5 text-sm shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-gray-600 dark:bg-gray-700"
+              value={datePaid}
+              onChange={(e) => setDatePaid(e.target.value)}
+            />
+            {daysLate > 0 && (
+              <p className="text-xs text-red-500">Late by {daysLate} day(s)</p>
+            )}
+          </div>
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">Status</label>
+            <select
+              className="w-full rounded-lg border border-gray-300 p-2.5 text-sm shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-gray-600 dark:bg-gray-700"
+              value={status}
+              onChange={(e) => setStatus(e.target.value as LedgerStatus)}
+            >
+              <option value="paid">Paid</option>
+              <option value="unpaid">Unpaid</option>
+              <option value="follow_up">Follow up</option>
+            </select>
+          </div>
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">Amount</label>
+            <input
+              type="number"
+              className="w-full rounded-lg border border-gray-300 p-2.5 text-sm shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-gray-600 dark:bg-gray-700"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+            />
+          </div>
+          <div className="flex flex-col justify-end gap-1 text-sm text-gray-600 dark:text-gray-300">
+            <span className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Balance</span>
+            <span className="text-base font-semibold text-gray-900 dark:text-gray-100">{entry.balance}</span>
+          </div>
         </div>
-        <div className="mb-3">
-          <label className="mb-1 block text-sm">Status</label>
-          <select
-            className="w-full rounded border p-2 dark:border-gray-600 dark:bg-gray-700"
-            value={status}
-            onChange={(e) => setStatus(e.target.value as LedgerStatus)}
-          >
-            <option value="paid">Paid</option>
-            <option value="unpaid">Unpaid</option>
-            <option value="follow_up">Follow up</option>
-          </select>
-        </div>
-        <div className="mb-3">
-          <label className="mb-1 block text-sm">Amount</label>
-          <input
-            type="number"
-            className="w-full rounded border p-2 dark:border-gray-600 dark:bg-gray-700"
-            value={amount}
-            onChange={(e) => setAmount(e.target.value)}
-          />
-        </div>
-        <div className="mb-3 text-sm">
-          <p>Balance: {entry.balance}</p>
-        </div>
-        <div className="mb-3">
+        <div className="mt-6">
           <div className="mb-1 flex items-center justify-between">
-            <label className="block text-sm">Evidence</label>
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">Evidence</label>
             {(evidenceUrl || evidenceFile || entry.evidenceUrl) && (
               <button
                 type="button"
-                className="text-xs text-red-500 hover:text-red-400"
+                className="text-xs font-medium text-red-500 transition hover:text-red-400"
                 onClick={handleClearEvidence}
               >
                 Clear
@@ -201,27 +214,27 @@ export default function EditLedgerEntryModal({ entry, onSave, onClose }: Props) 
               href={entry.evidenceUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="mb-2 inline-flex items-center gap-2 rounded border border-blue-200 bg-blue-50 px-2 py-1 text-sm text-blue-700 transition hover:bg-blue-100 dark:border-blue-500/40 dark:bg-blue-500/10 dark:text-blue-200"
+              className="mb-2 inline-flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-3 py-1.5 text-sm text-blue-700 transition hover:bg-blue-100 dark:border-blue-500/40 dark:bg-blue-500/10 dark:text-blue-200"
             >
               <span className="truncate">{entry.evidenceName ?? "View evidence"}</span>
             </a>
           )}
           {evidenceFile && (
-            <div className="mb-2 rounded border border-dashed border-blue-300 px-2 py-1 text-xs text-blue-600 dark:border-blue-500 dark:text-blue-200">
+            <div className="mb-2 rounded-lg border border-dashed border-blue-300 px-3 py-1.5 text-xs text-blue-600 dark:border-blue-500 dark:text-blue-200">
               Selected file: {evidenceFile.name}
             </div>
           )}
           <input
             type="file"
             accept="application/pdf,image/*"
-            className="w-full rounded border p-2 text-sm dark:border-gray-600 dark:bg-gray-700"
+            className="w-full rounded-lg border border-dashed border-gray-300 p-3 text-sm transition hover:border-blue-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-gray-600 dark:bg-gray-700"
             onChange={(e) => handleFileChange(e.target.files?.[0] ?? null)}
           />
           <div className="mt-2 space-y-2 text-sm">
             <input
               type="url"
               placeholder="Paste a link to evidence"
-              className="w-full rounded border p-2 text-sm dark:border-gray-600 dark:bg-gray-700"
+              className="w-full rounded-lg border border-gray-300 p-2.5 text-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-gray-600 dark:bg-gray-700"
               value={evidenceUrl}
               onChange={(e) => {
                 setEvidenceUrl(e.target.value);
@@ -233,29 +246,59 @@ export default function EditLedgerEntryModal({ entry, onSave, onClose }: Props) 
             <input
               type="text"
               placeholder="Evidence name (optional)"
-              className="w-full rounded border p-2 text-sm dark:border-gray-600 dark:bg-gray-700"
+              className="w-full rounded-lg border border-gray-300 p-2.5 text-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-gray-600 dark:bg-gray-700"
               value={evidenceName}
               onChange={(e) => setEvidenceName(e.target.value)}
             />
           </div>
-          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
             Upload a new document or provide a link. Clearing the fields will remove existing
             evidence.
           </p>
         </div>
-        {error && <p className="mb-3 text-sm text-red-500">{error}</p>}
-        <div className="mt-4 flex justify-end gap-2">
+        <div className="mt-6">
+          <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+            Confirm changes
+          </label>
+          <div className="relative overflow-hidden rounded-full bg-gray-200 p-2 dark:bg-gray-700">
+            <input
+              type="range"
+              min={0}
+              max={100}
+              step={5}
+              value={confirmationProgress}
+              onChange={(e) => {
+                const nextValue = Number(e.target.value);
+                if (nextValue >= 95) {
+                  setConfirmationProgress(100);
+                } else {
+                  setConfirmationProgress(nextValue);
+                }
+              }}
+              className="range-thumb w-full appearance-none bg-transparent"
+            />
+            <div
+              className="pointer-events-none absolute inset-2 rounded-full bg-blue-500 transition-all"
+              style={{ width: `${Math.min(100, Math.max(16, confirmationProgress))}%` }}
+            />
+            <span className="pointer-events-none absolute inset-0 flex items-center justify-center text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-200">
+              {isConfirmed ? "Confirmed" : "Slide right to confirm"}
+            </span>
+          </div>
+        </div>
+        {error && <p className="mt-3 text-sm text-red-500">{error}</p>}
+        <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end">
           <button
-            className="rounded bg-gray-200 px-4 py-2 text-sm transition hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
+            className="rounded-lg bg-gray-200 px-4 py-2 text-sm font-medium transition hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
             onClick={handleRequestClose}
             disabled={isSaving}
           >
             Cancel
           </button>
           <button
-            className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-400"
+            className="rounded-lg bg-blue-600 px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-400"
             onClick={handleSave}
-            disabled={isSaving}
+            disabled={isSaving || !isConfirmed}
           >
             {isSaving ? "Saving..." : "Save"}
           </button>


### PR DESCRIPTION
## Summary
- restyled the ledger entry modal with a wider layout, refined spacing, and smoother transitions for readability
- added a confirmation slider that must be completed before saving changes to prevent accidental edits
- introduced shared range input styling to support the new confirmation control

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68e25c6de8dc832cb4c212eaa4485fd0