### PR TITLE
Fix expense updates and add toast notifications

### DIFF
--- a/app/api/expenses/[id]/route.ts
+++ b/app/api/expenses/[id]/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server';
 import { expenses } from '../../store';
+import { zExpense } from '../../../lib/validation';
+import { prisma } from '../../../lib/prisma';
 
 export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
   const idx = expenses.findIndex((e) => e.id === params.id);
@@ -8,4 +10,31 @@ export async function DELETE(_req: Request, { params }: { params: { id: string }
   }
   expenses.splice(idx, 1);
   return new NextResponse(null, { status: 204 });
+}
+
+export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+  const idx = expenses.findIndex((expense) => expense.id === params.id);
+  if (idx === -1) {
+    return new NextResponse('Not found', { status: 404 });
+  }
+
+  try {
+    const body = await req.json();
+    const current = expenses[idx];
+    const parsed = zExpense.parse({ ...current, ...body, id: params.id });
+
+    if (process.env.MOCK_MODE === 'true') {
+      expenses[idx] = parsed;
+    } else {
+      await (prisma as any).mockData.update({
+        where: { id: params.id },
+        data: { data: parsed },
+      });
+    }
+
+    return NextResponse.json(parsed);
+  } catch (err: any) {
+    const message = err?.message ?? 'Invalid expense payload';
+    return new NextResponse(message, { status: 400 });
+  }
 }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactNode, createContext, useState, useEffect } from 'react';
+import { ToastProvider } from '../components/ui/use-toast';
 
 const queryClient = new QueryClient();
 
@@ -43,7 +44,7 @@ export default function Providers({ children }: { children: ReactNode }) {
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeContext.Provider value={{ theme, toggleTheme }}>
-        {children}
+        <ToastProvider>{children}</ToastProvider>
       </ThemeContext.Provider>
     </QueryClientProvider>
   );

--- a/components/ExpenseForm.tsx
+++ b/components/ExpenseForm.tsx
@@ -194,7 +194,10 @@ export default function ExpenseForm({
       return created as ExpenseRow;
     },
     onSuccess: (savedExpense) => {
-      toast({ title: isEditMode ? "Expense updated" : "Expense saved" });
+      toast({
+        title: isEditMode ? "Expense updated" : "Expense saved",
+        variant: "success",
+      });
       setOpen(false);
       setForm(computeInitialForm());
       setError(null);
@@ -212,7 +215,11 @@ export default function ExpenseForm({
     onError: (err: any) => {
       const message = err instanceof Error ? err.message : "Failed to save expense";
       setError(message);
-      toast({ title: "Failed to save expense", description: message });
+      toast({
+        title: "Failed to save expense",
+        description: message,
+        variant: "destructive",
+      });
     },
   });
 
@@ -276,12 +283,12 @@ export default function ExpenseForm({
                       expense: {
                         propertyId: form.propertyId,
                         date: form.date,
-                        category: form.category,
+                        category: form.category || form.group,
                         vendor: form.vendor,
                         amount: parseFloat(form.amount),
                         gst: form.gst ? parseFloat(form.gst) : 0,
-                        notes: form.notes,
-                        label: form.label,
+                        notes: form.notes || undefined,
+                        label: form.label || undefined,
                       },
                       receipt: form.receipt,
                     });

--- a/components/ui/use-toast.ts
+++ b/components/ui/use-toast.ts
@@ -1,14 +1,91 @@
-import { useCallback } from "react";
+"use client";
 
-export function useToast() {
+import { AnimatePresence, motion } from "framer-motion";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+type ToastVariant = "default" | "success" | "destructive";
+
+export type ToastOptions = {
+  title: string;
+  description?: string;
+  variant?: ToastVariant;
+};
+
+type ToastInstance = ToastOptions & { id: number };
+
+type ToastContextValue = {
+  toast: (options: ToastOptions) => void;
+};
+
+const ToastContext = createContext<ToastContextValue | undefined>(undefined);
+
+const variantStyles: Record<ToastVariant, string> = {
+  default:
+    "border border-gray-200 bg-white/95 text-gray-900 shadow-lg backdrop-blur dark:border-gray-700 dark:bg-gray-900/95 dark:text-gray-100",
+  success: "bg-emerald-500 text-white shadow-lg",
+  destructive: "bg-red-500 text-white shadow-lg",
+};
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastInstance[]>([]);
+  const idRef = useRef(0);
+
+  const removeToast = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((toast) => toast.id !== id));
+  }, []);
+
   const toast = useCallback(
-    ({ title, description }: { title: string; description?: string }) => {
-      if (typeof window !== "undefined") {
-        alert(title + (description ? "\n" + description : ""));
-      }
+    ({ title, description, variant = "default" }: ToastOptions) => {
+      idRef.current += 1;
+      const id = idRef.current;
+      setToasts((prev) => [...prev, { id, title, description, variant }]);
+      setTimeout(() => removeToast(id), 3000);
     },
-    []
+    [removeToast]
   );
 
-  return { toast };
+  const value = useMemo(() => ({ toast }), [toast]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div className="pointer-events-none fixed right-4 top-4 z-[9999] flex max-w-sm flex-col gap-3">
+        <AnimatePresence>
+          {toasts.map(({ id, title, description, variant = "default" }) => (
+            <motion.div
+              key={id}
+              initial={{ opacity: 0, y: -12, scale: 0.95 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: -12, scale: 0.95 }}
+              transition={{ duration: 0.2 }}
+              className={`pointer-events-auto overflow-hidden rounded-lg px-4 py-3 ${variantStyles[variant]}`}
+              role={variant === "destructive" ? "alert" : "status"}
+              aria-live={variant === "destructive" ? "assertive" : "polite"}
+            >
+              <div className="font-medium">{title}</div>
+              {description && (
+                <div className="mt-1 text-sm opacity-90">{description}</div>
+              )}
+            </motion.div>
+          ))}
+        </AnimatePresence>
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error("useToast must be used within a ToastProvider");
+  }
+  return context;
 }

--- a/tests/ExpenseForm.test.tsx
+++ b/tests/ExpenseForm.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import ExpenseForm from '../components/ExpenseForm';
+import { ToastProvider } from '../components/ui/use-toast';
 
 vi.mock('../lib/api', () => ({
   createExpense: vi.fn(),
@@ -13,7 +14,9 @@ const renderForm = () => {
   const client = new QueryClient();
   render(
     <QueryClientProvider client={client}>
-      <ExpenseForm open showTrigger={false} />
+      <ToastProvider>
+        <ExpenseForm open showTrigger={false} />
+      </ToastProvider>
     </QueryClientProvider>
   );
 };


### PR DESCRIPTION
## Summary
- add a PATCH handler to the expenses API so edits persist instead of returning 405 errors
- replace the alert-based toast helper with an animated in-app popup provider and wire it through the app
- adjust the expense form payload to use valid categories for custom labels and update tests to include the toast provider

## Testing
- npm run test:unit *(fails: vitest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e25cf4247c832c8960a12fc3bdbf94