### PR TITLE
Match other income search width to expenses

### DIFF
--- a/components/IncomesTable.tsx
+++ b/components/IncomesTable.tsx
@@ -352,11 +352,11 @@ export default function IncomesTable({
           </span>
           <input
             type="search"
-            className={`${filterControlClass} w-full min-w-[12rem] pl-10`}
-            placeholder="Search income"
+            className={`${filterControlClass} w-full min-w-[18rem] pl-10`}
+            placeholder="Search for other income"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            aria-label="Search income"
+            aria-label="Search for other income"
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- align the other income search field width with the expense search input to avoid truncation of its placeholder text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e57f8eb964832c8aafacf8d75f3d7a