### PR TITLE
Add edit mode for property management

### DIFF
--- a/app/properties/page.tsx
+++ b/app/properties/page.tsx
@@ -1,9 +1,11 @@
 'use client';
 
+import { useEffect, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import Link from 'next/link';
 import PropertyOverviewCard from '../../components/PropertyOverviewCard';
 import PropertiesGridSkeleton from '../../components/skeletons/PropertiesGridSkeleton';
+import PropertyEditModal from '../../components/PropertyEditModal';
 import { listProperties } from '../../lib/api';
 import type { PropertySummary } from '../../types/property';
 
@@ -16,6 +18,29 @@ export default function PropertiesPage() {
     queryFn: listProperties,
   });
 
+  const [isEditMode, setIsEditMode] = useState(false);
+  const [selectedPropertyId, setSelectedPropertyId] = useState<string | null>(null);
+
+  const selectedProperty = useMemo(() => {
+    if (!selectedPropertyId) return null;
+    return data.find((property) => property.id === selectedPropertyId) ?? null;
+  }, [data, selectedPropertyId]);
+
+  useEffect(() => {
+    if (!isEditMode) {
+      setSelectedPropertyId(null);
+    }
+  }, [isEditMode]);
+
+  const handleSelectProperty = (property: PropertySummary) => {
+    if (!isEditMode) return;
+    setSelectedPropertyId(property.id);
+  };
+
+  const closeEditModal = () => {
+    setSelectedPropertyId(null);
+  };
+
   return (
     <div className="relative">
       {isPending && (
@@ -24,21 +49,79 @@ export default function PropertiesPage() {
         </div>
       )}
       <div className={`p-6 space-y-4 ${isPending ? 'opacity-0' : 'opacity-100'}`}>
-        <div className="flex items-center justify-between">
-          <h1 className="text-2xl font-semibold">Properties</h1>
-          <Link
-            href="/properties/new"
-            className="px-2 py-1 bg-blue-500 text-white"
-          >
-            Add Property
-          </Link>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold">Properties</h1>
+            {isEditMode && (
+              <p className="mt-1 text-sm text-indigo-600 dark:text-indigo-300">
+                Select a property below to edit its details.
+              </p>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <Link
+              href="/properties/new"
+              className="inline-flex items-center gap-2 rounded-full bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-950"
+            >
+              <svg
+                aria-hidden="true"
+                className="h-4 w-4"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                viewBox="0 0 24 24"
+              >
+                <path d="M12 5v14m-7-7h14" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+              Add Property
+            </Link>
+            <button
+              type="button"
+              aria-pressed={isEditMode}
+              onClick={() => setIsEditMode((prev) => !prev)}
+              className={`inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-950 ${
+                isEditMode
+                  ? 'border-indigo-500 bg-indigo-600 text-white shadow-sm hover:bg-indigo-500'
+                  : 'border-indigo-200 bg-white text-indigo-600 shadow-sm hover:border-indigo-300 hover:bg-indigo-50 dark:border-indigo-500/40 dark:bg-gray-900 dark:text-indigo-200 dark:hover:bg-gray-800'
+              }`}
+            >
+              <svg
+                aria-hidden="true"
+                className="h-4 w-4"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                viewBox="0 0 24 24"
+              >
+                <path d="M12 20h9" strokeLinecap="round" strokeLinejoin="round" />
+                <path
+                  d="M16.5 3.5a2.121 2.121 0 0 1 3 3L9 17l-4 1 1-4 10.5-10.5Z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+              {isEditMode ? 'Exit Edit Mode' : 'Edit Properties'}
+            </button>
+          </div>
         </div>
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {data.map((p) => (
-            <PropertyOverviewCard key={p.id} property={p} />
+            <PropertyOverviewCard
+              key={p.id}
+              property={p}
+              isEditMode={isEditMode}
+              onSelect={isEditMode ? handleSelectProperty : undefined}
+            />
           ))}
         </div>
       </div>
+      {selectedProperty && (
+        <PropertyEditModal
+          open={isEditMode && !!selectedProperty}
+          property={selectedProperty}
+          onClose={closeEditModal}
+        />
+      )}
     </div>
   );
 }

--- a/components/PropertyOverviewCard.tsx
+++ b/components/PropertyOverviewCard.tsx
@@ -7,15 +7,22 @@ import type { PropertySummary } from "../types/property";
 
 interface Props {
   property: PropertySummary;
+  isEditMode?: boolean;
+  onSelect?: (property: PropertySummary) => void;
 }
 
-export default function PropertyOverviewCard({ property }: Props) {
+export default function PropertyOverviewCard({ property, isEditMode = false, onSelect }: Props) {
   const detailPath = `/properties/${property.id}`;
   const router = useRouter();
 
   const handleNavigate = useCallback(() => {
+    if (isEditMode && onSelect) {
+      onSelect(property);
+      return;
+    }
+
     router.push(detailPath);
-  }, [detailPath, router]);
+  }, [detailPath, isEditMode, onSelect, property, router]);
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLElement>) => {
@@ -27,14 +34,22 @@ export default function PropertyOverviewCard({ property }: Props) {
     [handleNavigate],
   );
 
+  const ariaLabel = isEditMode
+    ? `Edit details for ${property.address}`
+    : `View details for ${property.address}`;
+
   return (
     <article
-      role="link"
+      role={isEditMode ? "button" : "link"}
       tabIndex={0}
-      aria-label={`View details for ${property.address}`}
+      aria-label={ariaLabel}
       onClick={handleNavigate}
       onKeyDown={handleKeyDown}
-      className="group flex h-72 cursor-pointer flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white text-left shadow-sm transition hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100 dark:focus-visible:ring-slate-400 dark:focus-visible:ring-offset-slate-950"
+      className={`group flex h-72 cursor-pointer flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white text-left shadow-sm transition hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100 dark:focus-visible:ring-slate-400 dark:focus-visible:ring-offset-slate-950 ${
+        isEditMode
+          ? "border-dashed border-indigo-300 bg-indigo-50/50 hover:border-indigo-400 dark:border-indigo-500/60 dark:bg-slate-900/60"
+          : ""
+      }`}
     >
       <div className="relative shrink-0 basis-[65%] overflow-hidden">
         <img
@@ -50,9 +65,16 @@ export default function PropertyOverviewCard({ property }: Props) {
           </h2>
           <p className="text-sm leading-tight text-slate-600 dark:text-slate-300">Tenant: {property.tenant}</p>
         </div>
-        <p className="text-right text-lg font-semibold leading-tight text-indigo-600 dark:text-indigo-300">
-          ${property.rent}/week
-        </p>
+        <div className="flex items-center justify-between text-sm">
+          {isEditMode && (
+            <span className="rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-medium text-indigo-600 dark:bg-indigo-500/20 dark:text-indigo-200">
+              Click to edit
+            </span>
+          )}
+          <p className="ml-auto text-right text-lg font-semibold leading-tight text-indigo-600 dark:text-indigo-300">
+            ${property.rent}/week
+          </p>
+        </div>
       </div>
     </article>
   );


### PR DESCRIPTION
## Summary
- restyle the properties toolbar with a rounded Add Property button and an Edit mode toggle
- introduce an edit mode on the properties grid that opens the existing property edit modal when a card is selected
- update property overview cards to provide edit affordances and guidance while in edit mode

## Testing
- Not run (npm install failed: received 403 when downloading dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68e5804e0328832c8ee7271e2a825c51