### PR TITLE
Fix expenses route validation import path

### DIFF
--- a/app/api/expenses/[id]/route.ts
+++ b/app/api/expenses/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { expenses } from '../../store';
-import { zExpense } from '../../../lib/validation';
+import { zExpense } from '../../../../lib/validation';
 import { prisma } from '../../../lib/prisma';
 
 export async function DELETE(_req: Request, { params }: { params: { id: string } }) {


### PR DESCRIPTION
## Summary
- correct the expenses route to import zExpense from the proper validation module

## Testing
- npm run build *(fails: next not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e35692c120832ca4841170291132a5