### PR TITLE
Fix prisma import path in expenses API route

### DIFF
--- a/app/api/expenses/[id]/route.ts
+++ b/app/api/expenses/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { expenses } from '../../store';
-import { zExpense } from '../../../lib/validation';
-import { prisma } from '../../../lib/prisma';
+import { zExpense } from '../../../../lib/validation';
+import { prisma } from '../../../../lib/prisma';
 
 export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
   const idx = expenses.findIndex((e) => e.id === params.id);


### PR DESCRIPTION
## Summary
- correct the prisma client import path in the expenses API route so it resolves to the shared library module

## Testing
- npm run build *(fails: next binary unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e35692c120832ca4841170291132a5