### PR TITLE
Auto-calculate GST in expense form

### DIFF
--- a/tests/expense-delete.spec.ts
+++ b/tests/expense-delete.spec.ts
@@ -10,7 +10,7 @@ test('user can add and delete an expense', async ({ page }) => {
   await page.getByLabel('Category').selectOption('General repairs');
   await page.getByLabel('Vendor').fill('Acme Corp');
   await page.getByLabel('Amount').fill('100');
-  await page.getByLabel('GST').fill('10');
+  await page.getByLabel('GST').check();
   await page.getByLabel('Notes').fill('Test expense');
   await page.getByRole('button', { name: 'Save' }).click();
 

--- a/tests/expenses.spec.ts
+++ b/tests/expenses.spec.ts
@@ -9,7 +9,8 @@ test('expenses can be added and filtered', async ({ page }) => {
   await page.getByLabel('Category').selectOption('General repairs');
   await page.getByLabel('Vendor').fill('Acme Corp');
   await page.getByLabel('Amount').fill('100');
-  await page.getByLabel('GST').fill('10');
+  await page.getByLabel('GST').check();
+  await expect(page.getByText('$10.00')).toBeVisible();
   await page.getByLabel('Notes').fill('Test expense');
   await page.getByRole('button', { name: 'Save' }).click();
 


### PR DESCRIPTION
## Summary
- add an auto-calculated GST toggle so the form derives 10% of the amount instead of requiring manual entry
- update the expense form state management and submission payload to honour the GST toggle selection
- refresh Playwright tests to interact with the new GST behaviour

## Testing
- npm run lint *(fails: ESLint couldn't find eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e57dff9998832cac3c85893668bd55