### PR TITLE
Add rent ledger toggle to income form

### DIFF
--- a/app/(app)/properties/[id]/page.tsx
+++ b/app/(app)/properties/[id]/page.tsx
@@ -9,6 +9,7 @@ import ExpenseForm from "../../../../components/ExpenseForm";
 import DocumentUploadModal from "../../../../components/DocumentUploadModal";
 import { getProperty, listProperties } from "../../../../lib/api";
 import type { PropertySummary } from "../../../../types/property";
+import type { IncomeListType } from "../../../../types/income";
 import { useURLState } from "../../../../lib/useURLState";
 import PropertyHero from "./components/PropertyHero";
 import PropertyEditModal from "../../../../components/PropertyEditModal";
@@ -39,6 +40,7 @@ export default function PropertyPage() {
     defaultValue: DEFAULT_PROPERTY_TAB,
   });
   const [incomeOpen, setIncomeOpen] = useState(false);
+  const [incomeListType, setIncomeListType] = useState<IncomeListType>("rentLedger");
   const [expenseOpen, setExpenseOpen] = useState(false);
   const [documentOpen, setDocumentOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
@@ -90,6 +92,13 @@ export default function PropertyPage() {
       ? activeTab
       : DEFAULT_PROPERTY_TAB;
   }, [activeTab]);
+
+  const handleOpenIncome = () => {
+    const nextListType: IncomeListType =
+      resolvedTab === "other-income" ? "otherIncome" : "rentLedger";
+    setIncomeListType(nextListType);
+    setIncomeOpen(true);
+  };
 
   if (isError && !isRedirecting) {
     return <div className="p-6">Failed to load property</div>;
@@ -154,7 +163,7 @@ export default function PropertyPage() {
               <div className="flex min-h-0 flex-col lg:sticky lg:top-6 lg:self-start">
                 <PropertyHero
                   property={property}
-                  onAddIncome={() => setIncomeOpen(true)}
+                  onAddIncome={handleOpenIncome}
                   onAddExpense={() => setExpenseOpen(true)}
                   onUploadDocument={() => setDocumentOpen(true)}
                   onNavigateToTab={handleNavigateToTab}
@@ -186,7 +195,13 @@ export default function PropertyPage() {
                 </section>
               </div>
             </section>
-            <IncomeForm propertyId={id} open={incomeOpen} onOpenChange={setIncomeOpen} showTrigger={false} />
+            <IncomeForm
+              propertyId={id}
+              open={incomeOpen}
+              onOpenChange={setIncomeOpen}
+              showTrigger={false}
+              defaultListType={incomeListType}
+            />
             <ExpenseForm propertyId={id} open={expenseOpen} onOpenChange={setExpenseOpen} showTrigger={false} />
             <DocumentUploadModal propertyId={id} open={documentOpen} onClose={() => setDocumentOpen(false)} />
             <PropertyEditModal

--- a/app/(app)/properties/[id]/sections/OtherIncome.tsx
+++ b/app/(app)/properties/[id]/sections/OtherIncome.tsx
@@ -1,19 +1,11 @@
 "use client";
 
 import IncomesTable from "../../../../../components/IncomesTable";
+import { RENT_LEDGER_CATEGORY_NAMES } from "../../../../../lib/income-ledger";
 
 interface OtherIncomeProps {
   propertyId: string;
 }
-
-const CORE_RENT_CATEGORIES = [
-  "Base rent",
-  "Rent",
-  "Rent payment",
-  "Core rent",
-  "Arrears catch-up",
-  "Arrears catchup",
-];
 
 export default function OtherIncome({ propertyId }: OtherIncomeProps) {
   return (
@@ -21,7 +13,7 @@ export default function OtherIncome({ propertyId }: OtherIncomeProps) {
       <div className="flex-1 min-h-0">
         <IncomesTable
           propertyId={propertyId}
-          excludeCategories={CORE_RENT_CATEGORIES}
+          excludeCategories={[...RENT_LEDGER_CATEGORY_NAMES]}
         />
       </div>
     </div>

--- a/lib/income-ledger.ts
+++ b/lib/income-ledger.ts
@@ -1,0 +1,25 @@
+export const RENT_LEDGER_CATEGORY_NAMES = [
+  "Base rent",
+  "Rent",
+  "Rent payment",
+  "Core rent",
+  "Arrears catch-up",
+  "Arrears catchup",
+  "Arrears catch up",
+] as const;
+
+export const RENT_LEDGER_CATEGORY_GROUP = "CoreRent" as const;
+
+export const RENT_LEDGER_DEFAULT_CATEGORY = "Base rent" as const;
+
+const normalizeCategory = (value: string) =>
+  value.toLowerCase().replace(/[\-_]/g, " ").replace(/\s+/g, " ").trim();
+
+const RENT_LEDGER_CATEGORY_SET = new Set(
+  RENT_LEDGER_CATEGORY_NAMES.map((value) => normalizeCategory(value))
+);
+
+export const isRentLedgerCategory = (value?: string | null) => {
+  if (!value) return false;
+  return RENT_LEDGER_CATEGORY_SET.has(normalizeCategory(value));
+};

--- a/types/income.ts
+++ b/types/income.ts
@@ -10,3 +10,5 @@ export interface IncomeRow {
   evidenceUrl?: string;
   evidenceName?: string;
 }
+
+export type IncomeListType = "rentLedger" | "otherIncome";


### PR DESCRIPTION
## Summary
- add shared helpers for rent ledger category detection
- update the income form to switch between rent ledger and other income targets with dynamic messaging
- default property income modal to the appropriate list type and reuse the shared category list for other income filtering

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68e58344dff8832cb8f9eca06def06a9