### PR TITLE
Capitalize dashboard empty state message

### DIFF
--- a/components/dashboard/PieCard.tsx
+++ b/components/dashboard/PieCard.tsx
@@ -66,7 +66,7 @@ export default function PieCard<T extends Record<string, any>>({ title, data, la
         </div>
       ) : (
         <div className="flex h-[320px] items-center justify-center px-4 text-center text-sm text-text-secondary sm:h-[360px] lg:h-[400px]">
-          log data to see visualisations!
+          Log data to see visualisations!
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- capitalize the log data placeholder in the dashboard pie card empty state

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68e5779e34d4832c83ef46904585e3a2