### PR TITLE
Align expense and document modals with income modal dimensions

### DIFF
--- a/components/DocumentUploadModal.tsx
+++ b/components/DocumentUploadModal.tsx
@@ -159,7 +159,7 @@ export default function DocumentUploadModal({ open, onClose, propertyId }: Props
             transition={{ duration: 0.2 }}
           >
             <motion.div
-              className="w-full max-w-md space-y-4 rounded-xl bg-white p-6 shadow-lg dark:bg-slate-900 dark:text-slate-100"
+              className="w-full max-w-[500px] max-h-[500px] space-y-4 overflow-y-auto rounded-xl bg-white p-6 shadow-lg dark:bg-slate-900 dark:text-slate-100"
               onClick={(e) => e.stopPropagation()}
               initial={{ opacity: 0, y: 16, scale: 0.96 }}
               animate={{ opacity: 1, y: 0, scale: 1 }}

--- a/components/ExpenseForm.tsx
+++ b/components/ExpenseForm.tsx
@@ -255,7 +255,7 @@ export default function ExpenseForm({
                 transition={{ duration: 0.2 }}
               >
                 <motion.form
-                  className="h-full w-full max-w-2xl max-h-full space-y-3 overflow-y-auto rounded-lg bg-white p-6 text-gray-900 shadow-lg dark:bg-gray-800 dark:text-gray-100"
+                  className="h-full w-full max-w-[500px] max-h-[500px] space-y-3 overflow-y-auto rounded-lg bg-white p-6 text-gray-900 shadow-lg dark:bg-gray-800 dark:text-gray-100"
                   onClick={(e) => e.stopPropagation()}
                   onSubmit={(e) => {
                     e.preventDefault();


### PR DESCRIPTION
## Summary
- match the expense modal width and height constraints to approximately 500x500 to align with the income modal sizing
- apply the same 500px sizing constraints to the document upload modal so its layout mirrors the other forms

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68e57876e148832cb55347af54a4c9a7